### PR TITLE
Make FUSE a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ libc = "0.2.176"
 
 
 [target.'cfg(unix)'.dependencies]
-fuser = "0.16.0"
+fuser = {version = "0.16.0", optional = true}
 
 
 [dev-dependencies]
@@ -44,3 +44,8 @@ rstest = "0.26.1"
 tar = "0.4.44"
 tempfile = "3.23.0"
 xz2 = "0.1.7"
+
+
+[features]
+default = ["fuse"]
+fuse = ["fuser"] #FUSE for mount command

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -50,7 +50,7 @@ pub mod cmd_sync;
 pub mod cmd_unlock;
 pub mod cmd_verify;
 
-#[cfg(unix)]
+#[cfg(all(feature = "fuse", unix))]
 pub mod cmd_mount;
 
 // CLI arguments
@@ -81,7 +81,7 @@ pub enum Command {
     Key(cmd_key::CmdArgs),
     Log(cmd_log::CmdArgs),
     Ls(cmd_ls::CmdArgs),
-    #[cfg(unix)]
+    #[cfg(all(feature = "fuse", unix))]
     Mount(cmd_mount::CmdArgs),
     Restore(cmd_restore::CmdArgs),
     Snapshot(cmd_snapshot::CmdArgs),
@@ -217,7 +217,7 @@ pub fn run(args: &Cli) -> Result<()> {
         Command::Key(cmd_args) => cmd_key::run(&args.global_args, cmd_args),
         Command::Log(cmd_args) => cmd_log::run(&args.global_args, cmd_args),
         Command::Ls(cmd_args) => cmd_ls::run(&args.global_args, cmd_args),
-        #[cfg(unix)]
+        #[cfg(all(feature = "fuse", unix))]
         Command::Mount(cmd_args) => cmd_mount::run(&args.global_args, cmd_args),
         Command::Restore(cmd_args) => cmd_restore::run(&args.global_args, cmd_args),
         Command::Snapshot(cmd_args) => cmd_snapshot::run(&args.global_args, cmd_args),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,5 +24,5 @@ pub mod restorer;
 pub mod ui;
 pub mod utils;
 
-#[cfg(unix)]
+#[cfg(all(feature = "fuse", unix))]
 pub mod fuse;


### PR DESCRIPTION
The mount command depends on the libfuse library. This library is not available in all OSes and/or distributions. Mount should be an optional feature for those platforms that support it.