### PR TITLE
Stabilized paths

### DIFF
--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -16,7 +16,7 @@
 
 use std::{
     collections::VecDeque,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -93,14 +93,7 @@ pub fn run(global: &GlobalArgs, args: &CmdArgs) -> Result<()> {
         PathBuf::new()
     } else if absolute_source_paths.len() == 1 {
         let single_source = absolute_source_paths.first().unwrap();
-        if single_source == Path::new("/") {
-            PathBuf::new()
-        } else {
-            single_source
-                .parent()
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|| PathBuf::new())
-        }
+        utils::extract_parent(single_source).unwrap_or(PathBuf::new())
     } else {
         utils::calculate_lcp(&absolute_source_paths)
     };
@@ -156,7 +149,7 @@ pub fn run(global: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let mut num_files = 0;
     let mut num_dirs = 0;
     let mut total_bytes = 0;
-    let scan_streamer = FSNodeStreamer::from_paths(source_paths)?;
+    let scan_streamer = FSNodeStreamer::from_paths(source_paths.clone())?;
     for stream_node_result in scan_streamer {
         let (_, stream_node) = stream_node_result?;
         let node = stream_node.node;

--- a/src/repository/tree.rs
+++ b/src/repository/tree.rs
@@ -28,7 +28,7 @@ use std::os::unix::fs::MetadataExt;
 use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::archiver::Archiver;
+use crate::{archiver::Archiver, utils};
 
 use super::{ObjectId, RepositoryBackend};
 
@@ -203,23 +203,36 @@ pub type StreamNodeInfo = (PathBuf, StreamNode);
 #[derive(Debug)]
 pub struct FSNodeStreamer {
     stack: Vec<PathBuf>,
+    intermediate_paths: Vec<(PathBuf, usize)>,
 }
 
 impl FSNodeStreamer {
     /// Creates an FSNodeStreamer from multiple root paths. The paths are iterated in lexicographical order.
-    pub fn from_paths(paths: &[PathBuf]) -> Result<Self> {
-        for path in paths {
+    pub fn from_paths(mut paths: Vec<PathBuf>) -> Result<Self> {
+        for path in &paths {
             if !path.exists() {
                 bail!("Path {} does not exist", path.display());
             }
         }
 
-        let mut roots = paths.to_vec();
-        roots.sort_by(|a, b| b.cmp(a));
-        Ok(Self { stack: roots })
+        // Calculate intermediate paths and count children (root included)
+        let common_root = utils::calculate_lcp(&paths);
+        let (_root_children_count, intermediate_path_set) =
+            utils::intermediate_paths(&common_root, &paths);
+        let mut intermediate_paths: Vec<(PathBuf, usize)> =
+            intermediate_path_set.into_iter().collect();
+
+        // Sort paths in reverse order
+        paths.sort_by(|a, b| b.cmp(a));
+        intermediate_paths.sort_by(|(a, _), (b, _)| a.file_name().cmp(&b.file_name()));
+
+        Ok(Self {
+            stack: paths,
+            intermediate_paths,
+        })
     }
 
-    fn sorted_children(dir: &Path) -> Result<Vec<PathBuf>> {
+    fn get_children_sorted(dir: &Path) -> Result<Vec<PathBuf>> {
         let mut children: Vec<_> = fs::read_dir(dir)?
             .map(|res| res.map(|e| e.path()))
             .collect::<Result<_, _>>()?;
@@ -232,26 +245,51 @@ impl Iterator for FSNodeStreamer {
     type Item = Result<StreamNodeInfo>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // helper to peek the next path in each list
+        fn peek_path(entry: &(PathBuf, usize)) -> &PathBuf {
+            &entry.0
+        }
+
+        // decide which source has the lexicographically smaller “next” element
+        let take_intermediate = match (self.intermediate_paths.last(), self.stack.last()) {
+            (Some(iv @ _), Some(sv @ _)) => peek_path(iv).cmp(sv) == std::cmp::Ordering::Less,
+            (Some(_), None) => true,
+            _ => false,
+        };
+
+        if take_intermediate {
+            // pop from intermediate_paths
+            let (path, num_children) = self.intermediate_paths.pop().unwrap();
+            return Some(Ok((
+                path.clone(),
+                StreamNode {
+                    node: Node::from_path(path.clone()).unwrap(),
+                    num_children,
+                },
+            )));
+        }
+
+        // otherwise pop from the DFS stack as before
         let path = self.stack.pop()?;
-        let res = (|| {
+        let result = (|| {
             let node = Node::from_path(path.clone())?;
 
             let num_children = if node.is_dir() {
-                let children = Self::sorted_children(&path)?;
-                let num_children = children.len();
+                let children = Self::get_children_sorted(&path)?;
+                let n = children.len();
+                // push in *reverse* so that the very first child is at the top of the stack
                 for child in children.into_iter().rev() {
                     self.stack.push(child);
                 }
-
-                num_children
+                n
             } else {
                 0
             };
 
-            let stream_node = StreamNode { node, num_children };
-            Ok((path, stream_node))
+            Ok((path, StreamNode { node, num_children }))
         })();
-        Some(res)
+
+        Some(result)
     }
 }
 
@@ -285,6 +323,7 @@ impl SerializedNodeStreamer {
                 ));
             }
         }
+
         Ok(Self { repo, stack })
     }
 }
@@ -512,7 +551,7 @@ mod test {
         let tmp_path = temp_dir.path();
         create_tree(tmp_path)?;
 
-        let streamer = FSNodeStreamer::from_paths(&vec![tmp_path.join("dir_a")])?;
+        let streamer = FSNodeStreamer::from_paths(vec![tmp_path.join("dir_a")])?;
         let nodes: Vec<Result<(PathBuf, StreamNode)>> = streamer.collect();
 
         assert_eq!(nodes.len(), 6);
@@ -548,7 +587,7 @@ mod test {
         create_tree(tmp_path)?;
 
         let streamer =
-            FSNodeStreamer::from_paths(&vec![tmp_path.join("dir_a"), tmp_path.join("dir_b")])?;
+            FSNodeStreamer::from_paths(vec![tmp_path.join("dir_a"), tmp_path.join("dir_b")])?;
         let nodes: Vec<Result<(PathBuf, StreamNode)>> = streamer.collect();
 
         assert_eq!(nodes.len(), 8);
@@ -588,8 +627,8 @@ mod test {
         let tmp_path = temp_dir.path();
         create_tree(tmp_path)?;
 
-        let dir_a = FSNodeStreamer::from_paths(&vec![tmp_path.join("dir_a")])?;
-        let dir_b = FSNodeStreamer::from_paths(&vec![tmp_path.join("dir_b")])?;
+        let dir_a = FSNodeStreamer::from_paths(vec![tmp_path.join("dir_a")])?;
+        let dir_b = FSNodeStreamer::from_paths(vec![tmp_path.join("dir_b")])?;
         let diff_streamer = NodeDiffStreamer::new(dir_a, dir_b);
         let diffs: Vec<Result<(PathBuf, Option<StreamNode>, Option<StreamNode>, NodeDiff)>> =
             diff_streamer.collect();
@@ -613,8 +652,8 @@ mod test {
         let tmp_path = temp_dir.path();
         create_tree(tmp_path)?;
 
-        let dir_a1 = FSNodeStreamer::from_paths(&vec![tmp_path.join("dir_a")])?;
-        let dir_a2 = FSNodeStreamer::from_paths(&vec![tmp_path.join("dir_a")])?;
+        let dir_a1 = FSNodeStreamer::from_paths(vec![tmp_path.join("dir_a")])?;
+        let dir_a2 = FSNodeStreamer::from_paths(vec![tmp_path.join("dir_a")])?;
         let diff_streamer = NodeDiffStreamer::new(dir_a1, dir_a2);
         let diffs: Vec<Result<(PathBuf, Option<StreamNode>, Option<StreamNode>, NodeDiff)>> =
             diff_streamer.collect();


### PR DESCRIPTION
The Archiver stores paths relative to the LCP of the target paths. The root path is store for future reference.

The FSNodeStreamer must not emit the root node, but it must emit the intermediate nodes without exploring into them.
The SerializedNodeStreamer is consistent with this, since the Snapshot tree does not contain a dedicated Node for the LCP.

However, for this to work, the Archiver needs to know how many root children to expect. This requires calculating the intermediate paths in two separate places. This calculation doesn't add a significant overhead, but I should anyway consider if this can be optimized.