### PR TITLE
Display error count on restore and allow continuing after error

### DIFF
--- a/src/commands/cmd_restore.rs
+++ b/src/commands/cmd_restore.rs
@@ -85,6 +85,10 @@ pub struct CmdArgs {
     #[clap(long, default_value_t=Resolution::Fail)]
     pub resolution: Resolution,
 
+    /// Quit immediately if a restore error occurs
+    #[clap(long, default_value_t = false)]
+    pub quit_on_error: bool,
+
     /// Skip verification of data
     #[clap(long = "no-verify", value_parser, default_value_t = false)]
     pub no_verify: bool,
@@ -199,16 +203,21 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
         restorer::Options {
             dry_run: args.dry_run,
             resolution: args.resolution.clone(),
+            quit_on_error: args.quit_on_error,
             strip_prefix: common_prefix,
         },
         progress_reporter.clone(),
     )?;
 
     progress_reporter.finalize();
+    let error_count = progress_reporter
+        .error_counter
+        .load(std::sync::atomic::Ordering::Relaxed);
 
     cli::log!(
-        "Finished in {}",
-        utils::pretty_print_duration(start.elapsed())
+        "Finished in {} with {}",
+        utils::pretty_print_duration(start.elapsed(),),
+        utils::format_count(error_count, "error", "errors")
     );
 
     Ok(())

--- a/src/restorer/mod.rs
+++ b/src/restorer/mod.rs
@@ -43,6 +43,7 @@ pub struct Options {
     pub resolution: Resolution,
     pub strip_prefix: Option<PathBuf>,
     pub dry_run: bool,
+    pub quit_on_error: bool,
 }
 
 pub struct Restorer {}
