### PR TITLE
Some fixes and improvements for cmd_mount

### DIFF
--- a/src/commands/cmd_mount.rs
+++ b/src/commands/cmd_mount.rs
@@ -16,12 +16,12 @@
 
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use clap::Args;
 use colored::Colorize;
 
 use crate::{
-    backend::new_backend_with_prompt,
+    backend::{BackendUrl, new_backend_with_prompt},
     commands::{GlobalArgs, cleanup::CleanupHandler},
     fuse::fs::MapacheFS,
     repository::repo::{RepoConfig, Repository},
@@ -42,6 +42,14 @@ pub struct CmdArgs {
 }
 
 pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
+    // Don't allow mounting on the repo path
+    let cannonical_mountpoint = std::fs::canonicalize(args.mountpoint.clone())?;
+    if let BackendUrl::Local(repo_path) = BackendUrl::from(&global_args.repo)? {
+        if cannonical_mountpoint == repo_path.canonicalize()? {
+            bail!("Cannot mount the repository on itself");
+        }
+    }
+
     let pass = utils::get_password_from_file(&global_args.password_file)?;
     let backend = new_backend_with_prompt(global_args, true)?;
 
@@ -52,18 +60,20 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
         Repository::try_open_with_lock(pass, global_args.key.as_ref(), backend, config, false)?;
 
     // Listen for CTRL + C to unmount.
-    let mpoint = args.mountpoint.clone();
+    let mpoint = cannonical_mountpoint.clone();
+    let lock_handle_clone = lock_handle.clone();
     let _cleanup_handler = CleanupHandler::new(move || {
         let _ = MapacheFS::unmount(&mpoint);
+        let _ = lock_handle_clone.write().unlock();
     })?;
 
-    ui::cli::log!("Mounting repository in {}", &args.mountpoint.display());
+    ui::cli::log!("Mounting repository in {}", cannonical_mountpoint.display());
     ui::cli::log!(
         "Press {} to finish or unmount the filesystem manually.",
         "Ctrl+C".bold()
     );
     unsafe {
-        MapacheFS::mount(repo, &args.mountpoint, args.allow_other)?;
+        MapacheFS::mount(repo, &cannonical_mountpoint, args.allow_other)?;
     }
 
     Ok(())

--- a/src/commands/cmd_mount.rs
+++ b/src/commands/cmd_mount.rs
@@ -16,13 +16,14 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use clap::Args;
 use colored::Colorize;
 
 use crate::{
     backend::{BackendUrl, new_backend_with_prompt},
     commands::{GlobalArgs, cleanup::CleanupHandler},
+    fs,
     fuse::fs::MapacheFS,
     repository::repo::{RepoConfig, Repository},
     ui,
@@ -39,11 +40,30 @@ pub struct CmdArgs {
     /// Mount point
     #[arg(long, value_parser, default_value_t = false)]
     pub allow_other: bool,
+
+    /// Create the mountpoint if it does not exist
+    #[arg(short, long, value_parser, default_value_t = false)]
+    pub create_mountpoint: bool,
 }
 
 pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
+    // Check that mountpoint exists and is a directory, or create it if requested
+    let actual_mountpoint = args.mountpoint.clone();
+
+    if !fs::path_exists(&actual_mountpoint) {
+        if args.create_mountpoint {
+            std::fs::create_dir_all(&actual_mountpoint)
+                .with_context(|| "Could not create mount point")?;
+        } else {
+            bail!("Mountpoint doesn't exist");
+        }
+    } else if !actual_mountpoint.is_dir() {
+        bail!("Mountpoint must be a directory");
+    }
+
+    let cannonical_mountpoint = actual_mountpoint.canonicalize()?;
+
     // Don't allow mounting on the repo path
-    let cannonical_mountpoint = std::fs::canonicalize(args.mountpoint.clone())?;
     if let BackendUrl::Local(repo_path) = BackendUrl::from(&global_args.repo)? {
         if cannonical_mountpoint == repo_path.canonicalize()? {
             bail!("Cannot mount the repository on itself");

--- a/src/fuse/fs.rs
+++ b/src/fuse/fs.rs
@@ -86,7 +86,6 @@ impl Filesystem for MapacheFS {
             ui::cli::error!("Failed to read snapshots: {}", e.to_string());
         }
         let snapshots: Vec<(ID, Snapshot)> = snapshot_streamer.unwrap().collect();
-        let (latest_id, latest_snapshot) = snapshots.last().unwrap().clone();
 
         // snapshots
         let snapshots_ino = self.stash.add_dir(FUSE_ROOT_ID, String::from("snapshots"));
@@ -98,8 +97,6 @@ impl Filesystem for MapacheFS {
             self.stash
                 .add_snapshot_dir(ids_ino, id.to_hex(), snapshot.tree.clone());
         }
-        self.stash
-            .add_symlink(ids_ino, String::from("latest"), latest_id.to_hex());
 
         // by_date
         let by_date_ino = self.stash.add_dir(snapshots_ino, String::from("by_date"));
@@ -108,11 +105,18 @@ impl Filesystem for MapacheFS {
             let target = format!("../ids/{}", id.to_hex());
             self.stash.add_symlink(by_date_ino, name.clone(), target);
         }
-        self.stash.add_symlink(
-            by_date_ino,
-            String::from("latest"),
-            utils::pretty_print_timestamp(&latest_snapshot.timestamp),
-        );
+
+        // Links to the latest snapshot
+        if !snapshots.is_empty() {
+            let (latest_id, latest_snapshot) = snapshots.last().unwrap().clone();
+            self.stash
+                .add_symlink(ids_ino, String::from("latest"), latest_id.to_hex());
+            self.stash.add_symlink(
+                by_date_ino,
+                String::from("latest"),
+                utils::pretty_print_timestamp(&latest_snapshot.timestamp),
+            );
+        }
 
         Ok(())
     }

--- a/src/repository/lock.rs
+++ b/src/repository/lock.rs
@@ -152,7 +152,6 @@ impl LockHandle {
     }
 
     pub fn unlock(&mut self) -> Result<()> {
-        println!("Unlock");
         self.alive_flag.store(false, Ordering::SeqCst);
         self.repo
             .delete_file(FileType::Lock, self.lock.lock().id())?;
@@ -162,7 +161,6 @@ impl LockHandle {
 
 impl Drop for LockHandle {
     fn drop(&mut self) {
-        println!("Drop lock handle");
         let _ = self.unlock();
     }
 }


### PR DESCRIPTION
Some bug fixes and improvements for the mount command.

- Removed leftover debug prints from Lock.
- Added --create-dir to create the mountpoint if it doesn't exist.
- Removed the `lastest` symlink when there are no snapshots in the repo as there is no `Snapshot` to point to. The unwrap on the snapshot vector is only guaranteed to succeed when the vector is not empty.