### PR TITLE
snapshot: separate status collection from reporting

### DIFF
--- a/core/src/archiver/mod.rs
+++ b/core/src/archiver/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod processor;
+pub(crate) mod progress;
 pub(crate) mod tree_serializer;
+pub use progress::SnapshotProgress;
 
 use std::{
     collections::BTreeSet,
@@ -45,14 +47,19 @@ struct PipelineStatus {
     /// Stores the first error that triggered the shutdown to report back to the user.
     first_error: Mutex<Option<anyhow::Error>>,
     progress_reporter: Arc<dyn SnapshotProgressReporter>,
+    progress: Arc<SnapshotProgress>,
 }
 
 impl PipelineStatus {
-    fn new(progress_reporter: Arc<dyn SnapshotProgressReporter>) -> Self {
+    fn new(
+        progress: Arc<SnapshotProgress>,
+        progress_reporter: Arc<dyn SnapshotProgressReporter>,
+    ) -> Self {
         Self {
             fatal_error_flag: AtomicBool::new(false),
             first_error: Mutex::new(None),
             progress_reporter,
+            progress,
         }
     }
 
@@ -82,9 +89,10 @@ pub(crate) fn snapshot(
     repo: Arc<Repository>,
     snapshot_options: SnapshotOptions,
     num_readers: usize,
+    progress: Arc<SnapshotProgress>,
     progress_reporter: Arc<dyn SnapshotProgressReporter>,
 ) -> Result<Snapshot> {
-    let status = Arc::new(PipelineStatus::new(progress_reporter.clone()));
+    let status = Arc::new(PipelineStatus::new(progress, progress_reporter.clone()));
 
     // Extract parent snapshot tree id
     let parent_tree_id: Option<ID> = snapshot_options
@@ -128,6 +136,7 @@ pub(crate) fn snapshot(
         snapshot_options.absolute_source_paths.clone(),
         snapshot_options.exclude_paths.clone(),
         status.clone(),
+        progress_reporter.clone(),
     );
     let diff_thread = spawn_diff_thread(status.clone(), previous_tree_stream, fs_stream, diff_tx);
     let processor_thread = spawn_processor_thread(
@@ -204,6 +213,7 @@ fn spawn_scanner_thread(
     absolute_source_paths: Vec<PathBuf>,
     exclude_paths: Vec<PathBuf>,
     status: Arc<PipelineStatus>,
+    progress_reporter: Arc<dyn SnapshotProgressReporter>,
 ) -> JoinHandle<Result<()>> {
     std::thread::spawn(move || {
         if no_scan {
@@ -221,11 +231,9 @@ fn spawn_scanner_thread(
             match item {
                 Ok((_path, stream_node)) => {
                     let node = stream_node.node;
-                    status.progress_reporter.add_expected_items(1);
+                    progress_reporter.add_expected_items(1);
                     if node.is_file() {
-                        status
-                            .progress_reporter
-                            .add_expected_bytes(node.metadata.size);
+                        progress_reporter.add_expected_bytes(node.metadata.size);
                     }
                 }
                 Err(e) => {
@@ -235,7 +243,7 @@ fn spawn_scanner_thread(
                 }
             }
         }
-        status.progress_reporter.scan_finished();
+        progress_reporter.scan_finished();
         Ok(())
     })
 }
@@ -316,6 +324,7 @@ fn spawn_processor_thread(
                         (path.as_path(), prev, next, diff),
                         repo.clone(),
                         &mut ctx,
+                        status.progress.as_ref(),
                         status.progress_reporter.as_ref(),
                     ) {
                         Ok(Some(stream_node)) => {

--- a/core/src/archiver/processor.rs
+++ b/core/src/archiver/processor.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use chunker::Chunker;
 
 use crate::{
+    archiver::SnapshotProgress,
     fs::{
         node::Node,
         tree::{NodeDiff, StreamNode},
@@ -32,6 +33,7 @@ pub(crate) fn process_item(
     ),
     repo: Arc<Repository>,
     encoding_context: &mut EncodingContext,
+    progress: &SnapshotProgress,
     progress_reporter: &dyn SnapshotProgressReporter,
 ) -> Result<Option<StreamNode>> {
     progress_reporter.processing_node(path.to_path_buf(), diff_type);
@@ -41,7 +43,7 @@ pub(crate) fn process_item(
             let prev = prev_node.with_context(|| {
                 format!("Inconsistent state: Deleted diff but no prev_node for {path:?}")
             })?;
-            report_node_diff(&prev.node, diff_type, progress_reporter);
+            report_node_diff(&prev.node, diff_type, progress);
             None
         }
 
@@ -56,9 +58,11 @@ pub(crate) fn process_item(
             next.node.blobs = prev.node.blobs;
 
             if next.node.is_file() {
+                progress.processed_bytes(next.node.metadata.size);
+                // let reporter update UI (but progress owns counters)
                 progress_reporter.processed_bytes(next.node.metadata.size);
             }
-            report_node_diff(&next.node, diff_type, progress_reporter);
+            report_node_diff(&next.node, diff_type, progress);
             Some(next)
         }
 
@@ -80,6 +84,7 @@ pub(crate) fn process_item(
                     encoding_context,
                     &mut reader,
                     &next.node,
+                    progress,
                     progress_reporter,
                 )
                 .with_context(|| format!("Failed to process blobs for: {}", path.display()))?;
@@ -87,54 +92,21 @@ pub(crate) fn process_item(
                 next.node.blobs = Some(blobs_ids);
             }
 
-            report_node_diff(&next.node, diff_type, progress_reporter);
+            report_node_diff(&next.node, diff_type, progress);
             Some(next)
         }
     };
 
+    progress.processed_node();
     progress_reporter.processed_node(path.to_path_buf(), diff_type);
 
     Ok(out)
 }
 
 #[inline]
-fn report_node_diff(
-    node: &Node,
-    diff_type: NodeDiff,
-    progress_reporter: &dyn SnapshotProgressReporter,
-) {
+fn report_node_diff(node: &Node, diff_type: NodeDiff, progress: &SnapshotProgress) {
     let is_dir = node.is_dir();
-
-    match diff_type {
-        NodeDiff::Deleted => {
-            if is_dir {
-                progress_reporter.deleted_dir();
-            } else {
-                progress_reporter.deleted_file();
-            }
-        }
-        NodeDiff::Unchanged => {
-            if is_dir {
-                progress_reporter.unchanged_dir();
-            } else {
-                progress_reporter.unchanged_file();
-            }
-        }
-        NodeDiff::New => {
-            if is_dir {
-                progress_reporter.new_dir();
-            } else {
-                progress_reporter.new_file();
-            }
-        }
-        NodeDiff::Changed => {
-            if is_dir {
-                progress_reporter.changed_dir();
-            } else {
-                progress_reporter.changed_file();
-            }
-        }
-    }
+    progress.increment_diff(is_dir, &diff_type);
 }
 
 /// Split file into chunks and store blobs.
@@ -143,10 +115,18 @@ pub(crate) fn chunk_and_store_file<R: Read>(
     encoding_context: &mut EncodingContext,
     reader: &mut R,
     node: &Node,
+    progress: &SnapshotProgress,
     progress_reporter: &dyn SnapshotProgressReporter,
 ) -> Result<Vec<ID>> {
     if node.metadata.size <= mapache::defaults::MIN_CHUNK_SIZE {
-        return store_small_file(repo, encoding_context, reader, node, progress_reporter);
+        return store_small_file(
+            repo,
+            encoding_context,
+            reader,
+            node,
+            progress,
+            progress_reporter,
+        );
     }
 
     let file_size = node.metadata.size;
@@ -155,6 +135,8 @@ pub(crate) fn chunk_and_store_file<R: Read>(
 
     for result in DEFAULT_CHUNKER.stream(reader) {
         let chunk = result.context("Failed to chunk file")?;
+        progress.processed_bytes(chunk.data.len() as u64);
+        // notify UI
         progress_reporter.processed_bytes(chunk.data.len() as u64);
 
         let id = repo
@@ -177,6 +159,7 @@ fn store_small_file<R: Read>(
     encoding_context: &mut EncodingContext,
     reader: &mut R,
     node: &Node,
+    progress: &SnapshotProgress,
     progress_reporter: &dyn SnapshotProgressReporter,
 ) -> Result<Vec<ID>> {
     let size = node.metadata.size as usize;
@@ -187,6 +170,7 @@ fn store_small_file<R: Read>(
     let id =
         repo.encode_and_save_blob(encoding_context, BlobType::Data, data, SaveID::CalculateID)?;
 
+    progress.processed_bytes(node.metadata.size);
     progress_reporter.processed_bytes(node.metadata.size);
 
     Ok(vec![id])

--- a/core/src/archiver/progress.rs
+++ b/core/src/archiver/progress.rs
@@ -1,0 +1,39 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::{
+    fs::tree::NodeDiff, repository::snapshot::DiffCountsAtomic,
+    ui::snapshot::SnapshotProcessSummary,
+};
+/// Centralized snapshot progress counters owned by the archiver.
+#[derive(Debug, Default)]
+pub struct SnapshotProgress {
+    pub processed_items: AtomicU64,
+    pub processed_bytes: AtomicU64,
+    pub diff_counts: DiffCountsAtomic,
+}
+
+impl SnapshotProgress {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn processed_node(&self) {
+        self.processed_items.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn processed_bytes(&self, bytes: u64) {
+        self.processed_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    pub fn increment_diff(&self, is_dir: bool, diff: &NodeDiff) {
+        self.diff_counts.increment(is_dir, diff);
+    }
+
+    pub fn summary(&self) -> SnapshotProcessSummary {
+        SnapshotProcessSummary {
+            processed_items_count: self.processed_items.load(Ordering::Relaxed),
+            processed_bytes: self.processed_bytes.load(Ordering::Relaxed),
+            diff_counts: self.diff_counts.snapshot(),
+        }
+    }
+}

--- a/core/src/commands/cmd_amend.rs
+++ b/core/src/commands/cmd_amend.rs
@@ -151,6 +151,7 @@ fn amend(
 
     if parsed_excludes.is_some() {
         repo.init_pack_saver(1)?;
+        let progress = Arc::new(crate::archiver::SnapshotProgress::new());
         let progress_reporter: Arc<dyn SnapshotProgressReporter> =
             Arc::new(CliSnapshotProgressReporter::new(None, None, 1));
         rewrite_snapshot_tree(
@@ -159,6 +160,7 @@ fn amend(
             parsed_excludes.as_ref(),
             false,
             None,
+            progress.clone(),
             progress_reporter.clone(),
         )?;
 

--- a/core/src/commands/cmd_rechunk.rs
+++ b/core/src/commands/cmd_rechunk.rs
@@ -66,6 +66,8 @@ pub fn run(global_args: &GlobalArgs, _args: &CmdArgs) -> Result<()> {
             num_snapshots
         );
 
+        let progress = Arc::new(crate::archiver::SnapshotProgress::new());
+
         let progress_reporter: Arc<dyn SnapshotProgressReporter> =
             Arc::new(CliSnapshotProgressReporter::new(
                 Some(snapshot.summary.processed_items_count),
@@ -79,6 +81,7 @@ pub fn run(global_args: &GlobalArgs, _args: &CmdArgs) -> Result<()> {
             None,
             true,
             Some(&mut rechunked_blob_list_map),
+            progress.clone(),
             progress_reporter.clone(),
         )?;
 

--- a/core/src/commands/cmd_snapshot.rs
+++ b/core/src/commands/cmd_snapshot.rs
@@ -183,6 +183,7 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     };
 
     // Run Archiver
+    let progress = Arc::new(archiver::SnapshotProgress::new());
     let progress_reporter: Arc<dyn SnapshotProgressReporter> = if global_args.json {
         Arc::new(JsonSnapshotProgressReporter::new(None, None))
     } else {
@@ -218,13 +219,14 @@ pub fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             no_scan: args.no_scan,
         },
         args.num_readers,
+        progress.clone(),
         progress_reporter.clone(),
     )?;
 
     // Flush repo and finalize pack saver
     let repo_stats: crate::repository::repo::RepoStatsSnapshot =
         repo.flush_and_finalize_pack_saver()?;
-    let snapshot_report_summary = progress_reporter.summary();
+    let snapshot_report_summary = progress.summary();
     let snapshot_report_summary_clone = snapshot_report_summary.clone();
 
     // Fill snapshot summary

--- a/core/src/mapache/mod.rs
+++ b/core/src/mapache/mod.rs
@@ -14,7 +14,9 @@ use rand::{TryRngCore, rngs::OsRng};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    archiver::{processor::chunk_and_store_file, tree_serializer::TreeSerializer},
+    archiver::{
+        SnapshotProgress, processor::chunk_and_store_file, tree_serializer::TreeSerializer,
+    },
     fs::{
         filter::{GlobRule, PathFilter},
         node::Node,
@@ -214,6 +216,7 @@ pub(crate) fn rewrite_snapshot_tree(
     excludes: Option<&Vec<PathBuf>>,
     rechunk: bool,
     mut rechunked_blobs_list_map: Option<&mut HashMap<Vec<ID>, Vec<ID>>>,
+    progress: Arc<SnapshotProgress>,
     progress_reporter: Arc<dyn SnapshotProgressReporter>,
 ) -> Result<()> {
     // Cannonicalize the exclude paths and filter the source paths using the excludes
@@ -254,7 +257,8 @@ pub(crate) fn rewrite_snapshot_tree(
 
         if stream_node.node.is_file() {
             if !rechunk {
-                // If not rechunking, just report processed bytes
+                // If not rechunking, update central progress and notify UI
+                progress.processed_bytes(stream_node.node.metadata.size);
                 progress_reporter.processed_bytes(stream_node.node.metadata.size);
             } else {
                 let blobs = stream_node
@@ -270,6 +274,7 @@ pub(crate) fn rewrite_snapshot_tree(
                         &mut encoding_context,
                         &mut blob_data_reader,
                         &stream_node.node,
+                        progress.as_ref(),
                         progress_reporter.as_ref(),
                     )
                 };
@@ -278,6 +283,7 @@ pub(crate) fn rewrite_snapshot_tree(
                     match map.entry(blobs.clone()) {
                         std::collections::hash_map::Entry::Occupied(entry) => {
                             // The file was already rechunked, so we can skip.
+                            progress.processed_bytes(stream_node.node.metadata.size);
                             progress_reporter.processed_bytes(stream_node.node.metadata.size);
                             entry.get().clone()
                         }

--- a/core/src/repository/snapshot.rs
+++ b/core/src/repository/snapshot.rs
@@ -226,7 +226,6 @@ pub struct SnapshotSummary {
     pub total_encoded_bytes: u64, // Total bytes after encoding
     pub data_blobs: u64,
     pub meta_blobs: u64,
-    pub total_blobs: u64,
 
     #[serde(flatten)]
     pub diff_counts: DiffCounts,

--- a/core/src/ui/snapshot/cli.rs
+++ b/core/src/ui/snapshot/cli.rs
@@ -11,17 +11,16 @@ use std::{
 use colored::Colorize;
 use crossbeam_channel::{Receiver, Sender};
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 
 use crate::{
     fs::{abbreviate_path, tree::NodeDiff},
     mapache::global::GlobalOpts,
-    repository::snapshot::DiffCountsAtomic,
     ui::{SPINNER_TICK_CHARS, default_bar_draw_target},
     utils,
 };
 
-use super::{SnapshotProcessSummary, SnapshotProgressReporter};
+use super::SnapshotProgressReporter;
 
 enum UiEvent {
     Start(PathBuf),
@@ -67,26 +66,19 @@ fn ui_loop(rx: Receiver<UiEvent>, update_interval: Duration, spinners: Vec<Progr
 }
 
 pub struct CliSnapshotProgressReporter {
-    // Hot-path counters
-    processed_items_count: Arc<AtomicU64>,
-    processed_bytes: Arc<AtomicU64>,
-
-    expected_items: Arc<RwLock<Option<AtomicU64>>>,
-    expected_bytes: Arc<RwLock<Option<AtomicU64>>>,
-
-    diff_counts: Arc<DiffCountsAtomic>,
-    error_counter: Arc<AtomicU64>,
-
-    determined_style: ProgressStyle,
-
     mp: MultiProgress,
     progress_bar: ProgressBar,
     companion_bar: ProgressBar,
     file_spinners: Vec<ProgressBar>,
 
+    expected_items: AtomicU64,
+    expected_bytes: AtomicU64,
+
+    error_counter: Arc<AtomicU64>,
+    determined_style: ProgressStyle,
+
     verbosity: u32,
 
-    // UI thread
     ui_tx: Sender<UiEvent>,
     ui_stop: AtomicBool,
     _ui_thread: Mutex<Option<JoinHandle<()>>>,
@@ -102,152 +94,116 @@ impl Drop for CliSnapshotProgressReporter {
 
 impl CliSnapshotProgressReporter {
     pub fn new(
-        expected_items: Option<u64>,
-        expected_size: Option<u64>,
+        expected_items_val: Option<u64>,
+        expected_size_val: Option<u64>,
         num_display_items: usize,
     ) -> Self {
         let verbosity = GlobalOpts::verbosity();
-
         let refresh_interval = GlobalOpts::progress_refresh_interval();
         let mp = MultiProgress::with_draw_target(default_bar_draw_target());
 
-        let progress_bar = match expected_size {
+        // 1. Shared state for the dynamic UI keys
+        let error_counter = Arc::new(AtomicU64::new(0));
+        let expected_items = AtomicU64::new(expected_items_val.unwrap_or(0));
+        let expected_bytes = AtomicU64::new(expected_size_val.unwrap_or(0));
+
+        // 2. Initialize Bars
+        let progress_bar = match expected_size_val {
             Some(size) => mp.add(ProgressBar::new(size)),
             None => mp.add(ProgressBar::no_length()),
         };
         progress_bar.enable_steady_tick(refresh_interval);
+
         let companion_bar = mp.add(ProgressBar::no_length());
-
-        // ---------------- Hot-path counters ----------------
-        let processed_items_count = Arc::new(AtomicU64::new(0));
-        let processed_bytes = Arc::new(AtomicU64::new(0));
-
-        let expected_items = Arc::new(RwLock::new(expected_items.map(AtomicU64::new)));
-        let expected_bytes = Arc::new(RwLock::new(expected_size.map(AtomicU64::new)));
-
-        let diff_counts = Arc::new(DiffCountsAtomic::default());
-        let error_counter = Arc::new(AtomicU64::new(0));
+        companion_bar.enable_steady_tick(refresh_interval);
+        if let Some(items) = expected_items_val {
+            companion_bar.set_length(items);
+        }
 
         // ---------------- Styles ----------------
-        // IMPORTANT: closures must not take write locks.
-        let processed_bytes_arc_clone = processed_bytes.clone();
-        let expected_bytes_arc_clone = expected_bytes.clone();
-        let undetermined_style = ProgressStyle::default_bar()
-            .template("[{custom_elapsed}] [{processed_bytes_fmt}] [{data_rate}/s]")
-            .expect("progress bar template")
+        let base_style = ProgressStyle::default_bar()
             .progress_chars("=> ")
             .with_key(
                 "custom_elapsed",
-                move |state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                    let s = utils::pretty_print_duration(state.elapsed());
-                    let _ = w.write_str(&s);
-                },
-            )
-            .with_key(
-                "processed_bytes_fmt",
-                move |_state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                    let bytes = processed_bytes_arc_clone.load(Ordering::Relaxed);
-                    let lock = expected_bytes_arc_clone.read();
-                    let s = match lock.as_ref() {
-                        Some(a) => {
-                            let expected = a.load(Ordering::Relaxed);
-                            format!(
-                                "{} / {}",
-                                utils::format_size_binary(bytes, 3),
-                                utils::format_size_binary(expected, 3),
-                            )
-                        }
-                        None => utils::format_size_binary(bytes, 3).to_string(),
-                    };
-                    let _ = w.write_str(&s);
+                |state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                    let _ = w.write_str(&utils::pretty_print_duration(state.elapsed()));
                 },
             )
             .with_key(
                 "data_rate",
-                move |state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                |state: &ProgressState, w: &mut dyn std::fmt::Write| {
                     let rate = state.per_sec().floor() as u64;
                     let _ = w.write_str(&utils::format_size_binary(rate, 1));
                 },
+            )
+            .with_key(
+                "processed_bytes_fmt",
+                |state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                    let bytes = state.pos();
+                    match state.len() {
+                        // Scan phase: "1.234 MB"
+                        None => {
+                            let _ = w.write_str(&utils::format_size_binary(bytes, 3));
+                        }
+                        // Final phase: "1.234 MB / 10.552 GB"
+                        Some(total) => {
+                            let _ = write!(
+                                w,
+                                "{} / {}",
+                                utils::format_size_binary(bytes, 3),
+                                utils::format_size_binary(total, 3)
+                            );
+                        }
+                    }
+                },
+            )
+            .with_key(
+                "custom_eta",
+                |state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                    let _ = w.write_str(&utils::pretty_print_duration(state.eta()));
+                },
             );
 
-        let processed_bytes_arc_clone = processed_bytes.clone();
-        let expected_bytes_arc_clone = expected_bytes.clone();
-        let determined_style = ProgressStyle::default_bar()
+        let determined_style = base_style.clone()
         .template("[{percent} %] [{bar:20.cyan/white}] [{custom_elapsed}] [{processed_bytes_fmt}] [{data_rate}/s] [ETA: {custom_eta}]")
-        .expect("progress bar template")
-        .progress_chars("=> ")
-        .with_key(
-            "custom_elapsed",
-            move |state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                let s = utils::pretty_print_duration(state.elapsed());
-                let _ = w.write_str(&s);
-            },
-        )
-        .with_key(
-            "processed_bytes_fmt",
-            move |_state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                let bytes = processed_bytes_arc_clone.load(Ordering::Relaxed);
-                let lock = expected_bytes_arc_clone.read();
-                let s = match lock.as_ref() {
-                    Some(a) => {
-                        let expected = a.load(Ordering::Relaxed);
-                        format!(
-                            "{} / {}",
-                            utils::format_size_binary(bytes, 3),
-                            utils::format_size_binary(expected, 3),
-                        )
-                    }
-                    None => utils::format_size_binary(bytes, 3).to_string(),
-                };
-                let _ = w.write_str(&s);
-            },
-        )
-        .with_key("custom_eta", move |state: &ProgressState, w: &mut dyn std::fmt::Write| {
-            let s = utils::pretty_print_duration(state.eta());
-            let _ = w.write_str(&s);
-        })
-        .with_key("data_rate", move |state: &ProgressState, w: &mut dyn std::fmt::Write| {
-            let rate = state.per_sec().floor() as u64;
-            let _ = w.write_str(&utils::format_size_binary(rate, 1));
+        .expect("template");
+
+        let undetermined_style = base_style
+            .clone()
+            .template("[{custom_elapsed}] [{processed_bytes_fmt}] [{data_rate}/s]")
+            .expect("template");
+
+        progress_bar.set_style(if expected_size_val.is_some() {
+            determined_style.clone()
+        } else {
+            undetermined_style
         });
 
-        match expected_size {
-            Some(_) => progress_bar.set_style(determined_style.clone()),
-            None => progress_bar.set_style(undetermined_style),
-        };
-
-        let error_counter_clone = error_counter.clone();
-        let expected_items_clone = expected_items.clone();
-        let processed_items_count_clone = processed_items_count.clone();
+        // Companion Bar: Dynamic Items and Errors
+        let error_counter_for_style = Arc::clone(&error_counter);
         companion_bar.set_style(
             ProgressStyle::default_bar()
-                .template("[{processed_items_fmt}] [{errors} errors]")
-                .expect("companion bar template")
-                .progress_chars("=> ")
+                .template("[{items_info}] [{errors} errors]")
+                .expect("template")
                 .with_key(
-                    "processed_items_fmt",
-                    move |_state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                        let item_count = processed_items_count_clone.load(Ordering::Relaxed);
-                        let lock = expected_items_clone.read();
-                        let s = match lock.as_ref() {
-                            Some(a) => {
-                                let expected = a.load(Ordering::Relaxed);
-                                format!("{item_count} / {expected} items")
-                            }
-                            None => format!("{item_count} items"),
-                        };
-                        let _ = w.write_str(&s);
+                    "items_info",
+                    |state: &ProgressState, w: &mut dyn std::fmt::Write| match state.len() {
+                        None => {
+                            let _ = write!(w, "{} items", state.pos());
+                        }
+                        Some(len) => {
+                            let _ = write!(w, "{} / {} items", state.pos(), len);
+                        }
                     },
                 )
                 .with_key(
                     "errors",
                     move |_state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                        let errors = error_counter_clone.load(Ordering::Relaxed);
-                        let _ = w.write_str(&errors.to_string());
+                        let count = error_counter_for_style.load(Ordering::Relaxed);
+                        let _ = write!(w, "{}", count);
                     },
                 ),
         );
-        companion_bar.enable_steady_tick(refresh_interval);
 
         // ---------------- Spinners ----------------
         let mut file_spinners = Vec::with_capacity(num_display_items);
@@ -263,81 +219,55 @@ impl CliSnapshotProgressReporter {
             file_spinners.push(s);
         }
 
-        // ---------------- UI channel + thread ----------------
+        // ---------------- UI Thread ----------------
         let (ui_tx, ui_rx) = crossbeam_channel::unbounded::<UiEvent>();
-        let ui_stop = AtomicBool::new(false);
-
-        // Clone handles (cheap: indicatif internals are Arc-based)
-        let spinners_for_thread = file_spinners.to_vec();
-
+        let spinners_for_thread = file_spinners.clone();
         let ui_thread = Some(thread::spawn(move || {
             ui_loop(ui_rx, refresh_interval, spinners_for_thread);
         }));
 
         Self {
-            processed_items_count,
-            processed_bytes,
-
-            expected_items,
-            expected_bytes,
-
-            diff_counts,
-            error_counter,
-
-            determined_style,
-
             mp,
             progress_bar,
             companion_bar,
             file_spinners,
-
+            error_counter,
+            expected_items,
+            expected_bytes,
+            determined_style,
             verbosity,
-
             ui_tx,
-            ui_stop,
+            ui_stop: AtomicBool::new(false),
             _ui_thread: Mutex::new(ui_thread),
         }
     }
+}
 
-    pub fn add_expected_items(&self, val: u64) {
-        let mut lock = self.expected_items.write();
-        match lock.as_ref() {
-            Some(a) => {
-                a.fetch_add(val, Ordering::Relaxed);
-            }
-            None => {
-                let _ = lock.insert(AtomicU64::new(val));
-            }
-        }
+impl SnapshotProgressReporter for CliSnapshotProgressReporter {
+    fn add_expected_items(&self, val: u64) {
+        self.expected_items.fetch_add(val, Ordering::Relaxed);
     }
 
-    pub fn add_expected_bytes(&self, val: u64) {
-        let mut lock = self.expected_bytes.write();
-        match lock.as_ref() {
-            Some(a) => {
-                a.fetch_add(val, Ordering::Relaxed);
-            }
-            None => {
-                let _ = lock.insert(AtomicU64::new(val));
-            }
-        }
+    fn add_expected_bytes(&self, val: u64) {
+        self.expected_bytes.fetch_add(val, Ordering::Relaxed);
     }
 
-    /// Call when scan completed and you now know total expected bytes.
-    pub fn scan_finished(&self) {
-        let lock = self.expected_bytes.read();
-        let bytes_opt = lock.as_ref().map(|a| a.load(Ordering::Relaxed));
-        drop(lock);
+    fn scan_finished(&self) {
+        let bytes = self.expected_bytes.load(Ordering::Relaxed);
+        let items = self.expected_items.load(Ordering::Relaxed);
 
-        if let Some(bytes) = bytes_opt {
+        if bytes > 0 {
             self.progress_bar.set_length(bytes);
             self.progress_bar.set_style(self.determined_style.clone());
         }
+
+        if items > 0 {
+            self.companion_bar.set_length(items);
+        }
     }
 
-    pub fn finalize(&self) {
+    fn finalize(&self) {
         self.ui_stop.store(true, Ordering::Relaxed);
-
         let _ = self.ui_tx.try_send(UiEvent::Shutdown);
 
         if let Some(h) = self._ui_thread.lock().take() {
@@ -352,7 +282,7 @@ impl CliSnapshotProgressReporter {
         let _ = self.mp.clear();
     }
 
-    pub fn processing_node(&self, path: PathBuf, diff: NodeDiff) {
+    fn processing_node(&self, path: PathBuf, diff: NodeDiff) {
         if self.ui_stop.load(Ordering::Relaxed) {
             return;
         }
@@ -373,9 +303,8 @@ impl CliSnapshotProgressReporter {
         }
     }
 
-    pub fn processed_node(&self, path: PathBuf, diff: NodeDiff) {
+    fn processed_node(&self, path: PathBuf, diff: NodeDiff) {
         if diff != NodeDiff::Deleted {
-            self.processed_items_count.fetch_add(1, Ordering::Relaxed);
             self.companion_bar.inc(1);
         }
 
@@ -385,144 +314,13 @@ impl CliSnapshotProgressReporter {
     }
 
     #[inline]
-    pub fn processed_bytes(&self, bytes: u64) {
-        self.processed_bytes.fetch_add(bytes, Ordering::Relaxed);
+    fn processed_bytes(&self, bytes: u64) {
         self.progress_bar.inc(bytes);
     }
 
-    #[inline]
-    pub fn new_file(&self) {
-        self.diff_counts.new_files.fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub fn changed_file(&self) {
-        self.diff_counts
-            .changed_files
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub fn unchanged_file(&self) {
-        self.diff_counts
-            .unchanged_files
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub fn deleted_file(&self) {
-        self.diff_counts
-            .deleted_files
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub fn new_dir(&self) {
-        self.diff_counts.new_dirs.fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub fn changed_dir(&self) {
-        self.diff_counts
-            .changed_dirs
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub fn deleted_dir(&self) {
-        self.diff_counts
-            .deleted_dirs
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub fn unchanged_dir(&self) {
-        self.diff_counts
-            .unchanged_dirs
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn error(&self, msg: &str) {
+    fn error(&self, msg: &str) {
         self.error_counter.fetch_add(1, Ordering::Relaxed);
         let _ = self.mp.println(format!("{} {msg}", "Error:".bold().red()));
-    }
-
-    pub(crate) fn summary(&self) -> SnapshotProcessSummary {
-        SnapshotProcessSummary {
-            processed_items_count: self.processed_items_count.load(Ordering::Relaxed),
-            processed_bytes: self.processed_bytes.load(Ordering::Relaxed),
-            diff_counts: self.diff_counts.snapshot(),
-        }
-    }
-}
-
-impl SnapshotProgressReporter for CliSnapshotProgressReporter {
-    fn processing_node(&self, path: PathBuf, diff: NodeDiff) {
-        self.processing_node(path, diff);
-    }
-
-    fn processed_node(&self, path: PathBuf, diff: NodeDiff) {
-        self.processed_node(path, diff);
-    }
-
-    fn processed_bytes(&self, bytes: u64) {
-        self.processed_bytes(bytes);
-    }
-
-    fn add_expected_items(&self, val: u64) {
-        self.add_expected_items(val);
-    }
-
-    fn add_expected_bytes(&self, val: u64) {
-        self.add_expected_bytes(val);
-    }
-
-    fn scan_finished(&self) {
-        self.scan_finished();
-    }
-
-    fn new_file(&self) {
-        self.new_file();
-    }
-
-    fn changed_file(&self) {
-        self.changed_file();
-    }
-
-    fn unchanged_file(&self) {
-        self.unchanged_file();
-    }
-
-    fn deleted_file(&self) {
-        self.deleted_file();
-    }
-
-    fn new_dir(&self) {
-        self.new_dir();
-    }
-
-    fn changed_dir(&self) {
-        self.changed_dir();
-    }
-
-    fn deleted_dir(&self) {
-        self.deleted_dir();
-    }
-
-    fn unchanged_dir(&self) {
-        self.unchanged_dir();
-    }
-
-    fn error(&self, msg: &str) {
-        self.error(msg);
-    }
-
-    fn finalize(&self) {
-        self.finalize();
-    }
-
-    fn summary(&self) -> SnapshotProcessSummary {
-        self.summary()
     }
 }
 
@@ -531,8 +329,6 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
-    /// Helper to create a test environment for the ui_loop.
-    /// We use hidden bars to avoid messing with the cargo test output.
     fn setup_ui_test(num_slots: usize) -> (Sender<UiEvent>, Vec<ProgressBar>, JoinHandle<()>) {
         let (tx, rx) = crossbeam_channel::unbounded();
         let refresh_interval = Duration::from_millis(100);
@@ -550,7 +346,6 @@ mod tests {
     fn test_ui_logic_persistence_and_sliding() {
         let (tx, spinners, _handle) = setup_ui_test(2);
 
-        // Start 3 items. A and B should occupy the 2 slots.
         tx.send(UiEvent::Start("A".into())).unwrap();
         tx.send(UiEvent::Start("B".into())).unwrap();
         tx.send(UiEvent::Start("C".into())).unwrap();
@@ -559,7 +354,6 @@ mod tests {
         assert_eq!(spinners[0].message(), "A");
         assert_eq!(spinners[1].message(), "B");
 
-        // Finish A. B should slide up to Slot 0, C should appear in Slot 1.
         tx.send(UiEvent::Done("A".into())).unwrap();
         std::thread::sleep(Duration::from_millis(50));
 
@@ -577,8 +371,6 @@ mod tests {
 
         std::thread::sleep(Duration::from_millis(20));
 
-        // Finish B (the second visible item).
-        // A should remain in Slot 0, C should move into Slot 1.
         tx.send(UiEvent::Done("B".into())).unwrap();
         std::thread::sleep(Duration::from_millis(50));
 
@@ -587,19 +379,15 @@ mod tests {
     }
 
     #[test]
-    fn test_reporter_atomic_counters() {
-        // GlobalOpts and utils are required by the reporter logic
+    fn test_reporter_progress_tracking() {
+        // We test that the ProgressBar's internal state is updated correctly
         let reporter = CliSnapshotProgressReporter::new(Some(10), Some(1000), 2);
 
         reporter.processed_bytes(500);
-        reporter.new_file();
-        reporter.new_dir();
         reporter.error("Test error");
 
-        let summary = reporter.summary();
-        assert_eq!(summary.processed_bytes, 500);
-        assert_eq!(summary.diff_counts.new_files, 1);
-        assert_eq!(summary.diff_counts.new_dirs, 1);
+        // Assert against the ProgressBar state directly
+        assert_eq!(reporter.progress_bar.position(), 500);
         assert_eq!(reporter.error_counter.load(Ordering::Relaxed), 1);
 
         reporter.finalize();
@@ -611,13 +399,17 @@ mod tests {
 
         // Initial state is undetermined
         assert_eq!(reporter.progress_bar.length(), None);
+        assert_eq!(reporter.companion_bar.length(), None);
+        assert_eq!(reporter.progress_bar.length(), None);
+        assert_eq!(reporter.companion_bar.length(), None);
 
         reporter.add_expected_bytes(2048);
         reporter.add_expected_items(5);
         reporter.scan_finished();
 
-        // Length should now be set
+        // Indicatif uses Option<u64> for length
         assert_eq!(reporter.progress_bar.length(), Some(2048));
+        assert_eq!(reporter.companion_bar.length(), Some(5));
 
         reporter.finalize();
     }

--- a/core/src/ui/snapshot/json.rs
+++ b/core/src/ui/snapshot/json.rs
@@ -2,20 +2,19 @@ use parking_lot::RwLock;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, atomic::AtomicU64};
 use std::time::{Duration, Instant};
 
-use crate::ui::json_reporter::JsonReporter;
-use crate::{
-    fs::tree::NodeDiff, mapache::global::GlobalOpts, repository::snapshot::DiffCountsAtomic,
-};
+use crate::{fs::tree::NodeDiff, mapache::global::GlobalOpts, ui::json_reporter::JsonReporter};
 
-use super::{SnapshotProcessSummary, SnapshotProgressReporter};
+use super::SnapshotProgressReporter;
 
 #[derive(Serialize)]
 struct StatusUpdateMsg {
     processed_items: u64,
     processed_bytes: u64,
+    scan_finished: bool,
     total_items: Option<u64>,
     total_bytes: Option<u64>,
     active_files: Vec<String>,
@@ -29,9 +28,9 @@ struct ErrorMsg<'a> {
 
 pub(crate) struct JsonSnapshotProgressReporter {
     json_reporter: JsonReporter,
-    diff_counts: DiffCountsAtomic,
     processed_items: AtomicU64,
     processed_bytes: AtomicU64,
+    scan_finished: AtomicBool,
     expected_items: Arc<RwLock<Option<AtomicU64>>>,
     expected_bytes: Arc<RwLock<Option<AtomicU64>>>,
     active_files: Mutex<HashSet<PathBuf>>,
@@ -47,7 +46,6 @@ impl JsonSnapshotProgressReporter {
 
         Self {
             json_reporter,
-            diff_counts: DiffCountsAtomic::default(),
             processed_items: AtomicU64::new(0),
             processed_bytes: AtomicU64::new(0),
             expected_items: Arc::new(RwLock::new(expected_items.map(AtomicU64::new))),
@@ -56,6 +54,7 @@ impl JsonSnapshotProgressReporter {
             refresh_interval,
             last_update: Mutex::new(Instant::now()),
             start_time: Instant::now(),
+            scan_finished: AtomicBool::new(expected_bytes.is_some() && expected_items.is_some()),
         }
     }
 
@@ -97,6 +96,10 @@ impl JsonSnapshotProgressReporter {
 
         let elapsed_seconds = self.start_time.elapsed().as_secs_f64();
 
+        let scan_finished = self
+            .scan_finished
+            .load(std::sync::atomic::Ordering::Relaxed);
+
         self.json_reporter.emit(
             "status_update",
             &StatusUpdateMsg {
@@ -106,6 +109,7 @@ impl JsonSnapshotProgressReporter {
                 total_bytes,
                 active_files,
                 elapsed_seconds,
+                scan_finished,
             },
         );
     }
@@ -167,55 +171,8 @@ impl SnapshotProgressReporter for JsonSnapshotProgressReporter {
     }
 
     fn scan_finished(&self) {
-        // Could emit a message here if needed
-    }
-
-    fn new_file(&self) {
-        self.diff_counts
-            .new_files
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn changed_file(&self) {
-        self.diff_counts
-            .changed_files
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn unchanged_file(&self) {
-        self.diff_counts
-            .unchanged_files
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn deleted_file(&self) {
-        self.diff_counts
-            .deleted_files
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn new_dir(&self) {
-        self.diff_counts
-            .new_dirs
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn changed_dir(&self) {
-        self.diff_counts
-            .changed_dirs
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn deleted_dir(&self) {
-        self.diff_counts
-            .deleted_dirs
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn unchanged_dir(&self) {
-        self.diff_counts
-            .unchanged_dirs
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.scan_finished
+            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn error(&self, msg: &str) {
@@ -226,17 +183,5 @@ impl SnapshotProgressReporter for JsonSnapshotProgressReporter {
         // Emit final status update
         self.emit_status_update();
         self.json_reporter.flush();
-    }
-
-    fn summary(&self) -> SnapshotProcessSummary {
-        SnapshotProcessSummary {
-            processed_items_count: self
-                .processed_items
-                .load(std::sync::atomic::Ordering::Relaxed),
-            processed_bytes: self
-                .processed_bytes
-                .load(std::sync::atomic::Ordering::Relaxed),
-            diff_counts: self.diff_counts.snapshot(),
-        }
     }
 }

--- a/core/src/ui/snapshot/mod.rs
+++ b/core/src/ui/snapshot/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod json;
 
 /// Summary of snapshot processing statistics
 #[derive(Debug, Clone, serde::Serialize)]
-pub(crate) struct SnapshotProcessSummary {
+pub struct SnapshotProcessSummary {
     pub processed_items_count: u64,
     pub processed_bytes: u64,
     pub diff_counts: DiffCounts,
@@ -35,36 +35,9 @@ pub trait SnapshotProgressReporter: Send + Sync {
     /// Called when scan is finished and we know total expected bytes
     fn scan_finished(&self);
 
-    /// Called when a new file is found
-    fn new_file(&self);
-
-    /// Called when a changed file is found
-    fn changed_file(&self);
-
-    /// Called when an unchanged file is found
-    fn unchanged_file(&self);
-
-    /// Called when a deleted file is found
-    fn deleted_file(&self);
-
-    /// Called when a new directory is found
-    fn new_dir(&self);
-
-    /// Called when a changed directory is found
-    fn changed_dir(&self);
-
-    /// Called when a deleted directory is found
-    fn deleted_dir(&self);
-
-    /// Called when an unchanged directory is found
-    fn unchanged_dir(&self);
-
     /// Called when an error occurs
     fn error(&self, msg: &str);
 
     /// Finalize the reporter (cleanup resources)
     fn finalize(&self);
-
-    /// Get the current summary of processed items
-    fn summary(&self) -> SnapshotProcessSummary;
 }


### PR DESCRIPTION
This makes the reporter independent from the archiver process, which would allow us to plug in a custom reporter (like a TUI or GUI).