### PR TITLE
Expect index to contain referenced blob id while repacking

### DIFF
--- a/src/commands/cmd_cat.rs
+++ b/src/commands/cmd_cat.rs
@@ -7,7 +7,7 @@ use crate::{
     backend::{BackendOptions, new_backend_with_prompt},
     commands::{GlobalArgs, cleanup::CleanupHandler},
     fs::tree::Tree,
-    mapache::{BlobType, ContentIdType},
+    mapache::ContentIdType,
     repository::repo::{RepoConfig, Repository},
     ui,
     utils::{self, size},
@@ -82,7 +82,7 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
                 None => bail!("No tree blobs found with prefix {prefix}"),
             };
             let tree = repo
-                .load_blob(id, BlobType::Tree)
+                .load_blob(id)
                 .with_context(|| "Failed to load tree blob")?;
             let tree: Tree = serde_json::from_slice(&tree)?;
             ui::cli::log!("{}", serde_json::to_string_pretty(&tree)?);
@@ -95,9 +95,7 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
                 Some(val) => val,
                 None => bail!("No blobs found with prefix {prefix}"),
             };
-            let blob = repo
-                .load_blob(id, BlobType::Data)
-                .with_context(|| "Failed to load blob")?;
+            let blob = repo.load_blob(id).with_context(|| "Failed to load blob")?;
             ui::cli::log!("{}", String::from_utf8(blob)?);
             Ok(())
         }

