### PR TITLE
Optimize verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Latest
 
+### Changes
+- Optimized the `verify` command massively. Removed unnecessary duplicate checks
+  and parallelize verification of packs. The performance gain can be up to 10x.
+
 ### Fixes
 
 - Fixed size reported by `rebuild-index`.

--- a/core/src/commands/cmd_verify.rs
+++ b/core/src/commands/cmd_verify.rs
@@ -1,27 +1,21 @@
-use std::{collections::BTreeSet, path::PathBuf, sync::Arc, time::Instant};
+use std::time::Instant;
 
 use anyhow::{Result, bail};
 use clap::Args;
 use colored::Colorize;
-use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
-use parking_lot::Mutex;
+use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
+use crate::mapache::defaults::SHORT_SNAPSHOT_ID_LEN;
 use crate::{
-    backend::{Handle, StorageBackend, new_backend_with_prompt},
+    backend::new_backend_with_prompt,
     commands::{GlobalArgs, cleanup::CleanupHandler},
-    fs::{node::NodeType, tree::SerializedNodeStream},
-    mapache::{
-        ContentIdType, ID,
-        defaults::{MAX_PATH_DISPLAY_LEN, SHORT_SNAPSHOT_ID_LEN},
-        global::GlobalOpts,
-    },
     repository::{
         repo::{RepoConfig, Repository},
         snapshot::SnapshotStream,
-        verify::{verify_blob, verify_pack, verify_snapshot_refs},
+        verify::{verify_pack, verify_snapshot_refs},
     },
-    ui::{self, SPINNER_TICK_CHARS, default_bar_draw_target},
+    ui::{self, default_bar_draw_target},
     utils::{self, size},
 };
 
@@ -33,18 +27,9 @@ use crate::{
                   that any active snapshot can be restored."
 )]
 pub struct CmdArgs {
-    /// Simulate a restore, reading and checking actual data from the repository.
-    #[clap(
-        short = 's',
-        long = "simulate-restore",
-        value_parser,
-        default_value_t = false
-    )]
-    pub simulate_restore: bool,
-
     /// Read all packs and discover unreferenced blobs
-    #[clap(short = 'a', long = "all-packs", value_parser, default_value_t = false)]
-    pub all_packs: bool,
+    #[clap(long = "read-packs", value_parser, default_value_t = false)]
+    pub read_packs: bool,
 }
 
 pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
@@ -75,9 +60,7 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
 
     let snapshot_stream = SnapshotStream::new(repo_arc.clone())?;
 
