### PR TITLE
Remove mountpoints created with `mount -c`

### DIFF
--- a/core/src/commands/cmd_mount.rs
+++ b/core/src/commands/cmd_mount.rs
@@ -87,7 +87,7 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
 
         if created_mountpoint {
             // Remove the mountpoint if it was created by us
-            let _ = std::fs::remove_dir(&mpoint);
+            let _ = std::fs::remove_dir_all(&mpoint);
         }
     })?;
 


### PR DESCRIPTION
The mountpoint must be removed with remove_dir_all().