### PR TITLE
amend --keep-old

### DIFF
--- a/src/commands/cmd_snapshot.rs
+++ b/src/commands/cmd_snapshot.rs
@@ -97,6 +97,8 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let backend = new_backend_with_prompt(global_args, args.dry_run)?;
     let (repo, _) = repository::try_open(pass, global_args.key.as_ref(), backend)?;
 
+    let start = Instant::now();
+
     // Get source paths from arguments or readdir root path
     let source_paths = if !args.as_root {
         args.paths.clone()
@@ -176,8 +178,6 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             Err(_) => bail!("Parent snapshot not found"),
         },
     };
-
-    let start = Instant::now();
 
     // Scan filesystem
     let spinner = ProgressBar::new_spinner();

--- a/src/commands/cmd_verify.rs
+++ b/src/commands/cmd_verify.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
+use std::{collections::BTreeSet, path::PathBuf, sync::Arc, time::Instant};
 
 use anyhow::{Result, bail};
 use clap::Args;
@@ -58,6 +58,8 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let backend = new_backend_with_prompt(global_args, false)?;
     let (repo, secure_storage) =
         repository::try_open(pass, global_args.key.as_ref(), backend.clone())?;
+
+    let start = Instant::now();
 
     let snapshot_streamer = SnapshotStreamer::new(repo.clone())?;
     let mut visited_blobs = BTreeSet::new();
@@ -164,6 +166,12 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     if error_counter > 0 {
         ui::cli::log!("{} {}", error_counter, "[ERROR]".bold().red());
     }
+
+    ui::cli::log!();
+    ui::cli::log!(
+        "Finished in {}",
+        utils::pretty_print_duration(start.elapsed())
+    );
 
     Ok(())
 }

--- a/src/repository/snapshot.rs
+++ b/src/repository/snapshot.rs
@@ -141,6 +141,9 @@ pub struct SnapshotSummary {
 
     #[serde(flatten)]
     pub diff_counts: DiffCounts,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amends: Option<ID>, // The ID of the snapshot amended by this one
 }
 
 /// A snapshot streamer.

--- a/src/ui/snapshot_progress.rs
+++ b/src/ui/snapshot_progress.rs
@@ -259,6 +259,7 @@ impl SnapshotProgressReporter {
             total_raw_bytes,
             total_encoded_bytes,
             diff_counts: self.diff_counts.read().clone(),
+            amends: None,
         }
     }
 }

--- a/tests/integration_tests/test_cmd_amend.rs
+++ b/tests/integration_tests/test_cmd_amend.rs
@@ -90,6 +90,7 @@ mod tests {
         let amend_args = cmd_amend::CmdArgs {
             snapshot: UseSnapshot::Latest,
             all: false,
+            keep_old: false,
             tags_str: None,
             clear_tags: false,
             description: None,
@@ -207,6 +208,7 @@ mod tests {
         let amend_args = cmd_amend::CmdArgs {
             snapshot: UseSnapshot::Latest,
             all: false,
+            keep_old: false,
             tags_str: None,
             clear_tags: true,
             description: None,
@@ -227,6 +229,7 @@ mod tests {
         let amend_args = cmd_amend::CmdArgs {
             snapshot: UseSnapshot::Latest,
             all: false,
+            keep_old: false,
             tags_str: Some("new_tag".to_string()),
             clear_tags: false,
             description: Some(String::from("This description is new")),


### PR DESCRIPTION
- Added an option to keep the amended snapshot.
- Updated the SnapshotSummary to reflect the new snapshot size and number of items. The appended sizes are increased with the size of the new meta. The diff counts cannot be updated.
- Added a new field to the SnapshotSummary to contain the ID of the amended snapshot. This field can indicate that the metadata contained by the summary corresponds to an amended snapshot and may not be accurate anymore, except for the fields mentioned above.