### PR TITLE
Migrate from AES-GCM to AES-GCM-SIV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,17 +24,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-gcm"
-version = "0.10.3"
+name = "aes-gcm-siv"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
 dependencies = [
  "aead",
  "aes",
  "cipher",
  "ctr",
- "ghash",
+ "polyval",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -502,16 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,7 +689,7 @@ dependencies = [
 name = "mapache"
 version = "0.1.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm-siv",
  "anyhow",
  "argon2",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ opt-level = 3
 
 
 [dependencies]
-aes-gcm = "0.10.3"
+aes-gcm-siv = "0.11.1"
 anyhow = "1.0.98"
 argon2 = "0.5.3"
 base64 = "0.22.1"

--- a/src/repository/storage.rs
+++ b/src/repository/storage.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use aes_gcm::{Aes256Gcm, Key as AesKey, KeyInit, Nonce, aead::Aead};
+use aes_gcm_siv::{Aes256GcmSiv, Key as AesKey, KeyInit, Nonce, aead::Aead};
 use anyhow::{Result, bail};
 use argon2::Argon2;
 use rand::TryRngCore;
@@ -95,8 +95,8 @@ impl SecureStorage {
 
     /// Encrypt data using AES-GCM
     pub fn encrypt_with_key(key: &[u8], data: &[u8]) -> Result<Vec<u8>> {
-        let key = AesKey::<Aes256Gcm>::from_slice(key);
-        let cipher = Aes256Gcm::new(key);
+        let key = AesKey::<Aes256GcmSiv>::from_slice(key);
+        let cipher = Aes256GcmSiv::new(key);
 
         // Generate a random nonce for each encryption
         let mut nonce = vec![0u8; AES_GCM_NONCE_LEN];
@@ -126,8 +126,8 @@ impl SecureStorage {
 
     /// Decrypt data using AES-GCM
     pub fn decrypt_with_key(key: &[u8], data: &[u8]) -> Result<Vec<u8>> {
-        let key = AesKey::<Aes256Gcm>::from_slice(key);
-        let cipher = Aes256Gcm::new(key);
+        let key = AesKey::<Aes256GcmSiv>::from_slice(key);
+        let cipher = Aes256GcmSiv::new(key);
 
         if data.len() < AES_GCM_NONCE_LEN {
             bail!("Decryption failed: invalid data");


### PR DESCRIPTION
Switched to AES-GCM-SIV to gain Nonce misuse resistance. This prevents catastrophic security failures in the event of accidental IV reuse, which is a risk when generating random IVs.

SecureStorage generates a random IV for every encoded message. The probability of a collision is astronomically low -- 96-bit Nonce for an expected maximum of about 10 million encrypted blobs -- but still greater than 0. The performance penalty of the SIV version should be negligible, while protecting about the very edge case of reusing an IV.

Another point to consider is that this specific implementation of AES-GCM-SIV has not been audited, although the dependencies (AES-GCM) and other parts of the RustCrypto project have.

**I really need to consider if the current implementation really guarantees a sufficiently low probability of a Nonce collision even in the most extreme use case.**