--- a/src/commands/cmd_stats.rs
+++ b/src/commands/cmd_stats.rs
@@ -235,13 +235,11 @@ fn stats_snapshots(repo: Arc<Repository>) -> Result<()> {
                 for blob_id in blobs {
                     // Single op membership check
                     if visited_blobs.insert(blob_id) {
-                        if let Some((_pack, _type, _off, encoded_len, raw_len)) =
-                            index_guard.get(&blob_id)
-                        {
+                        if let Some(locator) = index_guard.get(&blob_id) {
                             total_raw_data_size =
-                                total_raw_data_size.saturating_add(raw_len as u64);
+                                total_raw_data_size.saturating_add(locator.raw_length as u64);
                             total_encoded_data_size =
-                                total_encoded_data_size.saturating_add(encoded_len as u64);
+                                total_encoded_data_size.saturating_add(locator.length as u64);
                             num_referenced_blobs = num_referenced_blobs.saturating_add(1);
                         } else {
                             error_counter = error_counter.saturating_add(1);

--- a/src/commands/cmd_verify.rs
+++ b/src/commands/cmd_verify.rs
@@ -309,10 +309,10 @@ pub fn verify_snapshot(
                                 }
                             }
                         } else {
-                            let (_, _, _, raw_length, _) = index_guard
+                            let locator = index_guard
                                 .get(&blob)
                                 .expect("We visited this blob, so it should be indexed");
-                            bar.inc(raw_length as u64);
+                            bar.inc(locator.raw_length as u64);
                         }
                     }
                 }

--- a/src/fs/tree.rs
+++ b/src/fs/tree.rs
@@ -64,7 +64,7 @@ impl Tree {
 
     /// Load a tree from the repository.
     pub fn load_from_repo(repo: &Repository, root_id: &ID) -> Result<Tree> {
-        let tree_object = repo.load_blob(root_id, BlobType::Tree)?;
+        let tree_object = repo.load_blob(root_id)?;
         let tree: Tree = serde_json::from_slice(&tree_object)?;
         Ok(tree)
     }

--- a/src/fuse/cache.rs
+++ b/src/fuse/cache.rs
@@ -2,11 +2,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use anyhow::{Result, bail};
 
-use crate::{
-    fs::tree::Tree,
-    mapache::{BlobType, ID},
-    repository::repo::Repository,
-};
+use crate::{fs::tree::Tree, mapache::ID, repository::repo::Repository};
 
 /// A cache for `Tree` objects that uses a Least Recently Used (LRU) eviction policy.
 pub(super) struct TreeCache {
@@ -77,7 +73,7 @@ impl TreeCache {
         // Load from repository
         let tree_blob = self
             .repo
-            .load_blob(id, BlobType::Tree)
+            .load_blob(id)
             .unwrap_or_else(|_| panic!("Failed to load tree {}", id.to_hex()));
         let tree: Tree = serde_json::from_slice(&tree_blob)
             .unwrap_or_else(|_| panic!("Failed to serialize tree {}", id.to_hex()));
@@ -165,7 +161,7 @@ impl BlobCache {
 
         let blob_indexed_size = match self.repo.index().read().get(id) {
             None => bail!("Blob is not indexed"),
-            Some((.., encoded_size)) => encoded_size,
+            Some(blob_locator) => blob_locator.length,
         };
 
         // Evict all blobs in excess
@@ -182,7 +178,7 @@ impl BlobCache {
         // Cache miss: load from repository
         let blob = self
             .repo
-            .load_blob(id, BlobType::Data)
+            .load_blob(id)
             .unwrap_or_else(|_| panic!("Failed to load blob {}", id.to_hex()));
 
         self.size += blob.len() as u64;

--- a/src/fuse/stash.rs
+++ b/src/fuse/stash.rs
@@ -468,14 +468,14 @@ impl Stash {
             }
 
             let indexed_blob_descriptor = index.get(blob_id);
-            let (.., raw_len) = match indexed_blob_descriptor {
+            let locator = match indexed_blob_descriptor {
                 Some(desc) => desc,
                 None => bail!("Node with ino {ino} has unreferenced blobs (blob_id: {blob_id})"),
             };
 
-            if current_offset + (raw_len as i64) < offset {
+            if current_offset + (locator.raw_length as i64) < offset {
                 // We didn't reach the offset yet or are exactly at its end
-                current_offset += raw_len as i64;
+                current_offset += locator.raw_length as i64;
                 continue;
             }
 
@@ -485,12 +485,12 @@ impl Stash {
                 0
             };
 
-            let bytes_available_in_blob = raw_len as i64 - start_in_blob;
+            let bytes_available_in_blob = locator.raw_length as i64 - start_in_blob;
             let bytes_to_read_from_blob = std::cmp::min(size as i64, bytes_available_in_blob);
 
             if bytes_to_read_from_blob <= 0 {
                 // Should never happen, but...
-                current_offset += raw_len as i64;
+                current_offset += locator.raw_length as i64;
                 continue;
             }
 

--- a/src/mapache/mod.rs
+++ b/src/mapache/mod.rs
@@ -2,8 +2,6 @@ pub mod defaults;
 pub mod global;
 pub mod vars;
 
-use std::sync::LazyLock;
-
 use anyhow::{Context, Result, bail};
 use num_enum::FromPrimitive;
 use rand::{TryRngCore, rngs::OsRng};
@@ -17,8 +15,6 @@ pub type Hash256 = [u8; ID_LENGTH];
 /// This is an ID that identifies object by its content.
 #[derive(Hash, Default, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 pub struct ID(pub(crate) Hash256);
-
-pub(crate) static DEFAULT_ID: LazyLock<ID> = LazyLock::new(ID::default);
 
 impl ID {
     /// Creates a new, random ID.

--- a/src/repository/gc.rs
+++ b/src/repository/gc.rs
@@ -16,7 +16,7 @@ use crate::{
     backend::{StorageBackend, read_backend_dir},
     fs::tree::SerializedNodeStreamer,
     mapache::{
-        self, ContentIdType, DEFAULT_ID, ID, SaveID,
+        self, ContentIdType, ID, SaveID,
         defaults::{DEFAULT_MIN_PACK_SIZE_FACTOR, DEFAULT_PACK_SIZE},
         global::GlobalOpts,
     },
@@ -229,19 +229,12 @@ impl Plan {
             if self.referenced_blobs.contains(referenced_blob_id)
                 && self.obsolete_packs.contains(&locator.pack_id)
             {
-                // We need the BlobType. We use the canonical MasterIndex::get to get the BlobType
-                // for the referenced ID, or assume Data if the canonical index entry is missing (should not happen).
-                let (_, blob_type, _, _, _) = self.repo.index().read().get(referenced_blob_id).unwrap_or_else(|| {
-                    ui::cli::warning!("Referenced blob {} not found by canonical get. Assuming Data type for repack.", referenced_blob_id);
-                    (&DEFAULT_ID, mapache::BlobType::Data, 0, 0, 0)
-                });
-
                 // HashMap insertion here automatically deduplicates the *repack instruction* by Blob ID.
                 repack_blob_info.insert(
                     *referenced_blob_id,
                     (
                         locator.pack_id,
-                        blob_type,
+                        locator.blob_type,
                         locator.offset,
                         locator.raw_length,
                         locator.length,
@@ -407,8 +400,8 @@ fn get_referenced_blobs_and_packs(repo: Arc<Repository>) -> Result<(HashSet<ID>,
         }
 
         match index.read().get(&tree_id) {
-            Some((pack_id, _, _, _, _)) => {
-                referenced_packs.insert(*pack_id);
+            Some(locator) => {
+                referenced_packs.insert(locator.pack_id);
             }
             None => {
                 ui::cli::warning!(
@@ -437,8 +430,8 @@ fn get_referenced_blobs_and_packs(repo: Arc<Repository>) -> Result<(HashSet<ID>,
                         }
 
                         match index.read().get(tree) {
-                            Some((pack_id, _, _, _, _)) => {
-                                referenced_packs.insert(*pack_id);
+                            Some(locator) => {
+                                referenced_packs.insert(locator.pack_id);
                             }
                             None => {
                                 missing_tree_blobs += 1;
@@ -454,8 +447,8 @@ fn get_referenced_blobs_and_packs(repo: Arc<Repository>) -> Result<(HashSet<ID>,
                             }
 
                             match index.read().get(blob_id) {
-                                Some((pack_id, _, _, _, _)) => {
-                                    referenced_packs.insert(*pack_id);
+                                Some(locator) => {
+                                    referenced_packs.insert(locator.pack_id);
                                 }
                                 None => {
                                     missing_data_blobs += 1;

--- a/src/repository/index.rs
+++ b/src/repository/index.rs
@@ -37,6 +37,7 @@ pub struct BlobLocator {
     pub offset: u32,
     pub length: u32,
     pub raw_length: u32,
+    pub blob_type: BlobType,
 }
 
 /// Manages the mapping of blob IDs to their locations within pack files.
@@ -156,7 +157,7 @@ impl Index {
 
     /// Retrieves the pack ID, offset, and length for a given blob ID, if it exists.
     /// Returns `None` if the blob ID is not found.
-    pub fn get(&self, id: &ID) -> Option<(&ID, BlobType, u32, u32, u32)> {
+    pub fn get(&self, id: &ID) -> Option<BlobLocator> {
         self.data_ids
             .get(id)
             .map(|location| {
@@ -164,13 +165,14 @@ impl Index {
                     .pack_ids
                     .get_value(location.pack_array_index as usize)
                     .expect("pack_index should always be valid for an existing blob");
-                (
-                    pack_id,
-                    BlobType::Data,
-                    location.offset,
-                    location.length,
-                    location.raw_length,
-                )
+
+                BlobLocator {
+                    pack_id: *pack_id,
+                    blob_type: BlobType::Data,
+                    offset: location.offset,
+                    length: location.length,
+                    raw_length: location.raw_length,
+                }
             })
             .or_else(|| {
                 self.tree_ids.get(id).map(|location| {
@@ -178,13 +180,14 @@ impl Index {
                         .pack_ids
                         .get_value(location.pack_array_index as usize)
                         .expect("pack_index should always be valid for an existing blob");
-                    (
-                        pack_id,
-                        BlobType::Tree,
-                        location.offset,
-                        location.length,
-                        location.raw_length,
-                    )
+
+                    BlobLocator {
+                        pack_id: *pack_id,
+                        blob_type: BlobType::Tree,
+                        offset: location.offset,
+                        length: location.length,
+                        raw_length: location.raw_length,
+                    }
                 })
             })
     }
@@ -298,20 +301,34 @@ impl Index {
 
     pub fn iter_ids(&self) -> impl Iterator<Item = (&ID, BlobLocator)> {
         let pack_ids = &self.pack_ids;
-        self.data_ids
-            .iter()
-            .chain(self.tree_ids.iter())
-            .map(move |(id, loc)| {
-                (
-                    id,
-                    BlobLocator {
-                        pack_id: *pack_ids.get_value(loc.pack_array_index as usize).unwrap(),
-                        offset: loc.offset,
-                        length: loc.length,
-                        raw_length: loc.raw_length,
-                    },
-                )
-            })
+
+        let data_ids = self.data_ids.iter().map(move |(id, loc)| {
+            (
+                id,
+                BlobLocator {
+                    pack_id: *pack_ids.get_value(loc.pack_array_index as usize).unwrap(),
+                    offset: loc.offset,
+                    length: loc.length,
+                    raw_length: loc.raw_length,
+                    blob_type: BlobType::Data,
+                },
+            )
+        });
+
+        let tree_ids = self.tree_ids.iter().map(move |(id, loc)| {
+            (
+                id,
+                BlobLocator {
+                    pack_id: *pack_ids.get_value(loc.pack_array_index as usize).unwrap(),
+                    offset: loc.offset,
+                    length: loc.length,
+                    raw_length: loc.raw_length,
+                    blob_type: BlobType::Tree,
+                },
+            )
+        });
+
+        data_ids.chain(tree_ids)
     }
 
     fn remove_pack(&mut self, target_pack_id: &ID) {
@@ -384,7 +401,7 @@ impl MasterIndex {
 
     /// Retrieves an entry for a given blob ID by searching through finalized indices.
     /// Pending blobs (those not yet packed) cannot be retrieved via this method.
-    pub fn get(&self, id: &ID) -> Option<(&ID, BlobType, u32, u32, u32)> {
+    pub fn get(&self, id: &ID) -> Option<BlobLocator> {
         self.indices
             .iter()
             .rev()
@@ -656,20 +673,20 @@ mod tests {
         );
 
         // Test get for Data blob
-        let (p_id, b_type, offset, length, raw_len) = index.get(&data_blob.id).unwrap();
-        assert_eq!(*p_id, pack_id_a);
-        assert_eq!(b_type, BlobType::Data);
-        assert_eq!(offset, 100);
-        assert_eq!(length, 50);
-        assert_eq!(raw_len, 100);
+        let blob_locator = index.get(&data_blob.id).unwrap();
+        assert_eq!(blob_locator.pack_id, pack_id_a);
+        assert_eq!(blob_locator.blob_type, BlobType::Data);
+        assert_eq!(blob_locator.offset, 100);
+        assert_eq!(blob_locator.length, 50);
+        assert_eq!(blob_locator.raw_length, 100);
 
         // Test get for Tree blob
-        let (p_id, b_type, offset, length, raw_len) = index.get(&tree_blob.id).unwrap();
-        assert_eq!(*p_id, pack_id_b);
-        assert_eq!(b_type, BlobType::Tree);
-        assert_eq!(offset, 200);
-        assert_eq!(length, 30);
-        assert_eq!(raw_len, 60);
+        let blob_locator = index.get(&tree_blob.id).unwrap();
+        assert_eq!(blob_locator.pack_id, pack_id_b);
+        assert_eq!(blob_locator.blob_type, BlobType::Tree);
+        assert_eq!(blob_locator.offset, 200);
+        assert_eq!(blob_locator.length, 30);
+        assert_eq!(blob_locator.raw_length, 60);
 
         // Test iterator
         let ids: HashSet<&ID> = index.iter_ids().map(|(id, _)| id).collect();

--- a/src/repository/repo.rs
+++ b/src/repository/repo.rs
@@ -349,13 +349,16 @@ impl Repository {
     }
 
     /// Loads a blob from the repository.
-    pub fn load_blob(&self, id: &ID, blob_type: BlobType) -> Result<Vec<u8>> {
+    pub fn load_blob(&self, id: &ID) -> Result<Vec<u8>> {
         let index = self.index.read();
         let blob_entry = index.get(id);
         match blob_entry {
-            Some((pack_id, _blob_type, offset, length, _raw_length)) => {
-                self.load_from_pack(pack_id, blob_type, offset, length)
-            }
+            Some(locator) => self.load_from_pack(
+                &locator.pack_id,
+                locator.blob_type,
+                locator.offset,
+                locator.length,
+            ),
             None => bail!("Could not find blob {id:?} in index"),
         }
     }

--- a/src/repository/verify.rs
+++ b/src/repository/verify.rs
@@ -16,16 +16,20 @@ pub fn verify_blob(repo: &Repository, id: &ID) -> Result<(u64, u64)> {
     let index_guard = index.read();
     let blob_entry = index_guard.get(id);
     match blob_entry {
-        Some((pack_id, blob_type, offset, length, raw_length)) => {
+        Some(locator) => {
             // The ID of a blob is the hash of its plaintext content.
-            let blob_data =
-                repo.read_from_pack_and_decode(blob_type, pack_id, offset as u64, length as u64)?;
+            let blob_data = repo.read_from_pack_and_decode(
+                locator.blob_type,
+                &locator.pack_id,
+                locator.offset as u64,
+                locator.length as u64,
+            )?;
             let checksum = utils::calculate_hash(&blob_data);
             if checksum != id.0[..] {
                 bail!("Invalid blob checksum");
             }
 
-            Ok((raw_length as u64, length as u64))
+            Ok((locator.raw_length as u64, locator.length as u64))
         }
         None => bail!("Could not find blob {id:?} in index"),
     }

--- a/src/restorer/node_restorer.rs
+++ b/src/restorer/node_restorer.rs
@@ -13,7 +13,6 @@ use {
 
 use crate::{
     fs::node::{Node, NodeType},
-    mapache::BlobType,
     repository::repo::Repository,
     ui::restore_progress::RestoreProgressReporter,
 };
@@ -58,7 +57,7 @@ pub(crate) fn restore_node_to_path(
             };
 
             for (index, blob_id) in blocks.iter().enumerate() {
-                let chunk_data = repo.load_blob(blob_id, BlobType::Data).with_context(|| {
+                let chunk_data = repo.load_blob(blob_id).with_context(|| {
                     format!(
                         "Could not load block #{} ({}) for restoring file {}",
                         index + 1,


### PR DESCRIPTION
Include blob type in the BlobLocator.
Use BlobLocator struct instead of tuple.