### PR TITLE
Flush pending indexes periodically

### DIFF
--- a/src/archiver/processor.rs
+++ b/src/archiver/processor.rs
@@ -168,9 +168,9 @@ fn chunk_and_save_blobs(
     // same contents will no longer produce same chunks and IDs.
     let chunker = StreamCDC::with_level(
         reader,
-        global::defaults::MIN_CHUNK_SIZE,
-        global::defaults::AVG_CHUNK_SIZE,
-        global::defaults::MAX_CHUNK_SIZE,
+        global::defaults::MIN_CHUNK_SIZE as u32,
+        global::defaults::AVG_CHUNK_SIZE as u32,
+        global::defaults::MAX_CHUNK_SIZE as u32,
         Normalization::Level1,
     );
 

--- a/src/global/defaults.rs
+++ b/src/global/defaults.rs
@@ -16,10 +16,26 @@
 
 use crate::utils::size;
 
-// Index
-/// This is a approximate number. Whole packs are stored in the same index
-/// file, so this is a minimum.
-pub const BLOBS_PER_INDEX_FILE: u32 = 65536;
+// -- Index --
+// These are approximate numbers. Whole packs are stored in the same index
+// file and the packs don't contain a fix number of blobs.
+
+// These constants dictate index flushing during the snapshot process.
+//
+// Approximate total size referenced by an index when flushing. During the snapshot
+// process, we flush the index periodically in order to commit packs frequently. If the
+// snapshot process is interrupted, the packs referenced by an index are not lost when
+// resuming the snapshot. However, flushing often means saving a lot of small indexes
+// to file.
+// The garbage collector should merge all small indexes and consolidate them
+// into bigger index files.
+pub const INDEX_FLUSH_REFERENCE_SIZE_HINT: u64 = 4 * size::GiB;
+pub const PACKS_PER_FLUSHED_INDEX_FILE: usize =
+    (INDEX_FLUSH_REFERENCE_SIZE_HINT / MAX_PACK_SIZE) as usize;
+
+// Number of packs per index file when merging indexes during garbage collection.
+pub const INDEX_REFERENCE_SIZE_HINT: u64 = 32 * size::GiB;
+pub const PACKS_PER_INDEX_FILE: usize = (INDEX_REFERENCE_SIZE_HINT / MAX_PACK_SIZE) as usize;
 
 // Packing
 /// Minimum pack size before flushing to the backend.
@@ -27,11 +43,11 @@ pub const MAX_PACK_SIZE: u64 = 16 * size::MiB;
 
 // Chunking
 /// Minimum chunk size
-pub const MIN_CHUNK_SIZE: u32 = 512 * size::KiB as u32;
+pub const MIN_CHUNK_SIZE: u64 = 512 * size::KiB;
 /// Average chunk size
-pub const AVG_CHUNK_SIZE: u32 = 1 * size::MiB as u32;
+pub const AVG_CHUNK_SIZE: u64 = 1 * size::MiB;
 /// Maximum chunk size
-pub const MAX_CHUNK_SIZE: u32 = 8 * size::MiB as u32;
+pub const MAX_CHUNK_SIZE: u64 = 8 * size::MiB;
 
 // Display
 pub const SHORT_REPO_ID_LEN: usize = 5;


### PR DESCRIPTION
During the snapshot process, we flush the index periodically in order to commit packs frequently. If the snapshot process is interrupted, the packs referenced by an index are not lost when resuming the snapshot. However, flushing often means saving a lot of small indexes to file. The garbage collector should merge all small indexes and consolidate them into bigger index files.