### PR TITLE
Move password prompts to the init/open repository functions

### DIFF
--- a/src/commands/cmd_cat.rs
+++ b/src/commands/cmd_cat.rs
@@ -24,7 +24,6 @@ use crate::backend::new_backend_with_prompt;
 use crate::global::{ID, ID_LENGTH};
 use crate::repository::tree::Tree;
 use crate::repository::{self, RepositoryBackend};
-use crate::ui;
 
 use super::GlobalArgs;
 
@@ -50,10 +49,8 @@ pub enum Object {
 
 pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let backend = new_backend_with_prompt(&global_args.repo)?;
-    let repo_password = ui::cli::request_repo_password();
 
-    let repo: Arc<dyn RepositoryBackend> =
-        repository::try_open(repo_password, global_args.key.as_ref(), backend)?;
+    let repo: Arc<dyn RepositoryBackend> = repository::try_open(global_args.key.as_ref(), backend)?;
 
     match &args.object {
         Object::Manifest => {

--- a/src/commands/cmd_forget.rs
+++ b/src/commands/cmd_forget.rs
@@ -83,12 +83,11 @@ pub enum RetentionRule {
 
 pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let backend = new_backend_with_prompt(&global_args.repo)?;
-    let repo_password = ui::cli::request_repo_password();
 
     // If dry-run, wrap the backend inside the DryBackend
     let backend = make_dry_backend(backend, args.dry_run);
 
-    let repo = repository::try_open(repo_password, global_args.key.as_ref(), backend)?;
+    let repo = repository::try_open(global_args.key.as_ref(), backend)?;
     let mut snapshots_sorted: Vec<(ID, Snapshot)> = SnapshotStreamer::new(repo.clone())?.collect();
     snapshots_sorted.sort_by_key(|(_id, snapshot)| snapshot.timestamp);
 

--- a/src/commands/cmd_init.rs
+++ b/src/commands/cmd_init.rs
@@ -33,11 +33,9 @@ pub struct CmdArgs {
 
 pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let backend = new_backend_with_prompt(&global_args.repo)?;
-    let repo_password = ui::cli::request_new_password();
 
     ui::cli::log!("Initializing a new repository in \'{}\'", &global_args.repo);
-
-    repository::init_repository_with_version(args.repository_version, backend, repo_password)?;
+    repository::init_repository_with_version(args.repository_version, backend, )?;
 
     Ok(())
 }

--- a/src/commands/cmd_log.rs
+++ b/src/commands/cmd_log.rs
@@ -44,9 +44,7 @@ pub struct CmdArgs {
 
 pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let backend = new_backend_with_prompt(&global_args.repo)?;
-    let repo_password = ui::cli::request_repo_password();
-
-    let repo = repository::try_open(repo_password, global_args.key.as_ref(), backend)?;
+    let repo = repository::try_open(global_args.key.as_ref(), backend)?;
 
     let mut snapshots_sorted: Vec<(ID, Snapshot)> = SnapshotStreamer::new(repo.clone())?.collect();
     snapshots_sorted.sort_by_key(|(_id, snapshot)| snapshot.timestamp);

--- a/src/commands/cmd_ls.rs
+++ b/src/commands/cmd_ls.rs
@@ -29,7 +29,7 @@ use crate::{
         streamers::find_serialized_node,
         tree::{Metadata, Node, NodeType, Tree},
     },
-    ui, utils,
+    utils,
 };
 
 #[derive(Args, Debug)]
@@ -57,9 +57,7 @@ pub struct CmdArgs {
 
 pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let backend = new_backend_with_prompt(&global_args.repo)?;
-    let repo_password = ui::cli::request_repo_password();
-
-    let repo = repository::try_open(repo_password, global_args.key.as_ref(), backend)?;
+    let repo = repository::try_open(global_args.key.as_ref(), backend)?;
 
     let snapshot = {
         let (id, _) = repo.find(FileType::Snapshot, &args.snapshot)?;

--- a/src/commands/cmd_restore.rs
+++ b/src/commands/cmd_restore.rs
@@ -25,7 +25,7 @@ use crate::{
     global::ID,
     repository::{self, RepositoryBackend, snapshot::SnapshotStreamer},
     restorer::{Resolution, Restorer},
-    ui::{self, cli, restore_progress::RestoreProgressReporter},
+    ui::{cli, restore_progress::RestoreProgressReporter},
     utils,
 };
 
@@ -68,10 +68,7 @@ pub struct CmdArgs {
 
 pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let backend = new_backend_with_prompt(&global_args.repo)?;
-    let repo_password = ui::cli::request_repo_password();
-
-    let repo: Arc<dyn RepositoryBackend> =
-        repository::try_open(repo_password, global_args.key.as_ref(), backend)?;
+    let repo: Arc<dyn RepositoryBackend> = repository::try_open(global_args.key.as_ref(), backend)?;
 
     let (_snapshot_id, snapshot) = match &args.snapshot {
         UseSnapshot::Latest => {

--- a/src/commands/cmd_snapshot.rs
+++ b/src/commands/cmd_snapshot.rs
@@ -20,7 +20,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use clap::{ArgGroup, Args};
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -82,12 +82,11 @@ pub struct CmdArgs {
 
 pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let backend = new_backend_with_prompt(&global_args.repo)?;
-    let repo_password = ui::cli::request_repo_password();
 
     // If dry-run, wrap the backend inside the DryBackend
     let backend = make_dry_backend(backend, args.dry_run);
 
-    let repo = repository::try_open(repo_password, global_args.key.as_ref(), backend)?;
+    let repo = repository::try_open(global_args.key.as_ref(), backend)?;
 
     // Cannonicalize source paths
     let source_paths = &args.paths;

--- a/src/ui/cli.rs
+++ b/src/ui/cli.rs
@@ -25,31 +25,6 @@ macro_rules! log {
 }
 pub use log;
 
-/// Prints a log with a green tag.
-pub fn log_green(tag: &str, str: &str) {
-    println!("{}: {}", tag.bold().green(), str);
-}
-
-/// Prints a log with a cyan tag.
-pub fn log_cyan(tag: &str, str: &str) {
-    println!("{}: {}", tag.bold().cyan(), str);
-}
-
-/// Prints a log with a purple tag.
-pub fn log_purple(tag: &str, str: &str) {
-    println!("{}: {}", tag.bold().purple(), str);
-}
-
-/// Prints a log with a yellow tag.
-pub fn log_yellow(tag: &str, str: &str) {
-    println!("{}: {}", tag.bold().yellow(), str);
-}
-
-/// Prints a log with a red tag.
-pub fn log_red(tag: &str, str: &str) {
-    println!("{}: {}", tag.bold().red(), str);
-}
-
 /// Prints a warning log (warning: ...)
 pub fn log_warning(str: &str) {
     eprintln!("{}: {}", "Warning".bold().yellow(), str);
@@ -66,22 +41,22 @@ pub fn print_separator(character: char, count: usize) {
     println!("{}", repeated_string);
 }
 
-/// Requests a new password with confirmation.
-pub fn request_new_password() -> String {
-    Password::new()
-        .with_prompt("Enter new password")
-        .with_confirmation("Confirm password", "Passwords mismatching")
-        .interact()
-        .unwrap()
-}
-
-/// Requests a repository password without confirmation.
-#[inline]
-pub fn request_repo_password() -> String {
-    request_password("Enter password for repository")
-}
-
 /// Requests a password with a prompt without confirmation.
+#[inline]
 pub fn request_password(promt: &str) -> String {
     Password::new().with_prompt(promt).interact().unwrap()
+}
+
+/// Requests a password with a prompt and confirmation.
+#[inline]
+pub fn request_password_with_confirmation(
+    prompt: &str,
+    confirmation_prompt: &str,
+    mismatch_err_prompt: &str,
+) -> String {
+    Password::new()
+        .with_prompt(prompt)
+        .with_confirmation(confirmation_prompt, mismatch_err_prompt)
+        .interact()
+        .unwrap()
 }


### PR DESCRIPTION
With this, we can pass an opened repository between commands in case we need to pipeline command calls.