### PR TITLE
Refactor backend write for robustness & add tmp file cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
 ## Latest
+### Changes
+- Delete all .tmp files from the repository during GC.
 
 ### Fixes
 - Fixed calculation of file hashes (regression). The hash of a file is calculated after the contents are (potentially) encoded.
+- Ignore files with invalid ID names when loading indices, snapshots and keys.
 
 ## v0.1.0-beta.3
 ### Changes

--- a/src/archiver/tree_serializer.rs
+++ b/src/archiver/tree_serializer.rs
@@ -143,6 +143,7 @@ impl TreeSerializer {
 
     // Helper function to encapsulate the core finalization and serialization logic,
     // handling both root and non-root directories.
+    #[allow(clippy::type_complexity)]
     fn finalize_and_save(
         &mut self,
         dir_path: PathBuf,

--- a/src/backend/localfs.rs
+++ b/src/backend/localfs.rs
@@ -92,12 +92,23 @@ impl StorageBackend for LocalFS {
         let full_tmp_path = self.full_path(&tmp_path);
 
         // Write to a tmp path
-        std::fs::write(&full_tmp_path, contents).with_context(|| {
-            format!(
-                "Could not write to '{}' in local backend",
-                tmp_path.display()
-            )
-        })?;
+        if let Err(_) = std::fs::write(&full_tmp_path, contents) {
+            // If error, try creating the parent directory first and try again.
+            let parent_dir = path.parent().with_context(|| {
+                format!(
+                    "Could not create parent directory for '{}' in local backend",
+                    path.display()
+                )
+            })?;
+            let _ = self.create_dir(parent_dir);
+
+            std::fs::write(&full_tmp_path, contents).with_context(|| {
+                format!(
+                    "Could not write to '{}' in local backend",
+                    tmp_path.display()
+                )
+            })?;
+        }
 
         // Rename to the final path
         self.rename(&tmp_path, path)?;

--- a/src/backend/localfs.rs
+++ b/src/backend/localfs.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use crate::{
     backend::{Handle, NodeAttr},
     fs,
+    repository::repo::REPO_TMP_EXTENSION,
 };
 
 use super::StorageBackend;
@@ -88,11 +89,11 @@ impl StorageBackend for LocalFS {
 
     fn write(&self, handle: &Handle, contents: &[u8]) -> Result<()> {
         let path = handle.path;
-        let tmp_path = path.with_extension("tmp");
+        let tmp_path = path.with_extension(REPO_TMP_EXTENSION);
         let full_tmp_path = self.full_path(&tmp_path);
 
         // Write to a tmp path
-        if let Err(_) = std::fs::write(&full_tmp_path, contents) {
+        if std::fs::write(&full_tmp_path, contents).is_err() {
             // If error, try creating the parent directory first and try again.
             let parent_dir = path.parent().with_context(|| {
                 format!(

--- a/src/backend/sftp.rs
+++ b/src/backend/sftp.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use crossbeam_channel::{Receiver, Sender, bounded};
 use ssh2::{RenameFlags, Session, Sftp};
 
-use crate::{backend::Handle, ui};
+use crate::{backend::Handle, repository::repo::REPO_TMP_EXTENSION, ui};
 
 use super::StorageBackend;
 
@@ -348,7 +348,7 @@ impl StorageBackend for SftpBackend {
 
     fn write(&self, handle: &Handle, contents: &[u8]) -> Result<()> {
         let path = handle.path;
-        let tmp_path = path.with_extension("tmp");
+        let tmp_path = path.with_extension(REPO_TMP_EXTENSION);
         let full_tmp_path = self.full_path(&tmp_path);
         let conn = self.pool.get()?;
         let sftp = conn.sftp();
@@ -357,7 +357,7 @@ impl StorageBackend for SftpBackend {
         let mut file = sftp
             .create(&full_tmp_path)
             .with_context(|| format!("Failed to create file for writing: {tmp_path:?}"))?;
-        if let Err(_) = file.write_all(contents) {
+        if file.write_all(contents).is_err() {
             // If error, try creating the parent directory first and try again.
             let parent_dir = path.parent().with_context(|| {
                 format!(

--- a/src/backend/sftp.rs
+++ b/src/backend/sftp.rs
@@ -357,8 +357,19 @@ impl StorageBackend for SftpBackend {
         let mut file = sftp
             .create(&full_tmp_path)
             .with_context(|| format!("Failed to create file for writing: {tmp_path:?}"))?;
-        file.write_all(contents)
-            .with_context(|| format!("Failed to write to file: {tmp_path:?}"))?;
+        if let Err(_) = file.write_all(contents) {
+            // If error, try creating the parent directory first and try again.
+            let parent_dir = path.parent().with_context(|| {
+                format!(
+                    "Could not create parent directory for '{}' in sftp backend",
+                    path.display()
+                )
+            })?;
+            let _ = self.create_dir(parent_dir);
+
+            file.write_all(contents)
+                .with_context(|| format!("Failed to write to file: {tmp_path:?}"))?;
+        }
 
         // Rename to the final path reusing the connection.
         self.rename_internal(sftp, &tmp_path, path)

--- a/src/repository/gc.rs
+++ b/src/repository/gc.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -13,13 +13,17 @@ use indicatif::{ProgressBar, ProgressStyle};
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
+    backend::{StorageBackend, read_backend_dir},
     fs::tree::SerializedNodeStreamer,
     mapache::{
         self, DEFAULT_ID, FileType, ID, SaveID,
         defaults::{DEFAULT_MIN_PACK_SIZE_FACTOR, DEFAULT_PACK_SIZE},
         global::GlobalOpts,
     },
-    repository::{repo::Repository, snapshot::SnapshotStreamer},
+    repository::{
+        repo::{REPO_TMP_EXTENSION, Repository},
+        snapshot::SnapshotStreamer,
+    },
     ui::{self, SPINNER_TICK_CHARS, default_bar_draw_target},
     utils,
 };
@@ -165,6 +169,8 @@ impl Plan {
             deleted_size += self.delete_old_indices()?;
             deleted_size += self.delete_obsolete_packs()?;
         }
+
+        delete_tmp_files(self.repo.backend().as_ref())?;
 
         Ok((deleted_size - added_size) as i64)
     }
@@ -508,4 +514,26 @@ fn remove_expired_locks(repo: &Arc<Repository>) -> Result<u64> {
     );
 
     Ok(size_freed)
+}
+
+/// Remove all .tmp files in the repository.
+/// These spurious files could remain after a failed write or an interruption,
+/// as they are created for atomically writing to the repository.
+fn delete_tmp_files(backend: &dyn StorageBackend) -> Result<()> {
+    let nodes = read_backend_dir(backend, Path::new(""))?;
+    let tmp_nodes = nodes
+        .into_iter()
+        .filter(|node| match node.path().extension() {
+            Some(ext) => ext.to_string_lossy().to_string() == REPO_TMP_EXTENSION,
+            None => false,
+        });
+
+    for node in tmp_nodes {
+        if let Err(_) = backend.remove(node.path()) {
+            // Failing to delete one of these files is not a fatal error.
+            ui::cli::warning!("Could not remove tmp file {}", node.path().display())
+        }
+    }
+
+    Ok(())
 }

--- a/src/repository/keys.rs
+++ b/src/repository/keys.rs
@@ -307,6 +307,16 @@ impl Iterator for KeyFileStreamer {
                 continue;
             }
 
+            let id = match ID::from_hex(
+                path.file_name()
+                    .expect("File should have a name")
+                    .to_string_lossy()
+                    .as_ref(),
+            ) {
+                Err(_) => continue, // Ignore key files with invalid ID names
+                Ok(id) => id,
+            };
+
             let ss = SecureStorage::build().with_compression(zstd::DEFAULT_COMPRESSION_LEVEL);
 
             let keyfile_data =
@@ -331,15 +341,6 @@ impl Iterator for KeyFileStreamer {
                 }
             };
 
-            let id = match ID::from_hex(
-                path.file_name()
-                    .expect("File should have a name")
-                    .to_string_lossy()
-                    .as_ref(),
-            ) {
-                Err(e) => return Some(Err(e)),
-                Ok(id) => id,
-            };
             return Some(Ok((id, keyfile)));
         }
 

--- a/src/repository/repo.rs
+++ b/src/repository/repo.rs
@@ -36,6 +36,8 @@ pub const MANIFEST_PATH: &str = "manifest";
 pub const KEYS_DIR: &str = "keys";
 pub const LOCKS_DIR: &str = "locks";
 
+pub(crate) const REPO_TMP_EXTENSION: &str = "tmp";
+
 const OBJECTS_DIR_FANOUT: usize = 2;
 
 /// Authentication credentials of a user
@@ -295,6 +297,11 @@ impl Repository {
     /// Returns a reference to the repo manifest.
     pub fn manifest(&self) -> &Manifest {
         &self.manifest
+    }
+
+    /// Get the repository backend
+    pub fn backend(&self) -> Arc<dyn StorageBackend> {
+        self.backend.clone()
     }
 
     /// Encodes and saves a blob in the repository. This blob can be packed with other blobs in an pack file.

--- a/src/repository/repo.rs
+++ b/src/repository/repo.rs
@@ -469,7 +469,10 @@ impl Repository {
             if self.backend.is_file(&path)
                 && let Some(file_name) = path.file_name().and_then(|s| s.to_str())
             {
-                ids.push(ID::from_hex(file_name)?);
+                // Ignore all files with invalid ID names
+                if let Ok(id) = ID::from_hex(file_name) {
+                    ids.push(id);
+                }
             }
         }
 
@@ -754,7 +757,7 @@ impl Repository {
 
     /// Load the master index from file
     fn load_master_index(&mut self) -> Result<()> {
-        let files = self.backend.list_dir(&self.index_path)?;
+        let files = self.list_files(FileType::Index)?;
         let num_index_files = files.len();
 
         for file_path in files {
@@ -763,7 +766,10 @@ impl Repository {
                 .expect("Could not read index file name")
                 .to_string_lossy()
                 .clone();
-            let id = ID::from_hex(&file_name)?;
+            let id = match ID::from_hex(&file_name) {
+                Ok(id) => id,
+                Err(_) => continue, // Ignore invalid ID names
+            };
             let index_file = self.backend.read(
                 &Handle::new_with_hint(&file_path, true, FileType::Index),
                 0,


### PR DESCRIPTION
- If writing to a backend fails, it could be that a parent directory is missing. Create the parent and retry writing file.
- Delete all .tmp files from the repository during GC.
- Ignore files with invalid ID names when loading indices, snapshots and keys. A leftover .tmp file in one of these key directories must not hinder opening a repository.