### PR TITLE
Add --no-preserve-root option to cmd_restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Latest
 
+### Changes
+
+- Added a `--no-preserve-root` option to `mapache restore`.
+  This option is only used together with `--delete`. By default, `--delete` does
+  not delete any node in the root directory as a protection. `--no-preserve-root`
+  explicitly overrides this protection.
+
 ## v0.1.0
 
 ### Changes

--- a/core/src/commands/cmd_restore.rs
+++ b/core/src/commands/cmd_restore.rs
@@ -79,6 +79,10 @@ pub struct CmdArgs {
     #[clap(long, value_parser, default_value_t = false)]
     pub delete: bool,
 
+    /// When used with --delete, also delete nodes in the same level as the root.
+    #[clap(long, value_parser, default_value_t = false, requires = "delete")]
+    pub no_preserve_root: bool,
+
     /// Quit immediately if a restore error occurs
     #[clap(long, default_value_t = false)]
     pub quit_on_error: bool,
@@ -235,6 +239,7 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             args.include.clone(),
             args.exclude.clone(),
             args.dry_run,
+            args.no_preserve_root,
         )?;
         ui::cli::log!();
     }

--- a/core/src/restorer/sync.rs
+++ b/core/src/restorer/sync.rs
@@ -17,12 +17,19 @@ pub fn delete_nodes(
     include: Option<Vec<PathBuf>>,
     exclude: Option<Vec<PathBuf>>,
     dry_run: bool,
+    no_preserve_root: bool,
 ) -> Result<()> {
-    let tree_stream =
+    let mut tree_stream =
         SerializedTreeStream::new(repo, root_tree_id, PathBuf::new(), include.clone(), exclude)
             .with_context(|| {
                 format!("Failed to initialize snapshot tree stream for root ID {root_tree_id:?}")
             })?;
+
+    // If we preserve nodes at the root level, we skip the first node in the
+    // stream, which corresponds to the root.
+    if !no_preserve_root {
+        tree_stream.next();
+    }
 
     for item_result in tree_stream {
         // Handle potential errors from the stream itself.

--- a/core/tests/integration_tests/test_cmd_amend.rs
+++ b/core/tests/integration_tests/test_cmd_amend.rs
@@ -116,6 +116,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args).context("Failed to run cmd_restore")?;
 

--- a/core/tests/integration_tests/test_cmd_clean.rs
+++ b/core/tests/integration_tests/test_cmd_clean.rs
@@ -144,6 +144,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args).context("Failed to run cmd_restore")?;
 

--- a/core/tests/integration_tests/test_cmd_restore.rs
+++ b/core/tests/integration_tests/test_cmd_restore.rs
@@ -95,6 +95,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args).context("Failed to run cmd_restore")?;
 
@@ -214,6 +215,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args).context("Failed to run cmd_restore")?;
 