-    let mut visited_blobs = BTreeSet::new();
-
-    if args.all_packs {
+    if args.read_packs {
         let packs = repo_arc.list_packs()?;
 
         let style = ProgressStyle::default_bar()
@@ -107,7 +90,6 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
         bar.set_draw_target(default_bar_draw_target());
         bar.set_style(style);
 
-        let visited_blobs_mutex = Mutex::new(visited_blobs);
         let repo_ref = repo_arc.clone();
         let backend_ref = backend_arc.clone();
         let secure_storage_ref = secure_storage.clone();
@@ -115,17 +97,12 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
         let num_dangling_blobs: usize = packs
             .par_iter()
             .map(|pack_id| {
-                let mut visited_guard = visited_blobs_mutex.lock();
-
                 let verify_res = verify_pack(
                     repo_ref.as_ref(),
                     backend_ref.as_ref(),
                     secure_storage_ref.as_ref(),
                     pack_id,
-                    &mut visited_guard,
                 );
-
-                drop(visited_guard); // Release lock early
 
                 bar.inc(1);
 
@@ -136,14 +113,8 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             })
             .sum();
 
-        visited_blobs = visited_blobs_mutex.into_inner();
-
         bar.finish_and_clear();
-        ui::cli::log!(
-            "Verified {} blobs from {} packs",
-            visited_blobs.len(),
-            packs.len()
-        );
+
         if num_dangling_blobs > 0 {
             ui::cli::log!("Found {} unreferenced blobs", num_dangling_blobs);
         }
@@ -166,18 +137,7 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             num_snapshots
         );
 
-        let res = if args.simulate_restore {
-            verify_snapshot(
-                repo_arc.clone(),
-                backend_arc.clone(),
-                &snapshot_id,
-                &mut visited_blobs,
-            )
-        } else {
-            verify_snapshot_refs(repo_arc.clone(), &snapshot_id)
-        };
-
-        match res {
+        match verify_snapshot_refs(repo_arc.clone(), &snapshot_id) {
             Ok(_) => {
                 ui::cli::log!("{}", "[OK]".bold().green());
                 ok_counter += 1;
@@ -212,117 +172,4 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
 
         Ok(())
     }
-}
-
-/// Verify the checksum and contents of a snapshot with a known ID in the repository.
-/// This function will verify the checksum of the Snapshot object and the contents of all blobs
-/// referenced by it. It is a simulation of a restore.
-pub fn verify_snapshot(
-    repo: Arc<Repository>,
-    backend: Arc<dyn StorageBackend>,
-    snapshot_id: &ID,
-    visited_blobs: &mut BTreeSet<ID>,
-) -> Result<()> {
-    let snapshot_path = repo.get_path(ContentIdType::Snapshot, snapshot_id);
-    let snapshot_data = backend.read(&Handle::new(&snapshot_path), 0, 0)?;
-    let checksum = utils::calculate_hash(snapshot_data);
-    if checksum != snapshot_id.0[..] {
-        bail!("Invalid snapshot checksum");
-    }
-
-    let snapshot = repo.load_snapshot(snapshot_id, None)?;
-    let tree_id = snapshot.tree;
-    let stream =
-        SerializedNodeStream::new(repo.clone(), Some(tree_id), PathBuf::new(), None, None)?;
-
-    let mp = MultiProgress::with_draw_target(default_bar_draw_target());
-    let bar = mp.add(ProgressBar::new(snapshot.size()));
-    let bar_style = ProgressStyle::default_bar()
-        .template("[{percent} %] [{bar:20.cyan/white}] [{custom_elapsed}]  {processed_bytes_formated}  [ETA: {custom_eta}]")
-        .unwrap()
-        .progress_chars("=> ")
-        .with_key(
-            "custom_elapsed",
-            move |state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                let elapsed = state.elapsed();
-                let custom_elapsed = utils::pretty_print_duration(elapsed);
-                let _ = w.write_str(&custom_elapsed);
-            },
-        )
-        .with_key(
-            "processed_bytes_formated",
-            move |state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                let s = format!(
-                    "{} / {}",
-                    utils::format_size_binary(state.pos(), 3),
-                    utils::format_size_binary(state.len().unwrap(), 3)
-                );
-                let _ = w.write_str(&s);
-            },
-        )
-        .with_key(
-            "custom_eta",
-            move |state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                let eta = state.eta();
-                let custom_eta = utils::pretty_print_duration(eta);
-                let _ = w.write_str(&custom_eta);
-            },
-        );
-
-    bar.set_style(bar_style);
-
-    let spinner = mp.add(ProgressBar::new_spinner());
-    spinner.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.cyan} {msg}")
-            .unwrap()
-            .tick_chars(SPINNER_TICK_CHARS),
-    );
-    spinner.enable_steady_tick(GlobalOpts::progress_refresh_interval());
-
-    bar.set_position(0);
-
-    let index = repo.index();
-    let index_guard = index.read();
-
-    for (path, stream_node) in stream.flatten() {
-        spinner.set_message(utils::abbreviate_path(&path, MAX_PATH_DISPLAY_LEN));
-
-        let node = stream_node.node;
-        match node.node_type {
-            NodeType::File => {
-                if let Some(blobs) = node.blobs {
-                    for blob in blobs {
-                        if !visited_blobs.contains(&blob) {
-                            match verify_blob(repo.as_ref(), &blob) {
-                                Ok((raw_length, _encoded_length)) => {
-                                    visited_blobs.insert(blob);
-                                    bar.inc(raw_length);
-                                }
-                                Err(_) => {
-                                    let _ = mp.clear();
-                                    bail!("Snapshot has corrupt blobs");
-                                }
-                            }
-                        } else {
-                            let locator = index_guard
-                                .get(&blob)
-                                .expect("We visited this blob, so it should be indexed");
-                            bar.inc(locator.raw_length as u64);
-                        }
-                    }
-                }
-            }
-            NodeType::Symlink
-            | NodeType::Directory
-            | NodeType::BlockDevice
-            | NodeType::CharDevice
-            | NodeType::Fifo
-            | NodeType::Socket => (),
-        }
-    }
-
-    let _ = mp.clear();
-
-    Ok(())
 }

--- a/core/src/repository/verify.rs
+++ b/core/src/repository/verify.rs
@@ -1,6 +1,7 @@
-use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 use anyhow::{Result, bail};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
     backend::StorageBackend,
@@ -10,80 +11,39 @@ use crate::{
     utils,
 };
 
