### PR TITLE
Best effort metadata restore and warning logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Latest
 ### Changes
 - Delete all .tmp files from the repository during GC.
+- Best effort metadata restoring. Failing to restore metadata is not an error, but a warning.
+  Highly likely and recurrent warnings, which don't affect the integrity of the data, should not be logged.
 
 ### Fixes
 - Fixed calculation of file hashes (regression). The hash of a file is calculated after the contents are (potentially) encoded.

--- a/src/commands/cmd_restore.rs
+++ b/src/commands/cmd_restore.rs
@@ -223,6 +223,7 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     )?;
 
     progress_reporter.finalize();
+    let warning_count = progress_reporter.warning_counter.load(Ordering::Relaxed);
     let error_count = progress_reporter.error_counter.load(Ordering::Relaxed);
 
     if args.delete {
@@ -239,9 +240,10 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     }
 
     ui::cli::log!(
-        "Finished in {} with {}",
+        "Finished in {} with {} and {}",
         utils::pretty_print_duration(start.elapsed(),),
-        utils::format_count(error_count, "error", "errors")
+        utils::format_count(error_count, "error", "errors"),
+        utils::format_count(warning_count, "warning", "warnings")
     );
 
     Ok(())

--- a/src/commands/cmd_sync.rs
+++ b/src/commands/cmd_sync.rs
@@ -213,10 +213,7 @@ fn diff(
     let mut num_to_copy = 0;
     let mut num_to_delete = 0;
     let update_msg = |num_to_copy: usize, num_to_delete: usize| {
-        spinner.set_message(format!(
-            "{} to copy, {} to delete",
-            num_to_copy, num_to_delete
-        ));
+        spinner.set_message(format!("{num_to_copy} to copy, {num_to_delete} to delete"));
     };
 
     loop {

--- a/src/restorer/node_restorer.rs
+++ b/src/restorer/node_restorer.rs
@@ -7,12 +7,9 @@ use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 use std::{fs::OpenOptions, io::Write, path::Path};
 
 use {
-    anyhow::{Context, Result, bail},
+    anyhow::{Context, Result},
     filetime::{FileTime, set_file_times},
 };
-
-#[cfg(unix)]
-use anyhow::anyhow;
 
 use crate::{
     fs::node::{Node, NodeType},
@@ -92,7 +89,7 @@ pub(crate) fn restore_node_to_path(
 
             // Restore metadata after content is written
             if !dry_run {
-                restore_node_metadata(node, dst_path, progress_reporter.as_ref())?;
+                try_restore_node_metadata(node, dst_path, progress_reporter.as_ref());
             }
         }
 
@@ -167,7 +164,7 @@ pub(crate) fn restore_node_to_path(
             if !dry_run {
                 #[cfg(unix)]
                 {
-                    restore_symlink_metadata(node, dst_path, progress_reporter.as_ref())?;
+                    try_restore_symlink_metadata(node, dst_path, progress_reporter.as_ref());
                 }
                 #[cfg(not(unix))]
                 {
@@ -235,72 +232,6 @@ pub(crate) fn restore_node_to_path(
     Ok(())
 }
 
-/// Restores the metadata of a node to the specified destination path.
-/// This function attempts to restore all metadata fields with a best-effort approach.
-/// It will collect and return an error with a list of all failures, rather than
-/// failing on the first one.
-#[allow(unused_variables)]
-fn restore_node_metadata(
-    node: &Node,
-    dst_path: &Path,
-    progress_reporter: &RestoreProgressReporter,
-) -> Result<()> {
-    let mut errors = Vec::new();
-
-    // Set file times
-    if let Err(e) = restore_times(
-        dst_path,
-        node.metadata.accessed_time.as_ref(),
-        node.metadata.modified_time.as_ref(),
-    ) {
-        errors.push(e);
-    }
-
-    // Unix-specific metadata (mode, uid, gid)
-    #[cfg(unix)]
-    {
-        // Set file permissions (mode)
-        if !node.is_symlink()
-            && let Some(mode) = node.metadata.mode
-        {
-            let permissions = Permissions::from_mode(mode);
-            if std::fs::set_permissions(dst_path, permissions).is_err() {
-                errors.push(anyhow!("Could not set permissions (mode: {mode:o})."));
-            }
-        }
-
-        if !node.is_symlink() {
-            // Set owner (uid) and group (gid)
-            let uid = node.metadata.owner_uid;
-            let gid = node.metadata.owner_gid;
-
-            // Restoring uid and gid is very likely to fail unless the user is root.
-            if (uid.is_some() || gid.is_some())
-                && let Err(e) = std::os::unix::fs::chown(dst_path, uid, gid)
-            {
-                progress_reporter.warning(&format!(
-                    "Could not set ownership (uid: {:?}, gid: {:?}) for {}: {}",
-                    uid,
-                    gid,
-                    dst_path.display(),
-                    e
-                ));
-            }
-        }
-    }
-
-    if !errors.is_empty() {
-        let mut final_error_message =
-            format!("Failed to restore metadata for {}:\n", dst_path.display());
-        for err in errors {
-            final_error_message.push_str(&format!("  - {err}\n"));
-        }
-        bail!("{final_error_message}");
-    }
-
-    Ok(())
-}
-
 /// Restores file times
 pub fn restore_times(
     dst_path: &Path,
@@ -317,61 +248,78 @@ pub fn restore_times(
     Ok(())
 }
 
-#[cfg(unix)]
-fn restore_symlink_metadata(
+/// Restores the metadata of a node to the specified destination path.
+/// This function attempts to restore all metadata fields with a best-effort approach.
+#[allow(unused_variables)]
+fn try_restore_node_metadata(
     node: &Node,
     dst_path: &Path,
     progress_reporter: &RestoreProgressReporter,
-) -> Result<()> {
-    let mut errors = Vec::new();
+) {
+    // Set file times
+    if let Err(e) = restore_times(
+        dst_path,
+        node.metadata.accessed_time.as_ref(),
+        node.metadata.modified_time.as_ref(),
+    ) {
+        progress_reporter.warning(&format!(
+            "Could not set file times for {}).",
+            dst_path.display()
+        ));
+    }
 
+    // Unix-specific metadata (mode, uid, gid)
+    #[cfg(unix)]
+    {
+        // Set file permissions (mode)
+        if !node.is_symlink()
+            && let Some(mode) = node.metadata.mode
+        {
+            let permissions = Permissions::from_mode(mode);
+            if std::fs::set_permissions(dst_path, permissions).is_err() {
+                progress_reporter.warning(&format!("Could not set permissions (mode: {mode:o})."));
+            }
+        }
+
+        if !node.is_symlink() {
+            // Set owner (uid) and group (gid)
+            let uid = node.metadata.owner_uid;
+            let gid = node.metadata.owner_gid;
+
+            // Restoring uid and gid is very likely to fail unless the user is root.
+            if uid.is_some() || gid.is_some() {
+                let _ = std::os::unix::fs::chown(dst_path, uid, gid);
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn try_restore_symlink_metadata(
+    node: &Node,
+    dst_path: &Path,
+    progress_reporter: &RestoreProgressReporter,
+) {
     // Set file times using set_symlink_file_times
     if let Some(mtime) = node.metadata.modified_time.as_ref() {
         let ft_mtime = FileTime::from(*mtime);
         let ft_atime = node.metadata.accessed_time.map_or(ft_mtime, FileTime::from);
 
         if let Err(e) = filetime::set_symlink_file_times(dst_path, ft_atime, ft_mtime) {
-            errors.push(anyhow!("Could not set file times for symlink: {e}"));
+            progress_reporter.warning(&format!("Could not set file times for symlink: {e}"));
         }
     }
 
-    // Set permissions (mode)
-    if let Some(mode) = node.metadata.mode {
-        progress_reporter.warning(&format!(
-            "Skipping permission {mode} restoration for symlink {}",
-            dst_path.display()
-        ));
-    }
+    // TODO: Set permissions for symlink
 
     // Set owner (uid) and group (gid) using lchown
     let uid = node.metadata.owner_uid;
     let gid = node.metadata.owner_gid;
 
     // lchown is needed to change the ownership of the symlink itself, not the target.
-    if (uid.is_some() || gid.is_some())
-        && let Err(e) = std::os::unix::fs::chown(dst_path, uid, gid)
-    {
-        progress_reporter.warning(&format!(
-            "Could not set symlink ownership (uid: {:?}, gid: {:?}) for {}: {}",
-            uid,
-            gid,
-            dst_path.display(),
-            e
-        ));
+    if uid.is_some() || gid.is_some() {
+        let _ = std::os::unix::fs::chown(dst_path, uid, gid);
     }
-
-    if !errors.is_empty() {
-        let mut final_error_message = format!(
-            "Failed to restore symlink metadata for {}:\n",
-            dst_path.display()
-        );
-        for err in errors {
-            final_error_message.push_str(&format!("  - {err}\n"));
-        }
-        bail!("{final_error_message}");
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -412,7 +360,7 @@ mod tests {
 
         // Now restore the metadata from the node
         let reporter = RestoreProgressReporter::new(0, 0, 1);
-        restore_node_metadata(&node, &file_path, &reporter)?;
+        try_restore_node_metadata(&node, &file_path, &reporter);
 
         // Check if the mtime was restored back to the node's original mtime
         assert_eq!(

--- a/src/ui/restore_progress.rs
+++ b/src/ui/restore_progress.rs
@@ -22,6 +22,7 @@ pub struct RestoreProgressReporter {
     processing_items: Arc<RwLock<VecDeque<PathBuf>>>, // List of items being processed (for displaying)
 
     pub(crate) error_counter: Arc<AtomicU64>,
+    pub(crate) warning_counter: Arc<AtomicU64>,
 
     #[allow(dead_code)]
     mp: MultiProgress,
@@ -34,6 +35,7 @@ impl RestoreProgressReporter {
     pub fn new(num_expected_items: u64, num_expected_bytes: u64, num_display_items: usize) -> Self {
         let processed_items_count_arc = Arc::new(AtomicU64::new(0));
         let error_counter_arc = Arc::new(AtomicU64::new(0));
+        let warning_counter_arc = Arc::new(AtomicU64::new(0));
 
         let mp = MultiProgress::with_draw_target(default_bar_draw_target());
         let progress_bar = mp.add(ProgressBar::new(num_expected_bytes));
@@ -41,6 +43,7 @@ impl RestoreProgressReporter {
 
         let processed_items_count_arc_clone = processed_items_count_arc.clone();
         let error_counter_arc_clone = error_counter_arc.clone();
+        let warning_counter_arc_clone = warning_counter_arc.clone();
         progress_bar.set_style(
             ProgressStyle::default_bar()
                 .template(
@@ -66,7 +69,7 @@ impl RestoreProgressReporter {
 
         companion_bar.set_style(
             ProgressStyle::default_bar()
-                .template("[{processed_items_fmt}]  [{errors} errors]")
+                .template("[{processed_items_fmt}]  [{errors} errors, {warnings} warnings]")
                 .expect("The snapshot progress bar should have been created")
                 .progress_chars("=> ")
                 .with_key(
@@ -82,6 +85,13 @@ impl RestoreProgressReporter {
                     move |_state: &ProgressState, w: &mut dyn std::fmt::Write| {
                         let errors = error_counter_arc_clone.load(Ordering::SeqCst);
                         let _ = w.write_str(&errors.to_string());
+                    },
+                )
+                .with_key(
+                    "warnings",
+                    move |_state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                        let warnings = warning_counter_arc_clone.load(Ordering::SeqCst);
+                        let _ = w.write_str(&warnings.to_string());
                     },
                 ),
         );
@@ -103,6 +113,7 @@ impl RestoreProgressReporter {
             processed_items_count: processed_items_count_arc,
             processing_items: Arc::new(RwLock::new(VecDeque::new())),
             error_counter: error_counter_arc,
+            warning_counter: warning_counter_arc,
             mp,
             progress_bar,
             companion_bar,
@@ -156,7 +167,7 @@ impl RestoreProgressReporter {
     }
 
     pub fn warning(&self, msg: &str) {
-        self.error_counter.fetch_add(1, Ordering::SeqCst);
+        self.warning_counter.fetch_add(1, Ordering::SeqCst);
         let _ = self
             .mp
             .println(format!("{} {msg}", "Warning:".bold().yellow()));


### PR DESCRIPTION
Failing to set the owner should not be an error or crowd the console with warnings, since it is an operation that is mostly expected to fail during restore. As a best effort tool, mapache tries to chown, but there is no guarantee.

In general, failing to restore metadata is not an error, but a warning. Highly likely and recurrent warnings, which don't affect the integrity of the data, should not be logged.