### PR TITLE
Optimize Archiver

### DIFF
--- a/src/archiver/processor.rs
+++ b/src/archiver/processor.rs
@@ -81,7 +81,12 @@ pub(crate) fn process_item(
             Some(mut stream_node_info) => {
                 // If node is a file, save the contents
                 if stream_node_info.node.is_file() {
-                    let blobs_ids = file_saver::save_file(repo, &path, progress_reporter)?;
+                    let blobs_ids = file_saver::save_file(
+                        repo,
+                        &path,
+                        &stream_node_info.node,
+                        progress_reporter,
+                    )?;
                     stream_node_info.node.contents = Some(blobs_ids);
                 }
 

--- a/src/repository/repository_v1.rs
+++ b/src/repository/repository_v1.rs
@@ -447,10 +447,10 @@ impl Repository {
     }
 
     fn flush_packer(&self, mut packer_guard: MutexGuard<Packer>) -> Result<()> {
-        let (pack_data, packed_blob_descriptors) = packer_guard.flush();
+        let (pack_data, packed_blob_descriptors, hash) = packer_guard.flush();
         drop(packer_guard); // Drop the mutex so other workers can append to the packer
 
-        let pack_id = ID::from_content(&pack_data);
+        let pack_id = ID::from_bytes(hash.into());
         let pack_path = &self.get_object_path(&pack_id);
         self.backend.write(pack_path, &pack_data)?;
 


### PR DESCRIPTION
- Do not de-duplicate files smaller than the minimum chunk size.
- Calculate the hash of the pack data as more blobs are added.