-/// Verify the checksum and contents of a blob with a known ID in the repository.
-pub fn verify_blob(repo: &Repository, id: &ID) -> Result<(u64, u64)> {
-    let index = repo.index();
-    let index_guard = index.read();
-    let blob_entry = index_guard.get(id);
-    match blob_entry {
-        Some(locator) => {
-            // The ID of a blob is the hash of its plaintext content.
-            let blob_data = repo.read_from_pack_and_decode(
-                locator.blob_type,
-                &locator.pack_id,
-                locator.offset as u64,
-                locator.length as u64,
-            )?;
-            let checksum = utils::calculate_hash(&blob_data);
-            if checksum != id.0[..] {
-                bail!("Invalid blob checksum");
-            }
-
-            Ok((locator.raw_length as u64, locator.length as u64))
-        }
-        None => bail!("Could not find blob {id:?} in index"),
-    }
-}
-
-// No significant changes needed here, it's already concise.
-pub fn verify_data(id: &ID, data: &[u8], expected_len: Option<u32>) -> Result<u64> {
-    let checksum = utils::calculate_hash(data);
-    if checksum != id.0[..] {
-        bail!("Invalid blob checksum");
-    }
-    if let Some(some_len) = expected_len
-        && data.len() != some_len as usize
-    {
-        bail!("Invalid blob length");
-    }
-
-    Ok(data.len() as u64)
-}
-
-/// Verify the checksum and contents of a pack  with a known ID in the repository.
+/// Verify the checksum and contents of a pack with a known ID in the repository.
 pub fn verify_pack(
     repo: &Repository,
     backend: &dyn StorageBackend,
     secure_storage: &SecureStorage,
-    id: &ID,
-    visited_blobs: &mut BTreeSet<ID>,
+    pack_id: &ID,
 ) -> Result<usize> {
-    let pack_data = repo.load_pack(id)?;
-    let checksum = utils::calculate_hash(&pack_data);
-    if checksum != id.0[..] {
-        bail!("Invalid pack checksum");
-    }
-
-    let pack_header = Packer::parse_pack_footer(repo, backend, secure_storage, id)?;
-    let mut num_dangling_blobs = 0;
+    let pack_header = Packer::parse_pack_footer(repo, backend, secure_storage, pack_id)?;
 
     let index = repo.index();
     let index_guard = index.read();
 
-    for blob_descriptor in pack_header {
-        if !visited_blobs.contains(&blob_descriptor.id) {
-            // Only verify blobs referenced by the master index
-            if index_guard.contains(&blob_descriptor.id) {
-                // The blob ID is verified inside verify_blob
-                verify_blob(repo, &blob_descriptor.id)?;
-                visited_blobs.insert(blob_descriptor.id);
-            } else {
-                num_dangling_blobs += 1;
-            }
-        }
-    }
+    pack_header.par_iter().try_for_each(|blob_desc| {
+        let data = repo.load_blob(&blob_desc.id)?;
+        let checksum = utils::calculate_hash(&data);
 
-    Ok(num_dangling_blobs)
+        if checksum != blob_desc.id.0[..] {
+            bail!(
+                "Invalid checksum for blob {:?} in pack {:?}",
+                blob_desc.id,
+                pack_id
+            );
+        }
+
+        Ok(())
+    })?;
+
+    let num_dangling = pack_header
+        .iter()
+        .filter(|blob| !index_guard.contains(&blob.id))
+        .count();
+
+    Ok(num_dangling)
 }
 
 /// Verify that all blobs referenced by a snapshot are indexed.

--- a/core/tests/integration_tests/test_cmd_rebuild_index.rs
+++ b/core/tests/integration_tests/test_cmd_rebuild_index.rs
@@ -83,10 +83,7 @@ mod tests {
         commands::cmd_snapshot::run(&global, &snapshot_args)
             .context("Failed to run cmd_snapshot")?;
 
-        let verify_args = cmd_verify::CmdArgs {
-            simulate_restore: false,
-            all_packs: false,
-        };
+        let verify_args = cmd_verify::CmdArgs { read_packs: false };
         let first_verify_result = commands::cmd_verify::run(&global, &verify_args);
         assert!(first_verify_result.is_ok(), "First verify should pass");
 

--- a/core/tests/integration_tests/test_cmd_verify.rs
+++ b/core/tests/integration_tests/test_cmd_verify.rs
@@ -83,10 +83,7 @@ mod tests {
         commands::cmd_snapshot::run(&global, &snapshot_args)
             .context("Failed to run cmd_snapshot")?;
 
-        let verify_args = cmd_verify::CmdArgs {
-            simulate_restore: false,
-            all_packs: false,
-        };
+        let verify_args = cmd_verify::CmdArgs { read_packs: false };
         let first_verify_result = commands::cmd_verify::run(&global, &verify_args);
         assert!(first_verify_result.is_ok(), "First verify should pass");
 
@@ -168,10 +165,7 @@ mod tests {
         commands::cmd_snapshot::run(&global, &snapshot_args)
             .context("Failed to run cmd_snapshot")?;
 
-        let verify_args = cmd_verify::CmdArgs {
-            simulate_restore: true,
-            all_packs: false,
-        };
+        let verify_args = cmd_verify::CmdArgs { read_packs: false };
         let first_verify_result = commands::cmd_verify::run(&global, &verify_args);
         assert!(first_verify_result.is_ok(), "Verify should pass");
 
@@ -253,10 +247,7 @@ mod tests {
         commands::cmd_snapshot::run(&global, &snapshot_args)
             .context("Failed to run cmd_snapshot")?;
 
-        let verify_args = cmd_verify::CmdArgs {
-            simulate_restore: false,
-            all_packs: true,
-        };
+        let verify_args = cmd_verify::CmdArgs { read_packs: true };
         let first_verify_result = commands::cmd_verify::run(&global, &verify_args);
         assert!(first_verify_result.is_ok(), "Verify should pass");
 


### PR DESCRIPTION
Check all packs without walking the snapshot tree. There's no need to keep a list of visited blobs now and we can parallelize the verification of packs. The performance gain is massive without sacrificing checks. All data is read and dangling blobs are found.