### PR TITLE
Adjust DEFAULT_READ_CONCURRENCY to 2

### DIFF
--- a/core/src/mapache/defaults.rs
+++ b/core/src/mapache/defaults.rs
@@ -7,7 +7,7 @@ use crate::{repository::repo::RepoConfig, utils::size};
 pub(crate) const APP_NAME: &str = "mapache";
 
 // --- Concurrency ---
-pub(crate) const DEFAULT_READ_CONCURRENCY: usize = 4;
+pub(crate) const DEFAULT_READ_CONCURRENCY: usize = 2;
 pub(crate) const DEFAULT_WRITE_CONCURRENCY: usize = 4;
 
 // --- Index ---


### PR DESCRIPTION
This seems to work better for processing many small files in fast drives. Performance depends a lot on the storage medium so there is no magic value that works for all contexts, but restic also uses this value as a default.