### PR TITLE
Extend cmd_snapshot for sync

### DIFF
--- a/src/commands/cmd_restore.rs
+++ b/src/commands/cmd_restore.rs
@@ -34,9 +34,9 @@ use crate::{
         repo::{RepoConfig, Repository},
         verify::verify_snapshot_links,
     },
-    restorer::{self, Resolution, Restorer},
+    restorer::{self, Resolution, RestoreOptions},
     ui::{
-        self, PROGRESS_REFRESH_RATE_HZ, SPINNER_TICK_CHARS, cli, default_bar_draw_target,
+        self, PROGRESS_REFRESH_RATE_HZ, SPINNER_TICK_CHARS, default_bar_draw_target,
         restore_progress::RestoreProgressReporter,
     },
     utils::{self, format_size, size},
@@ -45,8 +45,9 @@ use crate::{
 impl std::fmt::Display for Resolution {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Resolution::Skip => write!(f, "skip"),
-            Resolution::Overwrite => write!(f, "overwrite"),
+            Resolution::Repo => write!(f, "repo"),
+            Resolution::Local => write!(f, "local"),
+            Resolution::Newer => write!(f, "newer"),
             Resolution::Fail => write!(f, "fail"),
         }
     }
@@ -82,11 +83,16 @@ pub struct CmdArgs {
 
     /// Method for conflict resolution in case a file or directory already exists in the target location.
     ///
-    /// skip: Skips restoring the conflicting item.
-    /// overwrite: Overwrites the item in the target location.
     /// fail: Terminates the command with an error.
+    /// local: Skips restoring and keeps the local item.
+    /// repo: Overwrites the item in the target location with the node from the snapshot.
+    /// newer: Keeps the item with the more recent modified time.
     #[clap(long, default_value_t=Resolution::Fail)]
     pub resolution: Resolution,
+
+    /// Delete files in the target directory that are not present in the snapshot.
+    #[clap(long, value_parser, default_value_t = false)]
+    pub delete: bool,
 
     /// Quit immediately if a restore error occurs
     #[clap(long, default_value_t = false)]
@@ -208,13 +214,13 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
 
     let start = Instant::now();
 
-    Restorer::restore(
+    restorer::restore(
         repo.clone(),
         &snapshot,
         &args.target,
         args.include.clone(),
         args.exclude.clone(),
-        restorer::Options {
+        RestoreOptions {
             dry_run: args.dry_run,
             resolution: args.resolution.clone(),
             quit_on_error: args.quit_on_error,
@@ -228,7 +234,19 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
         .error_counter
         .load(std::sync::atomic::Ordering::Relaxed);
 
-    cli::log!(
+    if args.delete {
+        // Delete local nodes not present in the snapshot tree
+        restorer::sync::delete_nodes(
+            repo,
+            args.target.clone(),
+            &snapshot.tree,
+            args.include.clone(),
+            args.exclude.clone(),
+            args.dry_run,
+        )?;
+    }
+
+    ui::cli::log!(
         "Finished in {} with {}",
         utils::pretty_print_duration(start.elapsed(),),
         utils::format_count(error_count, "error", "errors")

--- a/src/fs/tree.rs
+++ b/src/fs/tree.rs
@@ -251,7 +251,7 @@ impl Iterator for FSNodeStreamer {
 /// A depth‑first *pre‑order* streamer of serialized nodes.
 ///
 /// Items are produced in lexicographical order of their *full* paths. The root node is not emitted.
-/// Trees are loaded from the repository as they are needed. The full tree is not  stored in memory.
+/// Trees are loaded from the repository as they are needed. The full tree is not stored in memory.
 /// The iteration with a stack avoids recursive calls.
 ///
 /// This streamer also allows including and excluding a list of paths. Paths in the exclude list, and their
@@ -356,6 +356,86 @@ impl Iterator for SerializedNodeStreamer {
             }
 
             Ok((current_path, stream_node))
+        })();
+        Some(res)
+    }
+}
+
+/// A depth‑first *pre‑order* streamer of serialized trees.
+///
+/// Items are produced in lexicographical order of their *full* paths. The root tree is emitted.
+/// Trees are loaded from the repository as they are needed. The full tree is not stored in memory.
+/// The iteration with a stack avoids recursive calls.
+///
+/// This streamer also allows including and excluding a list of paths. Paths in the exclude list, and their
+/// children, are never explored nor emitted. If the include list is not empty, only nodes in the same branch
+/// (children and parents (intermediate nodes to reach the included path)) as those paths will be emitted.
+pub struct SerializedTreeStreamer {
+    repo: Arc<Repository>,
+    stack: Vec<(PathBuf, ID)>,
+    include: Option<Vec<PathBuf>>,
+    exclude: Option<Vec<PathBuf>>,
+}
+
+impl SerializedTreeStreamer {
+    pub fn new(
+        repo: Arc<Repository>,
+        root_id: &ID,
+        base_path: PathBuf,
+        include: Option<Vec<PathBuf>>,
+        exclude: Option<Vec<PathBuf>>,
+    ) -> Result<Self> {
+        let mut stack = Vec::new();
+        if utils::filter_path(&base_path, include.as_ref(), exclude.as_ref()) {
+            stack.push((base_path, root_id.clone()));
+        }
+
+        Ok(Self {
+            repo,
+            stack,
+            include,
+            exclude,
+        })
+    }
+}
+
+impl Iterator for SerializedTreeStreamer {
+    type Item = Result<(PathBuf, Tree)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (current_path, tree_id) = match self.stack.pop() {
+            None => return None, // Stack is empty, no more trees to stream
+            Some((path, id)) => (path, id),
+        };
+
+        let res = (|| {
+            let tree = Tree::load_from_repo(self.repo.as_ref(), &tree_id).with_context(|| {
+                format!(
+                    "Failed to load tree with ID {tree_id} for path {}",
+                    current_path.display()
+                )
+            })?;
+
+            // Collect children (directories only)
+            let mut children = Vec::new();
+            for node in tree.nodes.iter() {
+                if let Some(subtree_id) = &node.tree {
+                    // Check if the node is a directory (has a subtree ID) and apply filter
+                    let child_path = current_path.join(&node.name);
+                    if utils::filter_path(&child_path, self.include.as_ref(), self.exclude.as_ref())
+                    {
+                        children.push((child_path, subtree_id.clone()));
+                    }
+                }
+            }
+
+            // Push children to stack in reverse lexicographical order
+            children.sort_by(|(path1, _), (path2, _)| path1.cmp(path2));
+            for (child_path, child_id) in children.into_iter().rev() {
+                self.stack.push((child_path, child_id));
+            }
+
+            Ok((current_path, tree))
         })();
         Some(res)
     }
@@ -516,6 +596,7 @@ where
     }
 }
 
+/// Returns a serialized Node in a Tree if it exists.
 pub fn find_serialized_node(
     repo: &Repository,
     base_tree_id: &ID,

--- a/src/restorer/mod.rs
+++ b/src/restorer/mod.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 pub mod node_restorer;
+pub mod sync;
 
 use std::{
     collections::BTreeSet,
@@ -22,7 +23,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{Context, Ok, Result, bail};
+use anyhow::{Context, Result, bail};
 use clap::ValueEnum;
 
 use crate::{
@@ -34,123 +35,137 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, ValueEnum)]
 pub enum Resolution {
-    Skip,
-    Overwrite,
     Fail,
+    Repo,
+    Local,
+    Newer,
 }
 
-pub struct Options {
+pub struct RestoreOptions {
     pub resolution: Resolution,
     pub strip_prefix: Option<PathBuf>,
     pub dry_run: bool,
     pub quit_on_error: bool,
 }
 
-pub struct Restorer {}
+#[allow(clippy::too_many_arguments)]
+pub fn restore(
+    repo: Arc<Repository>,
+    snapshot: &Snapshot,
+    target_path: &Path,
+    include: Option<Vec<PathBuf>>,
+    exclude: Option<Vec<PathBuf>>,
+    opts: RestoreOptions,
+    progress_reporter: Arc<RestoreProgressReporter>,
+) -> Result<()> {
+    let tree = snapshot.tree.clone();
+    let node_streamer =
+        SerializedNodeStreamer::new(repo.clone(), Some(tree), PathBuf::new(), include, exclude)?;
 
-impl Restorer {
-    #[allow(clippy::too_many_arguments)]
-    pub fn restore(
-        repo: Arc<Repository>,
-        snapshot: &Snapshot,
-        target_path: &Path,
-        include: Option<Vec<PathBuf>>,
-        exclude: Option<Vec<PathBuf>>,
-        opts: Options,
-        progress_reporter: Arc<RestoreProgressReporter>,
-    ) -> Result<()> {
-        let tree = snapshot.tree.clone();
-        let node_streamer = SerializedNodeStreamer::new(
-            repo.clone(),
-            Some(tree),
-            PathBuf::new(),
-            include,
-            exclude,
-        )?;
+    // Exclude prefix components
+    let strip_excludes = if let Some(ref prefix) = opts.strip_prefix {
+        let (_, inter) = utils::get_intermediate_paths(&PathBuf::new(), &[prefix.to_path_buf()]);
+        inter.into_keys().collect()
+    } else {
+        BTreeSet::new()
+    };
 
-        // Exclude prefix components
-        let strip_excludes = if let Some(ref prefix) = opts.strip_prefix {
-            let (_, inter) =
-                utils::get_intermediate_paths(&PathBuf::new(), &[prefix.to_path_buf()]);
-            inter.into_keys().collect()
-        } else {
-            BTreeSet::new()
-        };
+    // Stack directories to restore file times later
+    // Modifying the metadata of a node changes the file times of the parent directory.
+    // Since the SerializedNodeStreamer emits paths in lexicographical order, we can
+    // pop them in reverse order from the stack.
+    let mut dir_stack = Vec::new();
 
-        // Stack directories to restore file times later
-        // Modifying the metadata of a node changes the file times of the parent directory.
-        // Since the SerializedNodeStreamer emits paths in lexicographical order, we can
-        // pop them in reverse order from the stack.
-        let mut dir_stack = Vec::new();
+    for node_res in node_streamer {
+        let (mut path, stream_node) = node_res?;
 
-        for node_res in node_streamer {
-            let (mut path, stream_node) = node_res?;
-
-            if let Some(prefix) = &opts.strip_prefix {
-                if strip_excludes.contains(&path) {
-                    continue;
-                }
-
-                path = path
-                    .strip_prefix(prefix)
-                    .with_context(|| "Failed to strip prefix from restore path")?
-                    .to_path_buf();
-
-                if path.to_str().unwrap() == "" {
-                    continue;
-                }
+        if let Some(prefix) = &opts.strip_prefix {
+            if strip_excludes.contains(&path) {
+                continue;
             }
 
-            let restore_path = target_path.join(&path);
+            path = path
+                .strip_prefix(prefix)
+                .with_context(|| "Failed to strip prefix from restore path")?
+                .to_path_buf();
 
-            if fs::path_exists(&restore_path) {
-                match opts.resolution {
-                    Resolution::Skip => {
-                        progress_reporter.processed_file(&path);
-                        continue;
-                    }
-                    Resolution::Overwrite => {}
-                    Resolution::Fail => {
-                        bail!("Target \'{}\' already exists", restore_path.display());
-                    }
-                }
-            }
-
-            if stream_node.node.is_dir() {
-                let path = restore_path.clone();
-                let atime = stream_node.node.metadata.accessed_time;
-                let mtime = stream_node.node.metadata.modified_time;
-                dir_stack.push((path, atime, mtime));
-            }
-
-            progress_reporter.processing_file(path.clone());
-
-            // Attempt to restore the node
-            if let Err(e) = node_restorer::restore_node_to_path(
-                repo.as_ref(),
-                progress_reporter.clone(),
-                &stream_node.node,
-                &restore_path,
-                opts.dry_run,
-            ) {
-                let error_msg = format!("Failed to restore item {}: {}", restore_path.display(), e);
-
-                if opts.quit_on_error {
-                    bail!(error_msg);
-                }
-                progress_reporter.error(&error_msg);
-            }
-
-            progress_reporter.processed_file(&path);
-        }
-
-        // Second pass for the directory file times
-        if !opts.dry_run {
-            while let Some((path, atime, mtime)) = dir_stack.pop() {
-                node_restorer::restore_times(&path, atime.as_ref(), mtime.as_ref())?;
+            if path.to_str().unwrap() == "" {
+                continue;
             }
         }
 
-        Ok(())
+        let restore_path = target_path.join(&path);
+
+        if fs::path_exists(&restore_path) {
+            match opts.resolution {
+                Resolution::Repo => (),
+                Resolution::Local => {
+                    progress_reporter.processed_file(&path);
+                    continue;
+                }
+                Resolution::Newer => {
+                    let local_metadata =
+                        std::fs::symlink_metadata(&restore_path).with_context(|| {
+                            format!(
+                                "Failed to get metadata for local file {}",
+                                restore_path.display()
+                            )
+                        })?;
+
+                    let local_mtime = local_metadata.modified().with_context(|| {
+                        format!(
+                            "Failed to get modified time for local file {}",
+                            restore_path.display()
+                        )
+                    })?;
+
+                    if let Some(repo_mtime) = stream_node.node.metadata.modified_time {
+                        if local_mtime >= repo_mtime {
+                            progress_reporter.processed_file(&path);
+                            continue;
+                        }
+                    }
+                }
+                Resolution::Fail => {
+                    bail!("Target {} exists already", restore_path.display());
+                }
+            }
+        }
+
+        if stream_node.node.is_dir() {
+            let path = restore_path.clone();
+            let atime = stream_node.node.metadata.accessed_time;
+            let mtime = stream_node.node.metadata.modified_time;
+            dir_stack.push((path, atime, mtime));
+        }
+
+        progress_reporter.processing_file(path.clone());
+
+        // Attempt to restore the node
+        if let Err(e) = node_restorer::restore_node_to_path(
+            repo.as_ref(),
+            progress_reporter.clone(),
+            &stream_node.node,
+            &restore_path,
+            opts.dry_run,
+        ) {
+            let error_msg = format!("Failed to restore item {}: {}", restore_path.display(), e);
+
+            if opts.quit_on_error {
+                bail!(error_msg);
+            }
+            progress_reporter.error(&error_msg);
+        }
+
+        progress_reporter.processed_file(&path);
     }
+
+    // Second pass for the directory file times
+    if !opts.dry_run {
+        while let Some((path, atime, mtime)) = dir_stack.pop() {
+            node_restorer::restore_times(&path, atime.as_ref(), mtime.as_ref())?;
+        }
+    }
+
+    Ok(())
 }

--- a/src/restorer/sync.rs
+++ b/src/restorer/sync.rs
@@ -1,0 +1,154 @@
+// mapache is an incremental backup tool
+// Copyright (C) 2025  Javier Lancha Vázquez <javier.lancha@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+
+use crate::{fs::tree::SerializedTreeStreamer, global::ID, repository::repo::Repository, ui};
+
+/// Delete all local nodes not present in a snapshot tree
+pub fn delete_nodes(
+    repo: Arc<Repository>,
+    target_path: PathBuf,
+    root_tree_id: &ID,
+    include: Option<Vec<PathBuf>>,
+    exclude: Option<Vec<PathBuf>>,
+    dry_run: bool,
+) -> Result<()> {
+    ui::cli::log!("Starting sync delete for '{}'", target_path.display());
+
+    let tree_streamer =
+        SerializedTreeStreamer::new(repo, root_tree_id, target_path.clone(), include, exclude)
+            .with_context(|| {
+                format!("Failed to initialize snapshot tree streamer for root ID {root_tree_id:?}")
+            })?;
+
+    // NOTE:
+    // It is crucial that the first item (the root tree) is skipped. The root path was never a part
+    // of the snapshot, only the selected nodes that were explicitly added. We MUST skip the root
+    // directory or there will be catastrophic consequences, i.e., deleting all other nodes in
+    // the root path that were never backed up.
+    for item_result in tree_streamer.skip(1) {
+        // Handle potential errors from the streamer itself.
+        // If an error occurs, log a warning and skip to the next item,
+        // rather than bailing out entirely, which seems to be the intended behavior.
+        let (dir_path, snapshot_tree) = match item_result {
+            Ok(data) => data,
+            Err(e) => {
+                ui::cli::warning!("Could not read snapshot subtree entry: {e}");
+                continue; // Skip to the next item in the stream
+            }
+        };
+
+        // Pre-process snapshot tree nodes into a HashSet for fast lookups
+        let snapshot_node_names: HashSet<&str> = snapshot_tree
+            .nodes
+            .iter()
+            .map(|node| node.name.as_str())
+            .collect();
+
+        // Delegate the processing of the local directory to a helper function
+        process_local_directory(&dir_path, &snapshot_node_names, dry_run)?
+    }
+
+    ui::cli::log!("Finished sync delete for '{}'\n", target_path.display());
+    Ok(())
+}
+
+// Helper function to process a single local directory to sync
+fn process_local_directory(
+    local_dir_path: &Path,
+    snapshot_node_names: &HashSet<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    let local_readdir = match local_dir_path.read_dir() {
+        Ok(readdir) => readdir,
+        Err(e) => {
+            // If the directory does not exist, there's nothing to delete in it.
+            if e.kind() == std::io::ErrorKind::NotFound {
+                ui::cli::verbose_1!(
+                    "Local directory '{}' not found, skipping.",
+                    local_dir_path.display()
+                );
+                return Ok(());
+            } else {
+                // For other errors (e.g., permission denied), propagate the error.
+                return Err(e).with_context(|| {
+                    format!(
+                        "Could not read local directory '{}'",
+                        local_dir_path.display()
+                    )
+                });
+            }
+        }
+    };
+
+    // The rest of the function remains the same, as it only executes if read_dir was successful
+    for node_res in local_readdir {
+        let dir_entry = match node_res {
+            Ok(entry) => entry,
+            Err(e) => {
+                ui::cli::warning!(
+                    "Failed to read local node in '{}': {e}",
+                    local_dir_path.display()
+                );
+                continue;
+            }
+        };
+
+        let local_name = dir_entry.file_name();
+        let local_name_str = local_name.to_string_lossy();
+        let local_path = dir_entry.path();
+
+        if !snapshot_node_names.contains(local_name_str.as_ref()) {
+            perform_deletion(&local_path, dry_run)?;
+        }
+    }
+
+    Ok(())
+}
+
+// Helper function to perform the actual file/directory deletion or log dry run
+fn perform_deletion(path_to_delete: &Path, dry_run: bool) -> Result<()> {
+    if dry_run {
+        ui::cli::log!(
+            "{} Would delete '{}'",
+            "[DRY RUN]".bold().purple(),
+            path_to_delete.display()
+        );
+    } else if path_to_delete.is_dir() {
+        ui::cli::verbose_1!("Deleting directory '{}'", path_to_delete.display(),);
+        std::fs::remove_dir_all(path_to_delete).with_context(|| {
+            format!(
+                "Failed to delete local directory '{}'",
+                path_to_delete.display()
+            )
+        })?;
+    } else {
+        ui::cli::verbose_1!("Deleting file '{}'", path_to_delete.display(),);
+        std::fs::remove_file(path_to_delete).with_context(|| {
+            format!("Failed to delete local file '{}'", path_to_delete.display())
+        })?;
+    }
+
+    Ok(())
+}

--- a/src/ui/restore_progress.rs
+++ b/src/ui/restore_progress.rs
@@ -124,6 +124,10 @@ impl RestoreProgressReporter {
     }
 
     pub fn finalize(&self) {
+        self.progress_bar.finish_and_clear();
+        for spinner in self.file_spinners.iter() {
+            spinner.finish_and_clear();
+        }
         let _ = self.mp.clear();
     }
 

--- a/src/ui/snapshot_progress.rs
+++ b/src/ui/snapshot_progress.rs
@@ -186,6 +186,11 @@ impl SnapshotProgressReporter {
     }
 
     pub fn finalize(&self) {
+        self.progress_bar.finish_and_clear();
+        self.companion_bar.finish_and_clear();
+        for spinner in self.file_spinners.iter() {
+            spinner.finish_and_clear();
+        }
         let _ = self.mp.clear();
     }
 

--- a/tests/integration_tests/test_cmd_amend.rs
+++ b/tests/integration_tests/test_cmd_amend.rs
@@ -28,6 +28,7 @@ mod tests {
             repo::{RepoConfig, Repository},
             snapshot::SnapshotStreamer,
         },
+        restorer::Resolution,
     };
 
     use tempfile::tempdir;
@@ -115,9 +116,10 @@ mod tests {
             include: None,
             exclude: None,
             strip_prefix: false,
-            resolution: mapache::restorer::Resolution::Skip,
+            resolution: Resolution::Local,
             no_verify: false,
             quit_on_error: true,
+            delete: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;

--- a/tests/integration_tests/test_cmd_clean.rs
+++ b/tests/integration_tests/test_cmd_clean.rs
@@ -23,6 +23,7 @@ mod tests {
     use mapache::{
         commands::{self, GlobalArgs, UseSnapshot, cmd_clean, cmd_restore, cmd_snapshot},
         global::{defaults::DEFAULT_DEFAULT_PACK_SIZE_MIB, set_global_opts_with_args},
+        restorer::Resolution,
     };
 
     use tempfile::tempdir;
@@ -138,9 +139,10 @@ mod tests {
             include: None,
             exclude: None,
             strip_prefix: false,
-            resolution: mapache::restorer::Resolution::Skip,
+            resolution: Resolution::Local,
             no_verify: false,
             quit_on_error: true,
+            delete: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;

--- a/tests/integration_tests/test_cmd_restore.rs
+++ b/tests/integration_tests/test_cmd_restore.rs
@@ -23,6 +23,7 @@ mod tests {
     use mapache::{
         commands::{self, GlobalArgs, UseSnapshot, cmd_restore, cmd_snapshot},
         global::{defaults::DEFAULT_DEFAULT_PACK_SIZE_MIB, set_global_opts_with_args},
+        restorer::Resolution,
     };
     use tempfile::tempdir;
 
@@ -91,9 +92,10 @@ mod tests {
             include: Some(vec![PathBuf::from("0"), PathBuf::from("1")]),
             exclude: Some(vec![PathBuf::from("0/00/file00.txt")]),
             strip_prefix: false,
-            resolution: mapache::restorer::Resolution::Skip,
+            resolution: Resolution::Local,
             no_verify: false,
             quit_on_error: true,
+            delete: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;
@@ -201,9 +203,10 @@ mod tests {
             include: None,
             exclude: None,
             strip_prefix: false,
-            resolution: mapache::restorer::Resolution::Skip,
+            resolution: Resolution::Local,
             no_verify: false,
             quit_on_error: true,
+            delete: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;
@@ -276,9 +279,10 @@ mod tests {
             ]),
             exclude: None,
             strip_prefix: true,
-            resolution: mapache::restorer::Resolution::Skip,
+            resolution: Resolution::Local,
             no_verify: false,
             quit_on_error: true,
+            delete: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore 1")?;
@@ -289,7 +293,7 @@ mod tests {
             assert!(restored_path.exists());
         }
 
-        // Run restore 1
+        // Run restore 2
         let restore_path = tmp_path.join("restore2");
         let restore_args = cmd_restore::CmdArgs {
             target: restore_path.clone(),
@@ -298,9 +302,10 @@ mod tests {
             include: Some(vec![PathBuf::from("0/00/file00.txt")]),
             exclude: None,
             strip_prefix: true,
-            resolution: mapache::restorer::Resolution::Skip,
+            resolution: Resolution::Local,
             no_verify: false,
             quit_on_error: true,
+            delete: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore 2")?;
@@ -310,6 +315,139 @@ mod tests {
             let restored_path = restore_path.join(path);
             assert!(restored_path.exists());
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_restore_sync() -> Result<()> {
+        let tmp_dir = tempdir()?;
+        let tmp_path = tmp_dir.path();
+        let password = "mapachito";
+        let password_path = tmp_path.join("password");
+        std::fs::write(&password_path, password)?;
+
+        let backup_data_path = test_utils::get_test_data_path(BACKUP_DATA_PATH);
+        let backup_data_tmp_path = tmp_path.join("backup");
+        test_utils::extract_tar_xz_archive(&backup_data_path, &backup_data_tmp_path)?;
+
+        let repo = String::from("repo");
+        let repo_path = tmp_path.join(&repo);
+
+        let global = GlobalArgs {
+            repo: repo_path.to_string_lossy().to_string(),
+            password_file: Some(password_path),
+            key: None,
+            quiet: true,
+            verbosity: None,
+            ssh_pubkey: None,
+            ssh_privatekey: None,
+            pack_size_mib: DEFAULT_DEFAULT_PACK_SIZE_MIB,
+        };
+        set_global_opts_with_args(&global);
+
+        // Init repo
+        init_repo(password, repo_path.clone())?;
+
+        // Run snapshot
+        let snapshot_args = cmd_snapshot::CmdArgs {
+            paths: vec![
+                backup_data_tmp_path.join("0"),
+                backup_data_tmp_path.join("1"),
+                backup_data_tmp_path.join("2"),
+                backup_data_tmp_path.join("file.txt"),
+            ],
+            as_root: false,
+            exclude: None,
+            tags_str: String::new(),
+            description: None,
+            rescan: false,
+            parent: UseSnapshot::Latest,
+            read_concurrency: 2,
+            write_concurrency: 5,
+            dry_run: false,
+        };
+        commands::cmd_snapshot::run(&global, &snapshot_args)
+            .with_context(|| "Failed to run cmd_snapshot")?;
+
+        // Run restore to create base files
+        let restore_path = tmp_path.join("restore");
+        let restore_args = cmd_restore::CmdArgs {
+            target: restore_path.clone(),
+            snapshot: UseSnapshot::Latest,
+            dry_run: false,
+            include: None,
+            exclude: None,
+            strip_prefix: false,
+            resolution: Resolution::Repo,
+            no_verify: true,
+            quit_on_error: false,
+            delete: false,
+        };
+        commands::cmd_restore::run(&global, &restore_args)
+            .with_context(|| "Failed to run cmd_restore (1/2)")?;
+
+        // Create extra files
+        std::fs::create_dir_all(restore_path.join("0"))?;
+        std::fs::create_dir_all(restore_path.join("1").join("10"))?;
+        std::fs::File::create(restore_path.join("extra_root.txt"))?;
+        std::fs::File::create(restore_path.join("0").join("extra0.txt"))?;
+        std::fs::File::create(restore_path.join("1").join("10").join("extra10.txt"))?;
+        assert!(restore_path.join("extra_root.txt").exists());
+        assert!(restore_path.join("0").join("extra0.txt").exists());
+        assert!(
+            restore_path
+                .join("1")
+                .join("10")
+                .join("extra10.txt")
+                .exists()
+        );
+
+        // Restore with --delete
+        let restore_args = cmd_restore::CmdArgs {
+            target: restore_path.clone(),
+            snapshot: UseSnapshot::Latest,
+            dry_run: false,
+            include: None,
+            exclude: None,
+            strip_prefix: false,
+            resolution: Resolution::Repo,
+            no_verify: true,
+            quit_on_error: false,
+            delete: true,
+        };
+        commands::cmd_restore::run(&global, &restore_args)
+            .with_context(|| "Failed to run cmd_restore (2/2)")?;
+
+        let paths = vec![
+            PathBuf::from("0"),
+            PathBuf::from("0/file0.txt"),
+            PathBuf::from("0/00"),
+            PathBuf::from("0/00/file00.txt"),
+            PathBuf::from("0/01"),
+            PathBuf::from("0/01/file01a.txt"),
+            PathBuf::from("0/01/file01b.txt"),
+            PathBuf::from("1"),
+            PathBuf::from("1/10"),
+            PathBuf::from("2"),
+            PathBuf::from("file.txt"),
+        ];
+
+        for path in &paths {
+            let restored_path = restore_path.join(path);
+            assert!(restored_path.exists());
+        }
+
+        // Assert that extra files were deleted, except at root level
+        assert!(restore_path.join("extra_root.txt").exists()); // Don't delete this node!
+        assert!(!restore_path.join("0").join("extra0.txt").exists());
+        assert!(
+            !restore_path
+                .join("1")
+                .join("10")
+                .join("extra10.txt")
+                .exists()
+        );
 
         Ok(())
     }

--- a/tests/integration_tests/test_cmd_snapshot.rs
+++ b/tests/integration_tests/test_cmd_snapshot.rs
@@ -93,9 +93,10 @@ mod tests {
             include: None,
             exclude: None,
             strip_prefix: false,
-            resolution: mapache::restorer::Resolution::Skip,
+            resolution: Resolution::Local,
             no_verify: false,
             quit_on_error: true,
+            delete: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;
@@ -207,9 +208,10 @@ mod tests {
             include: None,
             exclude: None,
             strip_prefix: false,
-            resolution: mapache::restorer::Resolution::Skip,
+            resolution: Resolution::Local,
             no_verify: false,
             quit_on_error: true,
+            delete: false,
         };
 
         let restore_result = commands::cmd_restore::run(&global, &restore_args);
@@ -278,9 +280,10 @@ mod tests {
             include: None,
             exclude: None,
             strip_prefix: false,
-            resolution: Resolution::Skip,
+            resolution: Resolution::Local,
             no_verify: false,
             quit_on_error: true,
+            delete: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;
@@ -402,9 +405,10 @@ mod tests {
             include: None,
             exclude: None,
             strip_prefix: false,
-            resolution: mapache::restorer::Resolution::Skip,
+            resolution: Resolution::Local,
             no_verify: false,
             quit_on_error: true,
+            delete: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .with_context(|| "Failed to run cmd_restore")?;


### PR DESCRIPTION
Extend the `restore` command to allow 'synchronizing' a snapshot tree into a local tree (keep the most recent version of nodes and delete extra nodes).

- Added new conflict `Resolution` variants: `Fail`, `Repo`, `Local`, `Newer`.
- Added `--delete` flag to delete nodes not present in the snapshot tree.
- Added `SerializedTreeStreamer`: a snapshot `Tree` streamer similar to the `SerializedNodeStreamer`, but this streamer only loads `Tree` objects.