### PR TITLE
Add excluded paths to snapshot command

### DIFF
--- a/src/archiver/mod.rs
+++ b/src/archiver/mod.rs
@@ -27,6 +27,7 @@ use std::{
 
 use anyhow::{Result, anyhow, bail};
 use chrono::Local;
+use tree_serializer::finalize_if_complete;
 
 use crate::{
     global::ID,
@@ -45,6 +46,7 @@ pub struct Archiver {
     repo: Arc<dyn RepositoryBackend>,
     absolute_source_paths: Vec<PathBuf>,
     snapshot_root_path: PathBuf,
+    exclude_paths: Vec<PathBuf>,
     parent_snapshot: Option<Snapshot>,
     read_concurrency: usize,
     write_concurrency: usize,
@@ -56,6 +58,7 @@ impl Archiver {
         repo: Arc<dyn RepositoryBackend>,
         absolute_source_paths: Vec<PathBuf>,
         snapshot_root_path: PathBuf,
+        exclude_paths: Vec<PathBuf>,
         parent_snapshot: Option<Snapshot>,
         (read_concurrency, write_concurrency): (usize, usize),
         progress_reporter: Arc<SnapshotProgressReporter>,
@@ -64,6 +67,7 @@ impl Archiver {
             repo,
             absolute_source_paths,
             snapshot_root_path,
+            exclude_paths,
             parent_snapshot,
             read_concurrency,
             write_concurrency,
@@ -87,7 +91,10 @@ impl Archiver {
         };
 
         // Create streamers
-        let fs_streamer = match FSNodeStreamer::from_paths(arch.absolute_source_paths.clone()) {
+        let fs_streamer = match FSNodeStreamer::from_paths(
+            arch.absolute_source_paths.clone(),
+            arch.exclude_paths.clone(),
+        ) {
             Ok(stream) => stream,
             Err(e) => bail!("Failed to create FSNodeStreamer: {:?}", e.to_string()),
         };
@@ -255,6 +262,17 @@ impl Archiver {
             arch_clone
                 .progress_reporter
                 .written_meta_bytes(index_raw_data, index_encoded_data);
+
+            // Try to finalize the snapshot root node. This is necessary in case of an empty snapshot,
+            // because no stage in the pipeline would call it.
+            finalize_if_complete(
+                serializer_snapshot_root_path_clone.clone(),
+                repo_clone.as_ref(),
+                &mut pending_trees,
+                &mut final_root_tree_id,
+                &serializer_snapshot_root_path_clone,
+                &serializer_progress_reporter_clone,
+            )?;
 
             // The entire tree must be serialized by now, so we can create a
             // snapshot with the root tree id.

--- a/src/archiver/tree_serializer.rs
+++ b/src/archiver/tree_serializer.rs
@@ -142,7 +142,7 @@ pub(crate) fn handle_processed_item(
     )
 }
 
-fn finalize_if_complete(
+pub(crate) fn finalize_if_complete(
     dir_path: PathBuf,
     repo: &dyn RepositoryBackend,
     pending_trees: &mut BTreeMap<PathBuf, PendingTree>,

--- a/src/commands/cmd_forget.rs
+++ b/src/commands/cmd_forget.rs
@@ -195,7 +195,6 @@ pub fn apply_retention_rules(
                     let year = snapshot.timestamp.year();
                     kept_years.entry(year).or_insert(id.clone());
                 }
-                println!("{:#?}", kept_years);
                 let mut count = 0;
                 for (_, id) in kept_years.iter().rev() {
                     // Iterate years in reverse

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -233,6 +233,15 @@ pub fn bytes_to_hex(bytes: &[u8]) -> String {
     bytes.iter().map(|byte| format!("{:02x}", byte)).collect()
 }
 
+pub fn is_path_excluded(path_to_check: &Path, exclude_paths: &[PathBuf]) -> bool {
+    for excluded_path in exclude_paths {
+        if path_to_check == excluded_path || path_to_check.starts_with(excluded_path) {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Added option --exclude. Each single exclude paths needs an --exclude flag:
  backup -r repo snapshot p1 p2 pn --exclude e1 --exclude e2

The FSNodeStreamer now allows excluding paths.