### PR TITLE
SerializedNodeDataReader

### DIFF
--- a/core/src/archiver/processor.rs
+++ b/core/src/archiver/processor.rs
@@ -1,7 +1,6 @@
 use std::{
-    fs::File,
     io::{BufReader, Read},
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::Arc,
 };
 
@@ -72,11 +71,15 @@ pub(crate) fn process_item(
             let mut stream_node_info = next_node
                 .with_context(|| "New or changed item but the next node was not provided")?;
 
+            let source_file = std::fs::File::open(&path)?;
+            let mut reader =
+                BufReader::with_capacity(mapache::defaults::MIN_CHUNK_SIZE as usize, source_file);
+
             // Only chunk and store the file content if it's a file
             if stream_node_info.node.is_file() {
                 let blobs_ids = chunk_and_store_file(
                     repo,
-                    &path,
+                    &mut reader,
                     &stream_node_info.node,
                     progress_reporter.clone(),
                 )?;
@@ -136,23 +139,18 @@ fn report_node_diff(
 /// encrypted and stored in the repository. Files smaller than the minimum chunk size are stored
 /// directly as blobs.
 #[cfg(not(feature = "custom-chunker"))]
-pub(crate) fn chunk_and_store_file(
+pub(crate) fn chunk_and_store_file<R: Read>(
     repo: Arc<Repository>,
-    src_path: &Path,
+    reader: &mut R,
     node: &Node,
     progress_reporter: Arc<SnapshotProgressReporter>,
 ) -> Result<Vec<ID>> {
-    let source_file = File::open(src_path)
-        .with_context(|| format!("Could not open file '{}'", src_path.display()))?;
-
     // Do not chunk if the file is smaller than the minimum chunk size
     if node.metadata.size <= mapache::defaults::MIN_CHUNK_SIZE {
-        return store_small_file(repo, source_file, src_path, node, progress_reporter);
+        return store_small_file(repo, reader, node, progress_reporter);
     }
 
-    let reader = BufReader::with_capacity(mapache::defaults::MIN_CHUNK_SIZE as usize, source_file);
-
-    let file_size = reader.get_ref().metadata()?.len();
+    let file_size = node.metadata.size;
     let estimated_num_chunks = (file_size / mapache::defaults::NORMAL_CHUNK_SIZE).max(1) as usize;
     let mut chunk_ids = Vec::with_capacity(estimated_num_chunks);
 
@@ -165,12 +163,12 @@ pub(crate) fn chunk_and_store_file(
     );
 
     for result in chunker {
-        let chunk = result.with_context(|| "Failed to chunk file")?;
+        let chunk = result.context("Failed to chunk file")?;
         progress_reporter.processed_bytes(chunk.data.len() as u64);
 
         let (id, (raw_data_size, encoded_data_size), (raw_meta_size, encoded_meta_size)) = repo
             .encode_and_save_blob(BlobType::Data, chunk.data, SaveID::CalculateID)
-            .with_context(|| format!("Failed to save blob from '{}'", src_path.display()))?;
+            .context("Failed to save blob")?;
 
         chunk_ids.push(id);
         progress_reporter.written_data_bytes(raw_data_size, encoded_data_size);
@@ -186,33 +184,28 @@ pub(crate) fn chunk_and_store_file(
 /// encrypted and stored in the repository. Files smaller than the minimum chunk size are stored
 /// directly as blobs.
 #[cfg(feature = "custom-chunker")]
-pub(crate) fn chunk_and_store_file(
+pub(crate) fn chunk_and_store_file<R: Read>(
     repo: Arc<Repository>,
-    src_path: &Path,
+    reader: &mut R,
     node: &Node,
     progress_reporter: Arc<SnapshotProgressReporter>,
 ) -> Result<Vec<ID>> {
-    let source_file = File::open(src_path)
-        .with_context(|| format!("Could not open file '{}'", src_path.display()))?;
-
     // Do not chunk if the file is smaller than the minimum chunk size
     if node.metadata.size <= mapache::defaults::MIN_CHUNK_SIZE {
-        return store_small_file(repo, source_file, src_path, node, progress_reporter);
+        return store_small_file(repo, reader, node, progress_reporter);
     }
 
-    let reader = BufReader::with_capacity(mapache::defaults::MIN_CHUNK_SIZE as usize, source_file);
-
-    let file_size = reader.get_ref().metadata()?.len();
+    let file_size = node.metadata.size;
     let estimated_num_chunks = (file_size / mapache::defaults::NORMAL_CHUNK_SIZE).max(1) as usize;
     let mut chunk_ids = Vec::with_capacity(estimated_num_chunks);
 
     for result in DEFAULT_CHUNKER.stream(reader) {
-        let chunk = result.with_context(|| "Failed to chunk file")?;
+        let chunk = result.context("Failed to chunk file")?;
         progress_reporter.processed_bytes(chunk.data.len() as u64);
 
         let (id, (raw_data_size, encoded_data_size), (raw_meta_size, encoded_meta_size)) = repo
             .encode_and_save_blob(BlobType::Data, chunk.data, SaveID::CalculateID)
-            .with_context(|| format!("Failed to save blob from '{}'", src_path.display()))?;
+            .context("Failed to save blob")?;
 
         chunk_ids.push(id);
         progress_reporter.written_data_bytes(raw_data_size, encoded_data_size);
@@ -223,16 +216,14 @@ pub(crate) fn chunk_and_store_file(
 }
 
 /// Stores a small file as a single blob and reports progress.
-fn store_small_file(
+fn store_small_file<R: Read>(
     repo: Arc<Repository>,
-    mut file: File,
-    src_path: &Path,
+    reader: &mut R,
     node: &Node,
     progress_reporter: Arc<SnapshotProgressReporter>,
 ) -> Result<Vec<ID>> {
     let mut data = Vec::with_capacity(node.metadata.size as usize);
-    file.read_to_end(&mut data)
-        .with_context(|| format!("Failed to read source file '{}'", src_path.display()))?;
+    reader.read_to_end(&mut data)?;
 
     let (id, (raw_data_size, encoded_data_size), (raw_meta_size, encoded_meta_size)) =
         repo.encode_and_save_blob(BlobType::Data, data, SaveID::CalculateID)?;

--- a/core/src/fs/tree.rs
+++ b/core/src/fs/tree.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::Ordering,
+    io::Read,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -635,6 +636,144 @@ pub fn find_serialized_node(
     }
 
     Ok(None)
+}
+
+/// A streaming reader over a node’s serialized data.
+///
+/// `SerializedNodeDataReader` exposes the contents of a `Node` as a
+/// single, contiguous byte stream, implementing [`std::io::Read`] so it
+/// can be consumed like a regular file.
+///
+/// The node’s data is stored in the repository as a sequence of blobs
+/// (arbitrary-sized chunks). This reader transparently stitches those
+/// blobs together in logical order, allowing callers to read across blob
+/// boundaries without needing to know how the data is chunked.
+///
+/// The reader:
+/// - keeps only **one blob** in memory at a time, making it suitable for
+///   very large files (gigabytes or terabytes);
+/// - uses prefix offsets to quickly determine which blob contains a given
+///   position;
+/// - loads each blob at most once during sequential reading;
+/// - maintains an internal cursor (`pos`) representing the global offset
+///   within the virtual file.
+///
+/// This adapter is intended for sequential reading patterns, but works
+/// correctly with any consumer of the `Read` trait.
+pub struct SerializedNodeDataReader {
+    repo: Arc<Repository>,
+
+    blob_ids: Vec<ID>,
+
+    /// Total length at the start of each blob
+    blob_prefix: Vec<u64>,
+    total_length: u64,
+
+    /// Global position across the whole virtual file.
+    pos: u64,
+
+    /// Cache of the currently loaded blob.
+    current_blob_idx: usize,
+    current_blob: Vec<u8>,
+}
+
+impl SerializedNodeDataReader {
+    pub fn new(repo: Arc<Repository>, node: &Node) -> Result<Self> {
+        let blobs = node
+            .blobs
+            .as_ref()
+            .ok_or_else(|| anyhow!("Node has no blobs"))?;
+
+        // Lookup raw blob lengths from the index.
+        let index = repo.index();
+        let index_guard = index.read();
+
+        let blob_lengths: Vec<u32> = blobs
+            .iter()
+            .map(|id| {
+                index_guard
+                    .get(id)
+                    .expect("Blob must exist in index")
+                    .raw_length
+            })
+            .collect();
+
+        // Compute the prefix sums
+        let mut prefix = Vec::with_capacity(blob_lengths.len() + 1);
+        prefix.push(0);
+        let mut acc = 0u64;
+        for &len in &blob_lengths {
+            acc += len as u64;
+            prefix.push(acc);
+        }
+
+        Ok(Self {
+            repo,
+            blob_ids: blobs.clone(),
+            blob_prefix: prefix.clone(),
+            total_length: acc,
+
+            pos: 0,
+
+            current_blob_idx: usize::MAX, // invalid index to force load on first read
+            current_blob: Vec::new(),
+        })
+    }
+
+    /// Return the index of the blob containing global position `pos`.
+    /// Uses binary search on `blob_prefix`.
+    fn blob_at(&self, pos: u64) -> usize {
+        match self.blob_prefix.binary_search(&pos) {
+            Ok(i) => i,      // exact boundary → at blob i
+            Err(i) => i - 1, // inside blob i-1
+        }
+    }
+
+    /// Ensure the blob at `idx` is loaded into `current_blob`.
+    fn ensure_blob_loaded(&mut self, idx: usize) -> Result<()> {
+        if idx != self.current_blob_idx {
+            let blob = self.repo.load_blob(&self.blob_ids[idx])?;
+            self.current_blob = blob;
+            self.current_blob_idx = idx;
+        }
+        Ok(())
+    }
+}
+
+impl Read for SerializedNodeDataReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if buf.is_empty() || self.pos >= self.total_length {
+            return Ok(0);
+        }
+
+        let mut written = 0;
+
+        while written < buf.len() && self.pos < self.total_length {
+            // Find blob index for current position
+            let idx = self.blob_at(self.pos);
+
+            // Load the blob if needed
+            self.ensure_blob_loaded(idx)
+                .map_err(std::io::Error::other)?;
+
+            // Compute offset inside this blob
+            let blob_start = self.blob_prefix[idx];
+            let inside = (self.pos - blob_start) as usize;
+
+            let available = self.current_blob.len() - inside;
+            let needed = buf.len() - written;
+            let to_copy = available.min(needed);
+
+            // Copy out to caller buffer
+            buf[written..written + to_copy]
+                .copy_from_slice(&self.current_blob[inside..inside + to_copy]);
+
+            written += to_copy;
+            self.pos += to_copy as u64;
+        }
+
+        Ok(written)
+    }
 }
 
 #[cfg(test)]

--- a/core/src/mapache/mod.rs
+++ b/core/src/mapache/mod.rs
@@ -2,17 +2,16 @@ pub mod defaults;
 pub mod global;
 pub mod vars;
 
-use std::{collections::HashSet, io::Write, path::PathBuf, sync::Arc};
+use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Result, bail};
 use num_enum::FromPrimitive;
 use rand::{TryRngCore, rngs::OsRng};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use tempfile::NamedTempFile;
 
 use crate::{
     archiver::{processor::chunk_and_store_file, tree_serializer::TreeSerializer},
-    fs::tree::{NodeDiff, SerializedNodeStream},
+    fs::tree::{NodeDiff, SerializedNodeDataReader, SerializedNodeStream},
     repository::{repo::Repository, snapshot::Snapshot},
     ui::snapshot_progress::SnapshotProgressReporter,
     utils,
@@ -239,30 +238,11 @@ pub(crate) fn rewrite_snapshot_tree(
                     // with this contents already. We can skip.
                     progress_reporter.processed_bytes(stream_node.node.metadata.size);
                 } else {
-                    let mut tmp_file = NamedTempFile::new()?;
-
-                    for (index, blob_id) in blobs.iter().enumerate() {
-                        let chunk_data = repo.load_blob(blob_id).with_context(|| {
-                            format!(
-                                "Could not load block #{} ({}) for file {}",
-                                index + 1,
-                                blob_id,
-                                path.display()
-                            )
-                        })?;
-
-                        tmp_file.write_all(&chunk_data).with_context(|| {
-                            format!(
-                                "Could not restore block #{} ({}) to tmp file",
-                                index + 1,
-                                blob_id,
-                            )
-                        })?;
-                    }
-
+                    let mut blob_data_reader =
+                        SerializedNodeDataReader::new(repo.clone(), &stream_node.node)?;
                     let new_chunks = chunk_and_store_file(
                         repo.clone(),
-                        tmp_file.path(),
+                        &mut blob_data_reader,
                         &stream_node.node,
                         progress_reporter.clone(),
                     )?;


### PR DESCRIPTION
Abstracts a serialized node file as a virtual file that can be read from, reading blobs transparently.