### PR TITLE
mapache clean --no-repack

### DIFF
--- a/core/src/commands/cmd_clean.rs
+++ b/core/src/commands/cmd_clean.rs
@@ -29,12 +29,16 @@ use crate::{
 pub struct CmdArgs {
     /// Garbage tolerance. The percentage [0-100] of garbage to tolerate in a
     /// pack file before repacking.
-    #[clap(short, long, default_value_t = 100.0 * DEFAULT_GC_TOLERANCE)]
+    #[clap(short, long, default_value_t = 100.0 * DEFAULT_GC_TOLERANCE, conflicts_with = "no_repack")]
     pub tolerance: f32,
 
     /// Verify that all referenced IDs are stored in the index without reading the data.
     #[clap(long, default_value_t = false)]
     pub verify: bool,
+
+    /// Don't repack
+    #[clap(long, default_value_t = false)]
+    pub no_repack: bool,
 
     /// Dry run. Displays what this command would do without
     /// making changes to the repository.
@@ -77,7 +81,12 @@ pub fn run_with_repo(
     args: &CmdArgs,
     repo: Arc<Repository>,
 ) -> Result<()> {
-    let tolerance = args.tolerance.clamp(0.0, 100.0) / 100.0;
+    let tolerance = if args.no_repack {
+        // No repack means a tolerance of 100 %.
+        100.0
+    } else {
+        args.tolerance.clamp(0.0, 100.0) / 100.0
+    };
 
     let start = Instant::now();
     ui::cli::log!();

--- a/core/src/commands/cmd_forget.rs
+++ b/core/src/commands/cmd_forget.rs
@@ -237,6 +237,7 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             tolerance: args.tolerance,
             dry_run: args.dry_run,
             verify: args.verify,
+            no_repack: false,
         };
 
         ui::cli::log!();

--- a/core/tests/integration_tests/test_cmd_clean.rs
+++ b/core/tests/integration_tests/test_cmd_clean.rs
@@ -128,6 +128,7 @@ mod tests {
             tolerance: 0.0_f32,
             dry_run: false,
             verify: true,
+            no_repack: false,
         };
         commands::cmd_clean::run(&global, &gc_args).context("Failed to run cmd_gc")?;
 
@@ -288,6 +289,7 @@ mod tests {
             tolerance: 0.0_f32,
             dry_run: true, // DRY-RUN !
             verify: true,
+            no_repack: false,
         };
         commands::cmd_clean::run(&global, &gc_args).context("Failed to run cmd_gc")?;
         let post_clean_nodes = read_backend_dir(backend.as_ref(), &PathBuf::new())?;
@@ -299,6 +301,7 @@ mod tests {
             tolerance: 0.0_f32,
             dry_run: false, // No dry-run
             verify: true,
+            no_repack: false,
         };
         commands::cmd_clean::run(&global, &gc_args).context("Failed to run cmd_gc")?;
         let post_clean_nodes = read_backend_dir(backend.as_ref(), &PathBuf::new())?;


### PR DESCRIPTION
--no-repack will set the tolerance to 100%, effectively disabling repacking.