@@ -298,6 +300,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .context("Failed to run cmd_restore 1")?;
@@ -321,6 +324,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .context("Failed to run cmd_restore 2")?;
@@ -335,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn test_restore_delete() -> Result<()> {
+    fn test_restore_delete_default() -> Result<()> {
         let tmp_dir = tempdir()?;
         let tmp_path = tmp_dir.path();
         let auth = Auth {
@@ -407,6 +411,7 @@ mod tests {
             no_verify: true,
             quit_on_error: false,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .context("Failed to run cmd_restore (1/2)")?;
@@ -439,6 +444,7 @@ mod tests {
             no_verify: true,
             quit_on_error: false,
             delete: true,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .context("Failed to run cmd_restore (2/2)")?;
@@ -463,7 +469,7 @@ mod tests {
         }
 
         // Assert that extra files were deleted, except at root level
-        assert!(!restore_path.join("extra_root.txt").exists());
+        assert!(restore_path.join("extra_root.txt").exists()); // Not deleted (root level)
         assert!(!restore_path.join("0").join("extra0.txt").exists());
         assert!(
             !restore_path
@@ -477,7 +483,7 @@ mod tests {
     }
 
     #[test]
-    fn test_restore_delete_with_include() -> Result<()> {
+    fn test_restore_delete_default_with_include() -> Result<()> {
         let tmp_dir = tempdir()?;
         let tmp_path = tmp_dir.path();
         let auth = Auth {
@@ -549,6 +555,7 @@ mod tests {
             no_verify: true,
             quit_on_error: false,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .context("Failed to run cmd_restore (1/2)")?;
@@ -581,6 +588,7 @@ mod tests {
             no_verify: true,
             quit_on_error: false,
             delete: true,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args)
             .context("Failed to run cmd_restore (2/2)")?;
@@ -609,6 +617,150 @@ mod tests {
                 .join("10")
                 .join("extra10.txt")
                 .exists() // Not deleted as it is outside the includes
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_restore_delete_no_preserve_root() -> Result<()> {
+        let tmp_dir = tempdir()?;
+        let tmp_path = tmp_dir.path();
+        let auth = Auth {
+            username: "mapachito".to_string(),
+            password: "password".to_string(),
+        };
+        let auth_file_path = tmp_path.join("auth");
+        std::fs::write(
+            &auth_file_path,
+            format!("{}\n{}", auth.username, auth.password),
+        )?;
+
+        let backup_data_path = test_utils::get_test_data_path(BACKUP_DATA_PATH);
+        let backup_data_tmp_path = tmp_path.join("backup");
+        test_utils::extract_tar_xz_archive(&backup_data_path, &backup_data_tmp_path)?;
+
+        let repo = String::from("repo");
+        let repo_path = tmp_path.join(&repo);
+
+        let global = GlobalArgs {
+            repo: repo_path.to_string_lossy().to_string(),
+            auth_file: Some(auth_file_path),
+            key: None,
+            quiet: *TEST_QUIET,
+            verbosity: Some(3),
+            ssh_pubkey: None,
+            ssh_privatekey: None,
+            pack_size_mib: DEFAULT_DEFAULT_PACK_SIZE_MIB,
+            no_cache: true,
+        };
+        set_global_opts_with_args(&global);
+
+        // Init repo
+        init_repo(&auth, repo_path.clone())?;
+
+        // Run snapshot
+        let snapshot_args = cmd_snapshot::CmdArgs {
+            paths: vec![
+                backup_data_tmp_path.join("0"),
+                backup_data_tmp_path.join("1"),
+                backup_data_tmp_path.join("2"),
+                backup_data_tmp_path.join("file.txt"),
+            ],
+            as_root: false,
+            exclude: None,
+            tags_str: String::new(),
+            description: None,
+            no_parent: false,
+            skip_if_unchanged: false,
+            no_scan: true,
+            parent: UseSnapshot::Latest,
+            read_concurrency: 2,
+            write_concurrency: 2,
+            dry_run: false,
+        };
+        commands::cmd_snapshot::run(&global, &snapshot_args)
+            .context("Failed to run cmd_snapshot")?;
+
+        // Run restore to create base files
+        let restore_path = tmp_path.join("restore");
+        let restore_args = cmd_restore::CmdArgs {
+            target: restore_path.clone(),
+            snapshot: UseSnapshot::Latest,
+            dry_run: false,
+            include: None,
+            exclude: None,
+            strip_prefix: false,
+            strategy: Strategy::Overwrite,
+            no_verify: true,
+            quit_on_error: false,
+            delete: false,
+            no_preserve_root: true,
+        };
+        commands::cmd_restore::run(&global, &restore_args)
+            .context("Failed to run cmd_restore (1/2)")?;
+
+        // Create extra files
+        std::fs::create_dir_all(restore_path.join("0"))?;
+        std::fs::create_dir_all(restore_path.join("1").join("10"))?;
+        std::fs::File::create(restore_path.join("extra_root.txt"))?;
+        std::fs::File::create(restore_path.join("0").join("extra0.txt"))?;
+        std::fs::File::create(restore_path.join("1").join("10").join("extra10.txt"))?;
+        assert!(restore_path.join("extra_root.txt").exists());
+        assert!(restore_path.join("0").join("extra0.txt").exists());
+        assert!(
+            restore_path
+                .join("1")
+                .join("10")
+                .join("extra10.txt")
+                .exists()
+        );
+
+        // Restore with --delete
+        let restore_args = cmd_restore::CmdArgs {
+            target: restore_path.clone(),
+            snapshot: UseSnapshot::Latest,
+            dry_run: false,
+            include: None,
+            exclude: None,
+            strip_prefix: false,
+            strategy: Strategy::Overwrite,
+            no_verify: true,
+            quit_on_error: false,
+            delete: true,
+            no_preserve_root: true,
+        };
+        commands::cmd_restore::run(&global, &restore_args)
+            .context("Failed to run cmd_restore (2/2)")?;
+
+        let paths = vec![
+            PathBuf::from("0"),
+            PathBuf::from("0/file0.txt"),
+            PathBuf::from("0/00"),
+            PathBuf::from("0/00/file00.txt"),
+            PathBuf::from("0/01"),
+            PathBuf::from("0/01/file01a.txt"),
+            PathBuf::from("0/01/file01b.txt"),
+            PathBuf::from("1"),
+            PathBuf::from("1/10"),
+            PathBuf::from("2"),
+            PathBuf::from("file.txt"),
+        ];
+
+        for path in &paths {
+            let restored_path = restore_path.join(path);
+            assert!(restored_path.exists());
+        }
+
+        // Assert that extra files were deleted
+        assert!(!restore_path.join("extra_root.txt").exists());
+        assert!(!restore_path.join("0").join("extra0.txt").exists());
+        assert!(
+            !restore_path
+                .join("1")
+                .join("10")
+                .join("extra10.txt")
+                .exists()
         );
 
         Ok(())
@@ -680,6 +832,7 @@ mod tests {
             no_verify: true,
             quit_on_error: false,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args_initial)
             .context("Failed to run initial cmd_restore")?;
@@ -711,6 +864,7 @@ mod tests {
             no_verify: true,
             quit_on_error: false,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args_overwrite)
             .context("Failed to run cmd_restore Overwrite")?;
@@ -732,6 +886,7 @@ mod tests {
             no_verify: true,
             quit_on_error: false,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args_skip)
             .context("Failed to run cmd_restore Skip")?;

--- a/core/tests/integration_tests/test_cmd_snapshot.rs
+++ b/core/tests/integration_tests/test_cmd_snapshot.rs
@@ -101,6 +101,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args).context("Failed to run cmd_restore")?;
 
@@ -225,6 +226,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
 
         let restore_result = commands::cmd_restore::run(&global, &restore_args);
@@ -306,6 +308,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args).context("Failed to run cmd_restore")?;
 
@@ -448,6 +451,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args).context("Failed to run cmd_restore")?;
 
@@ -562,6 +566,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args).context("Failed to run cmd_restore")?;
 
@@ -674,6 +679,7 @@ mod tests {
             no_verify: false,
             quit_on_error: true,
             delete: false,
+            no_preserve_root: false,
         };
         commands::cmd_restore::run(&global, &restore_args).context("Failed to run cmd_restore")?;
 


### PR DESCRIPTION
This new option is only used together with `--delete`. By default, `--delete` does not delete any node in the root directory as a protection. `--no-preserve-root` explicitly overrides this protection.