### PR TITLE
Use Hash instead of BTree

### DIFF
--- a/src/repository/gc.rs
+++ b/src/repository/gc.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     path::PathBuf,
     sync::{
         Arc,
@@ -47,18 +47,18 @@ pub struct Plan {
     pub total_packs: usize, // Total number of packs in the repository
     pub referenced_blobs: HashSet<ID>, // Blobs referenced by existing snapshots
     pub referenced_packs: HashSet<ID>, // Packs referenced by the referenced blobs
-    pub obsolete_packs: BTreeSet<ID>, // Packs containing non-referenced blobs or are small/duplicate sources
-    pub small_packs: BTreeSet<ID>,    // Small packs marked to be repacked (to merge)
-    pub tolerated_packs: BTreeSet<ID>, // Packs containing garbage, but keep due to tolerance
-    pub unused_packs: BTreeSet<ID>,   // Packs not referenced by any snapshot or index
-    pub index_ids: BTreeSet<ID>,      // Current index IDs
+    pub obsolete_packs: HashSet<ID>, // Packs containing non-referenced blobs or are small/duplicate sources
+    pub small_packs: HashSet<ID>,    // Small packs marked to be repacked (to merge)
+    pub tolerated_packs: HashSet<ID>, // Packs containing garbage, but keep due to tolerance
+    pub unused_packs: HashSet<ID>,   // Packs not referenced by any snapshot or index
+    pub index_ids: HashSet<ID>,      // Current index IDs
 }
 
 /// Scan the repository and make a plan of what needs to be cleaned.
 pub fn scan(repo: Arc<Repository>, tolerance: f32) -> Result<Plan> {
     let (referenced_blobs, referenced_packs) = get_referenced_blobs_and_packs(repo.clone())?;
 
-    let mut keep_packs: BTreeSet<ID> = repo.list_objects()?;
+    let mut keep_packs: HashSet<ID> = repo.list_objects()?;
     let mut unused_packs = keep_packs.clone();
 
     keep_packs.retain(|id| referenced_packs.contains(id));
@@ -69,11 +69,11 @@ pub fn scan(repo: Arc<Repository>, tolerance: f32) -> Result<Plan> {
         total_packs: keep_packs.len(),
         referenced_blobs,
         referenced_packs,
-        obsolete_packs: BTreeSet::new(),
-        tolerated_packs: BTreeSet::new(),
+        obsolete_packs: HashSet::new(),
+        tolerated_packs: HashSet::new(),
         unused_packs,
         index_ids: repo.index().read().ids(),
-        small_packs: BTreeSet::new(),
+        small_packs: HashSet::new(),
     };
 
     // Count garbage bytes in each pack
@@ -161,7 +161,7 @@ impl Plan {
         // Append small packs to the obsolete pack list. These will be repacked and deleted,
         // which helps consolidate storage and eliminates duplicates that might be in them.
         if self.small_packs.len() > 1 {
-            self.obsolete_packs.append(&mut self.small_packs);
+            self.obsolete_packs.extend(self.small_packs.drain());
         }
 
         deleted_size += self.delete_unused_packs()?;

--- a/src/repository/index.rs
+++ b/src/repository/index.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     time::Instant,
 };
 
@@ -464,14 +464,14 @@ impl MasterIndex {
     }
 
     /// Returns the IDs of all finalized (serialized) indices
-    pub fn ids(&self) -> BTreeSet<ID> {
+    pub fn ids(&self) -> HashSet<ID> {
         self.indices
             .iter()
             .filter_map(|idx| if !idx.is_pending() { idx.id() } else { None })
             .collect()
     }
 
-    pub fn cleanup(&mut self, obsolete_packs: Option<&BTreeSet<ID>>) {
+    pub fn cleanup(&mut self, obsolete_packs: Option<&HashSet<ID>>) {
         if let Some(packs_to_remove) = obsolete_packs {
             for idx in &mut self.indices {
                 // IMPORTANT: Mark index as pending so it can be overwritten/merged.
@@ -488,16 +488,13 @@ impl MasterIndex {
     /// Merges all current indices into a new collection of full indices.
     fn merge_index(&mut self) {
         let mut new_indices = Vec::new();
-        let mut processed_pack_ids = BTreeSet::new();
+        let mut processed_pack_ids = HashSet::new();
 
         // Temporarily take ownership of the indices vector
         let old_indices: Vec<Index> = std::mem::take(&mut self.indices);
 
         let mut current_index = Index::new();
 
-        // Iterate over all old indices (newest to oldest is often preferred, but
-        // iterating in order is fine for merging, as the check below handles
-        // duplicates based on a global BTreeSet).
         for idx in old_indices {
             let mut packs_to_merge: HashMap<&ID, Vec<PackedBlobDescriptor>> = HashMap::new();
 
@@ -650,7 +647,7 @@ mod tests {
         assert_eq!(raw_len, 60);
 
         // Test iterator
-        let ids: BTreeSet<&ID> = index.iter_ids().map(|(id, _)| id).collect();
+        let ids: HashSet<&ID> = index.iter_ids().map(|(id, _)| id).collect();
         assert_eq!(ids.len(), 2);
         assert!(ids.contains(&data_blob.id));
         assert!(ids.contains(&tree_blob.id));

--- a/src/repository/repo.rs
+++ b/src/repository/repo.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
-    collections::BTreeSet,
+    collections::HashSet,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -591,8 +591,8 @@ impl Repository {
     }
 
     /// Lists all packs in the repository.
-    pub fn list_objects(&self) -> Result<BTreeSet<ID>> {
-        let mut list = BTreeSet::new();
+    pub fn list_objects(&self) -> Result<HashSet<ID>> {
+        let mut list = HashSet::new();
 
         let num_folders: usize = 1 << (4 * OBJECTS_DIR_FANOUT);
         for n in 0..num_folders {


### PR DESCRIPTION
BTree was used everywhere possible to minimize memory use, but Hash structures are faster. If the memory use within normal use is similar we should switch back to Hash.

**We need to benchmark the differences.**