@@ -124,7 +125,7 @@ impl Restorer {
 
             progress_reporter.processing_file(path.clone());
 
-            // Attempt to restore the node.
+            // Attempt to restore the node
             if let Err(e) = node_restorer::restore_node_to_path(
                 repo.as_ref(),
                 progress_reporter.clone(),
@@ -132,11 +133,12 @@ impl Restorer {
                 &restore_path,
                 opts.dry_run,
             ) {
-                bail!(
-                    "Failed to restore item \'{}\': {}",
-                    restore_path.display(),
-                    e
-                )
+                let error_msg = format!("Failed to restore item {}: {}", restore_path.display(), e);
+
+                if opts.quit_on_error {
+                    bail!(error_msg);
+                }
+                progress_reporter.error(&error_msg);
             }
 
             progress_reporter.processed_file(&path);

--- a/src/restorer/node_restorer.rs
+++ b/src/restorer/node_restorer.rs
@@ -60,22 +60,21 @@ pub(crate) fn restore_node_to_path(
                 if let Some(parent) = dst_path.parent() {
                     fs::create_dir_all(parent).with_context(|| {
                         format!(
-                            "Could not create parent directories for file '{}'",
+                            "Could not create parent directories for file {}",
                             dst_path.display()
                         )
                     })?;
                 }
 
-                Some(
-                    OpenOptions::new()
-                        .create(true)
-                        .truncate(true)
-                        .write(true)
-                        .open(dst_path)
-                        .with_context(|| {
-                            format!("Could not create destination file '{}'", dst_path.display())
-                        })?,
-                )
+                match OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(dst_path)
+                {
+                    Ok(file) => Some(file),
+                    Err(e) => bail!("Could not create file {}: {}", dst_path.display(), e),
+                }
             } else {
                 None
             };
@@ -83,7 +82,7 @@ pub(crate) fn restore_node_to_path(
             for (index, blob_id) in blocks.iter().enumerate() {
                 let chunk_data = repo.load_blob(blob_id).with_context(|| {
                     format!(
-                        "Could not load block #{} ({}) for restoring file '{}'",
+                        "Could not load block #{} ({}) for restoring file {}",
                         index + 1,
                         blob_id,
                         dst_path.display()
@@ -99,7 +98,7 @@ pub(crate) fn restore_node_to_path(
                         .write_all(&chunk_data)
                         .with_context(|| {
                             format!(
-                                "Could not restore block #{} ({}) to file '{}'",
+                                "Could not restore block #{} ({}) to file {}",
                                 index + 1,
                                 blob_id,
                                 dst_path.display()
@@ -119,7 +118,7 @@ pub(crate) fn restore_node_to_path(
         NodeType::Directory => {
             if !dry_run {
                 std::fs::create_dir_all(dst_path).with_context(|| {
-                    format!("Could not create directory '{}'", dst_path.display())
+                    format!("Could not create directory {}", dst_path.display())
                 })?;
 
                 // We don't restore metadata for directories now, as the filetimes
@@ -144,7 +143,7 @@ pub(crate) fn restore_node_to_path(
                     && let Err(e) = std::os::unix::fs::symlink(&symlink_info.target_path, dst_path)
                 {
                     ui::cli::warning!(
-                        "Could not create symlink '{}' pointing to '{}' : {}",
+                        "Could not create symlink {} pointing to {} : {}",
                         dst_path.display(),
                         symlink_info.target_path.display(),
                         e.to_string()
@@ -164,7 +163,7 @@ pub(crate) fn restore_node_to_path(
                             )
                         {
                             ui::cli::warning!(
-                                "Could not create symlink '{}' pointing to '{}' : {}",
+                                "Could not create symlink {} pointing to {} : {}",
                                 dst_path.display(),
                                 symlink_info.target_path.display(),
                                 e.to_string()
@@ -180,7 +179,7 @@ pub(crate) fn restore_node_to_path(
                             )
                         {
                             ui::cli::warning!(
-                                "Could not create symlink '{}' pointing to '{}' : {}",
+                                "Could not create symlink {} pointing to '{}' : {}",
                                 dst_path.display(),
                                 symlink_info.target_path.display(),
                                 e.to_string()
@@ -201,12 +200,12 @@ pub(crate) fn restore_node_to_path(
         NodeType::BlockDevice => {
             #[cfg(unix)]
             ui::cli::warning!(
-                "Restoration of block device '{}' not supported yet.",
+                "Restoration of block device {} not supported yet.",
                 dst_path.display()
             );
             #[cfg(not(unix))]
             ui::cli::warning!(
-                "Block device restoration not supported on this operating system: '{}'",
+                "Block device restoration not supported on this operating system: {}",
                 dst_path.display()
             );
         }
@@ -214,12 +213,12 @@ pub(crate) fn restore_node_to_path(
         NodeType::CharDevice => {
             #[cfg(unix)]
             ui::cli::warning!(
-                "Restoration of character device '{}' not supported yet.",
+                "Restoration of character device {} not supported yet.",
                 dst_path.display()
             );
             #[cfg(not(unix))]
             ui::cli::warning!(
-                "Character device restoration not supported on this operating system: '{}'",
+                "Character device restoration not supported on this operating system: {}",
                 dst_path.display()
             );
         }
@@ -227,12 +226,12 @@ pub(crate) fn restore_node_to_path(
         NodeType::Fifo => {
             #[cfg(unix)]
             ui::cli::warning!(
-                "Restoration of FIFO (named pipe) '{}' not supported yet.",
+                "Restoration of FIFO (named pipe) {} not supported yet.",
                 dst_path.display()
             );
             #[cfg(not(unix))]
             ui::cli::warning!(
-                "FIFO restoration not supported on this operating system: '{}'",
+                "FIFO restoration not supported on this operating system: {}",
                 dst_path.display()
             );
         }
@@ -240,12 +239,12 @@ pub(crate) fn restore_node_to_path(
         NodeType::Socket => {
             #[cfg(unix)]
             ui::cli::warning!(
-                "Restoration of socket '{}' not supported yet.",
+                "Restoration of socket {} not supported yet.",
                 dst_path.display()
             );
             #[cfg(not(unix))]
             ui::cli::warning!(
-                "Socket restoration not supported on this operating system: '{}'",
+                "Socket restoration not supported on this operating system: {}",
                 dst_path.display()
             );
         }
@@ -273,7 +272,7 @@ fn restore_node_metadata(node: &Node, dst_path: &Path) -> Result<()> {
             let permissions = Permissions::from_mode(mode);
             if let Err(e) = std::fs::set_permissions(dst_path, permissions) {
                 bail!(
-                    "Could not set permissions for '{}': {}. This may not be supported for all node types (e.g. symlinks).",
+                    "Could not set permissions for {}: {}. This may not be supported for all node types (e.g. symlinks).",
                     dst_path.display(),
                     e.to_string()
                 );
@@ -288,7 +287,7 @@ fn restore_node_metadata(node: &Node, dst_path: &Path) -> Result<()> {
             if uid.is_some() || gid.is_some() {
                 if let Err(e) = std::os::unix::fs::chown(dst_path, uid, gid) {
                     bail!(
-                        "Could not set owner/group for '{}': {}. This operation often requires elevated privileges (e.g., root) and may not be supported for all node types (e.g. symlinks).",
+                        "Could not set owner/group for {}: {}. This operation often requires elevated privileges (e.g., root) and may not be supported for all node types (e.g. symlinks).",
                         dst_path.display(),
                         e.to_string()
                     );
@@ -311,7 +310,7 @@ pub fn restore_times(
         let ft_atime = atime.map_or(ft_mtime, |atime| FileTime::from(*atime));
 
         set_file_times(dst_path, ft_atime, ft_mtime)
-            .with_context(|| format!("Could not set file times for '{}'", dst_path.display()))?;
+            .with_context(|| format!("Could not set file times for {}", dst_path.display()))?;
     }
 
     Ok(())
@@ -345,9 +344,8 @@ mod tests {
         let ft_mtime = FileTime::from(prev_mtime);
         let ft_atime = node.metadata.accessed_time.map_or(ft_mtime, FileTime::from);
 
-        set_file_times(&file_path, ft_atime, ft_mtime).with_context(|| {
-            format!("Could not set modified time for '{}'", file_path.display())
-        })?;
+        set_file_times(&file_path, ft_atime, ft_mtime)
+            .with_context(|| format!("Could not set modified time for {}", file_path.display()))?;
 
         restore_node_metadata(&node, &file_path)?;
 

--- a/src/ui/restore_progress.rs
+++ b/src/ui/restore_progress.rs
@@ -18,23 +18,26 @@ use std::{
     collections::VecDeque,
     path::{Path, PathBuf},
     sync::{
-        Arc,
         atomic::{AtomicU64, Ordering},
+        Arc,
     },
     time::Duration,
 };
 
+use colored::Colorize;
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
 use parking_lot::RwLock;
 
 use crate::{
-    ui::{PROGRESS_REFRESH_RATE_HZ, SPINNER_TICK_CHARS, default_bar_draw_target},
+    ui::{default_bar_draw_target, PROGRESS_REFRESH_RATE_HZ, SPINNER_TICK_CHARS},
     utils,
 };
 
 pub struct RestoreProgressReporter {
     processed_items_count: Arc<AtomicU64>, // Number of files processed
     processing_items: Arc<RwLock<VecDeque<PathBuf>>>, // List of items being processed (for displaying)
+
+    pub(crate) error_counter: Arc<AtomicU64>,
 
     #[allow(dead_code)]
     mp: MultiProgress,
@@ -45,15 +48,17 @@ pub struct RestoreProgressReporter {
 impl RestoreProgressReporter {
     pub fn new(num_expected_items: u64, num_expected_bytes: u64, num_display_items: usize) -> Self {
         let processed_items_count_arc = Arc::new(AtomicU64::new(0));
+        let error_counter_arc = Arc::new(AtomicU64::new(0));
 
         let mp = MultiProgress::with_draw_target(default_bar_draw_target());
         let progress_bar = mp.add(ProgressBar::new(num_expected_bytes));
 
         let processed_items_count_arc_clone = processed_items_count_arc.clone();
+        let error_counter_arc_clone = error_counter_arc.clone();
         progress_bar.set_style(
             ProgressStyle::default_bar()
                 .template(
-                    "[{bar:20.cyan/white}] [{custom_elapsed}]  [{processed_bytes_formated}]  [{processed_items_formated}]  [ETA: {custom_eta}]"
+                    "[{bar:20.cyan/white}] [{custom_elapsed}]  [{processed_bytes_formated}]  [{processed_items_formated}]  [ETA: {custom_eta}]  {errors} errors"
                 )
                 .unwrap()
                 .progress_chars("=> ")
@@ -76,6 +81,9 @@ impl RestoreProgressReporter {
                     let custom_eta= utils::pretty_print_duration(eta);
                     let _ = w.write_str(&custom_eta);
                 })
+                .with_key("errors", move |_state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                    let _ = w.write_str(&error_counter_arc_clone.load(Ordering::SeqCst).to_string());
+                })
         );
 
         let mut file_spinners = Vec::with_capacity(num_display_items);
@@ -96,6 +104,7 @@ impl RestoreProgressReporter {
         Self {
             processed_items_count: processed_items_count_arc,
             processing_items: Arc::new(RwLock::new(VecDeque::new())),
+            error_counter: error_counter_arc,
             mp,
             progress_bar,
             file_spinners,
@@ -135,5 +144,10 @@ impl RestoreProgressReporter {
 
     pub fn processed_bytes(&self, bytes: u64) {
         self.progress_bar.inc(bytes);
+    }
+
+    pub fn error(&self, msg: &str) {
+        self.error_counter.fetch_add(1, Ordering::SeqCst);
+        let _ = self.mp.println(format!("{} {msg}", "Error:".bold().red()));
     }
 }

--- a/src/ui/snapshot_progress.rs
+++ b/src/ui/snapshot_progress.rs
@@ -19,7 +19,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         Arc,
-        atomic::{AtomicU32, AtomicU64, Ordering},
+        atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
@@ -51,7 +51,7 @@ pub struct SnapshotProgressReporter {
 
     processing_items: Arc<RwLock<VecDeque<PathBuf>>>, // List of items being processed (for displaying)
 
-    error_counter: Arc<AtomicU32>,
+    error_counter: Arc<AtomicU64>,
 
     #[allow(dead_code)]
     mp: MultiProgress,
@@ -76,7 +76,7 @@ impl SnapshotProgressReporter {
         let meta_encoded_bytes_arc = Arc::new(AtomicU64::new(0));
 
         let processing_items_arc = Arc::new(RwLock::new(VecDeque::new()));
-        let error_counter_arc = Arc::new(AtomicU32::new(0));
+        let error_counter_arc = Arc::new(AtomicU64::new(0));
 
         let processed_items_count_arc_clone = processed_items_count_arc.clone();
         let processed_bytes_arc_clone = processed_bytes_arc.clone();

--- a/tests/integration_tests/test_cmd_amend.rs
+++ b/tests/integration_tests/test_cmd_amend.rs
@@ -117,6 +117,7 @@ mod tests {
             strip_prefix: false,
             resolution: mapache::restorer::Resolution::Skip,
             no_verify: false,
+            quit_on_error: true,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;

--- a/tests/integration_tests/test_cmd_clean.rs
+++ b/tests/integration_tests/test_cmd_clean.rs
@@ -140,6 +140,7 @@ mod tests {
             strip_prefix: false,
             resolution: mapache::restorer::Resolution::Skip,
             no_verify: false,
+            quit_on_error: true,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;

--- a/tests/integration_tests/test_cmd_restore.rs
+++ b/tests/integration_tests/test_cmd_restore.rs
@@ -93,6 +93,7 @@ mod tests {
             strip_prefix: false,
             resolution: mapache::restorer::Resolution::Skip,
             no_verify: false,
+            quit_on_error: true,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;
@@ -202,6 +203,7 @@ mod tests {
             strip_prefix: false,
             resolution: mapache::restorer::Resolution::Skip,
             no_verify: false,
+            quit_on_error: true,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;
@@ -276,6 +278,7 @@ mod tests {
             strip_prefix: true,
             resolution: mapache::restorer::Resolution::Skip,
             no_verify: false,
+            quit_on_error: true,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore 1")?;
@@ -297,6 +300,7 @@ mod tests {
             strip_prefix: true,
             resolution: mapache::restorer::Resolution::Skip,
             no_verify: false,
+            quit_on_error: true,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore 2")?;

--- a/tests/integration_tests/test_cmd_snapshot.rs
+++ b/tests/integration_tests/test_cmd_snapshot.rs
@@ -95,6 +95,7 @@ mod tests {
             strip_prefix: false,
             resolution: mapache::restorer::Resolution::Skip,
             no_verify: false,
+            quit_on_error: true,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;
@@ -208,6 +209,7 @@ mod tests {
             strip_prefix: false,
             resolution: mapache::restorer::Resolution::Skip,
             no_verify: false,
+            quit_on_error: true,
         };
 
         let restore_result = commands::cmd_restore::run(&global, &restore_args);
@@ -278,6 +280,7 @@ mod tests {
             strip_prefix: false,
             resolution: Resolution::Skip,
             no_verify: false,
+            quit_on_error: true,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;
@@ -401,6 +404,7 @@ mod tests {
             strip_prefix: false,
             resolution: mapache::restorer::Resolution::Skip,
             no_verify: false,
+            quit_on_error: true,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;


### PR DESCRIPTION
Added a --quit-on-error flag to quit immediately after an error occurs. By default, a restore error does not stop the whole restoration, but it offers an opt-in flag to do so. Error messages are printed on top of the progress bar.