### PR TITLE
Add metadata to pack files

### DIFF
--- a/src/commands/cmd_restore.rs
+++ b/src/commands/cmd_restore.rs
@@ -42,13 +42,13 @@ impl std::fmt::Display for Resolution {
 
 #[derive(Args, Debug)]
 pub struct CmdArgs {
+    /// The ID of the snapshot to restore, or 'latest' to restore the most recent snapshot saved.
+    #[arg(value_parser = clap::value_parser!(UseSnapshot), default_value_t=UseSnapshot::Latest)]
+    pub snapshot: UseSnapshot,
+
     /// A path where the files will be restored.
     #[clap(long, required = true)]
     pub target: PathBuf,
-
-    /// The ID of the snapshot to restore, or 'latest' to restore the most recent snapshot saved.
-    #[clap(long, value_parser = clap::value_parser!(UseSnapshot), default_value_t=UseSnapshot::Latest)]
-    pub snapshot: UseSnapshot,
 
     /// A list of paths to restore.
     #[clap(long)]

--- a/src/global/mod.rs
+++ b/src/global/mod.rs
@@ -139,6 +139,10 @@ impl ID {
 
         Ok(Self(bytes))
     }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 /// Implementation of the Display trait for ID.
@@ -177,10 +181,29 @@ impl<'de> Deserialize<'de> for ID {
 }
 
 /// Type of objects that can be stored in a repository.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[repr(u8)]
 pub enum ObjectType {
-    Data,
-    Tree,
+    Data = 0x00,
+    Tree = 0x01,
+}
+
+impl From<ObjectType> for u8 {
+    fn from(obj_type: ObjectType) -> Self {
+        obj_type as u8
+    }
+}
+
+impl TryFrom<u8> for ObjectType {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(ObjectType::Data),
+            0x01 => Ok(ObjectType::Tree),
+            _ => Err(anyhow::anyhow!("Invalid ObjectType value: {}", value)),
+        }
+    }
 }
 
 /// Type of objects that can be stored in a Repository

--- a/src/mapache/mod.rs
+++ b/src/mapache/mod.rs
@@ -18,8 +18,8 @@ pub mod defaults;
 
 use std::sync::LazyLock;
 
-use aes_gcm::aead::{OsRng, rand_core::RngCore};
-use anyhow::{Context, Result, bail};
+use aes_gcm::aead::{rand_core::RngCore, OsRng};
+use anyhow::{bail, Context, Result};
 use parking_lot::{RwLock, RwLockReadGuard};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -138,6 +138,10 @@ impl ID {
         }
 
         Ok(Self(bytes))
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
     }
 }
 

--- a/src/repository/gc.rs
+++ b/src/repository/gc.rs
@@ -82,8 +82,8 @@ pub fn scan(repo: Arc<dyn RepositoryBackend>, tolerance: f32) -> Result<Plan> {
         if !plan.referenced_blobs.contains(id) {
             pack_garbage
                 .entry(locator.pack_id)
-                .and_modify(|size| *size += locator.length)
-                .or_insert(locator.length);
+                .and_modify(|size| *size += locator.length as u64)
+                .or_insert(locator.length as u64);
             spinner.inc(1);
         }
     }
@@ -188,8 +188,8 @@ impl Plan {
                     let data = self.repo.read_from_file(
                         global::FileType::Object,
                         &pack_id,
-                        offset,
-                        length,
+                        offset as u64,
+                        length as u64,
                     )?;
                     self.repo.save_blob(
                         blob_type,

--- a/src/repository/index.rs
+++ b/src/repository/index.rs
@@ -35,9 +35,9 @@ struct BlobLocation {
     /// The index into the `pack_ids` `IndexSet` for the pack containing this blob. See Index.
     pub pack_array_index: usize,
     /// The offset of the blob within its pack file.
-    pub offset: u64,
+    pub offset: u32,
     /// The length of the blob within its pack file.
-    pub length: u64,
+    pub length: u32,
 }
 
 /// Represents the location and size of a blob within a pack file.
@@ -45,8 +45,8 @@ struct BlobLocation {
 #[derive(Debug, Clone)]
 pub struct BlobLocator {
     pub pack_id: ID,
-    pub offset: u64,
-    pub length: u64,
+    pub offset: u32,
+    pub length: u32,
 }
 
 /// Manages the mapping of blob IDs to their locations within pack files.
@@ -164,7 +164,7 @@ impl Index {
 
     /// Retrieves the pack ID, offset, and length for a given blob ID, if it exists.
     /// Returns `None` if the blob ID is not found.
-    pub fn get(&self, id: &ID) -> Option<(ID, ObjectType, u64, u64)> {
+    pub fn get(&self, id: &ID) -> Option<(ID, ObjectType, u32, u32)> {
         self.data_ids
             .get(id)
             .map(|location| {
@@ -365,7 +365,7 @@ impl MasterIndex {
 
     /// Retrieves an entry for a given blob ID by searching through finalized indexes.
     /// Pending blobs (those not yet packed) cannot be retrieved via this method.
-    pub fn get(&self, id: &ID) -> Option<(ID, ObjectType, u64, u64)> {
+    pub fn get(&self, id: &ID) -> Option<(ID, ObjectType, u32, u32)> {
         self.indexes
             .iter()
             .find_map(|idx| if !idx.is_pending { idx.get(id) } else { None })
@@ -501,6 +501,6 @@ pub struct IndexFileBlob {
     pub id: ID,
     #[serde(rename = "type")]
     pub blob_type: ObjectType,
-    pub offset: u64,
-    pub length: u64,
+    pub offset: u32,
+    pub length: u32,
 }

--- a/src/repository/repository_v1.rs
+++ b/src/repository/repository_v1.rs
@@ -499,7 +499,7 @@ impl Repository {
         }
 
         if let Some(pack_saver) = self.pack_saver.write().as_ref() {
-            pack_saver.save_pack(pack_data)?;
+            pack_saver.save_pack(pack_data, SaveID::WithID(pack_id.clone()))?;
         } else {
             bail!("PackSaver is not initialized. Call `init_pack_saver` first.");
         }
@@ -538,9 +538,11 @@ impl Repository {
         Ok(())
     }
 
-    fn load_from_pack(&self, id: &ID, offset: u64, length: u64) -> Result<Vec<u8>> {
+    fn load_from_pack(&self, id: &ID, offset: u32, length: u32) -> Result<Vec<u8>> {
         let object_path = Self::get_object_path(&self.objects_path, id);
-        let data = self.backend.seek_read(&object_path, offset, length)?;
+        let data = self
+            .backend
+            .seek_read(&object_path, offset as u64, length as u64)?;
         self.secure_storage.decode(&data)
     }
 }


### PR DESCRIPTION
Pack files now contain a section at the end of the file that contains
the metadata describing the blob content.

The last 4 bytes of the filecontain the length of the section. For each blob
in the pack, the metadata section contains:

  - ID (32 bytes)
  - Length (4 bytes)
  - Blob type (1 byte)

The structure of the metadata section is:

```
| id | len | type | <- blob 1
| id | len | type | <- blob 2
 ...                <- blob N
| Metadata size |
```

This metadata should allow to scan the contents of the pack directly, without
reading the index. Also, if a pack became unreferenced from any snapshot, its
contents can still be processed.