### PR TITLE
Refactor tests with builder pattern

### DIFF
--- a/core/src/archiver/processor.rs
+++ b/core/src/archiver/processor.rs
@@ -48,14 +48,16 @@ pub(crate) async fn process_item(
     shutdown_signal: Arc<AtomicBool>,
 ) -> Result<Option<StreamNode>> {
     // Check if next_node has an error. If so, report it and skip the node.
-    if let Some(Err(e)) = next_node_res {
-        progress_reporter.warning(&format!("Skipping {}: {}", path.display(), e));
-        progress.processed_node();
-        return Ok(None);
-    }
+    let next_node = match next_node_res {
+        Some(Err(e)) => {
+            progress_reporter.warning(&format!("Skipping {}: {}", path.display(), e));
+            progress.processed_node();
+            return Ok(None);
+        }
+        Some(Ok(n)) => Some(n),
+        None => None,
+    };
 
-    // From here on, next_node_res is either None or Some(Ok(next_node)).
-    let next_node = next_node_res.map(|r| r.unwrap());
     let prev_node = match prev_node_res {
         Some(Ok(n)) => Some(n),
         Some(Err(_)) => None, // Should not happen in practice for SerializedNodeStream

--- a/core/src/commands/cmd_amend.rs
+++ b/core/src/commands/cmd_amend.rs
@@ -32,7 +32,7 @@ use crate::{
     utils::{self},
 };
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(group = ArgGroup::new("snapshot_group").multiple(false))]
 #[clap(group = ArgGroup::new("tags_group").multiple(false))]
 #[clap(group = ArgGroup::new("description_group").multiple(false))]

--- a/core/src/commands/cmd_bundle.rs
+++ b/core/src/commands/cmd_bundle.rs
@@ -46,7 +46,7 @@ impl crate::ui::restore::RestoreProgressReporter for BundleRestoreReporterAdapte
     fn finalize(&self) {}
 }
 
-#[derive(Debug, Args)]
+#[derive(Args, Debug, Clone)]
 #[clap(
     about = "Create, extract or mount .mapache bundle files",
     group = ArgGroup::new("mode").required(true).args(&["bundle", "extract"]),

--- a/core/src/commands/cmd_cat.rs
+++ b/core/src/commands/cmd_cat.rs
@@ -11,7 +11,7 @@ use crate::{
     ui,
 };
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(about = "Print repository objects")]
 pub struct CmdArgs {
     /// Object to print:

--- a/core/src/commands/cmd_clean.rs
+++ b/core/src/commands/cmd_clean.rs
@@ -29,7 +29,7 @@ impl ToExitCode for CleanError {
     }
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(
     about = "Clean up the repository",
     long_about = "Clean up the repository removing obsolete objects and merging pack and index files."

--- a/core/src/commands/cmd_completion.rs
+++ b/core/src/commands/cmd_completion.rs
@@ -6,7 +6,7 @@ use clap_complete::Shell;
 
 use crate::commands;
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(about = "Generate autocompletion scripts")]
 pub struct CmdArgs {
     /// Shell type (bash, zsh, fish, powershell, etc.)

--- a/core/src/commands/cmd_diff.rs
+++ b/core/src/commands/cmd_diff.rs
@@ -80,14 +80,14 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             while let Some(res) = stream.next().await {
                 let (path, source_res, target_res, diff_type) = res?;
 
-                let source = source_res.map(|r| r.unwrap());
-                let target = target_res.map(|r| r.unwrap());
+                let source = source_res.transpose()?;
+                let target = target_res.transpose()?;
 
                 let node = target
                     .as_ref()
                     .or(source.as_ref())
                     .map(|sn| &sn.node)
-                    .expect("Node missing");
+                    .expect("Node missing in diff result");
                 let path_display = if node.is_dir() {
                     path.to_string_lossy().blue().bold()
                 } else {
@@ -98,8 +98,14 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
                     NodeDiff::New => "+".bold().green(),
                     NodeDiff::Deleted => "-".bold().red(),
                     NodeDiff::Changed => {
-                        let s_node = &source.as_ref().unwrap().node;
-                        let t_node = &target.as_ref().unwrap().node;
+                        let s_node = &source
+                            .as_ref()
+                            .expect("Source node missing in Changed diff")
+                            .node;
+                        let t_node = &target
+                            .as_ref()
+                            .expect("Target node missing in Changed diff")
+                            .node;
                         if s_node.node_type != t_node.node_type {
                             "T".bold().purple()
                         } else if s_node.blobs != t_node.blobs {
@@ -113,9 +119,18 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
 
                 if diff_type != NodeDiff::Unchanged {
                     ui::cli::log!("{}  {}", symbol, path_display);
-                } else if source.as_ref().unwrap().node.blobs != target.as_ref().unwrap().node.blobs
-                {
-                    ui::cli::log!("{}  {}", "?".bold().white().on_red(), path.display());
+                } else {
+                    let s_node = &source
+                        .as_ref()
+                        .expect("Source node missing in Unchanged diff")
+                        .node;
+                    let t_node = &target
+                        .as_ref()
+                        .expect("Target node missing in Unchanged diff")
+                        .node;
+                    if s_node.blobs != t_node.blobs {
+                        ui::cli::log!("{}  {}", "?".bold().white().on_red(), path.display());
+                    }
                 }
 
                 counts.increment(node.is_dir(), &diff_type);

--- a/core/src/commands/cmd_forget.rs
+++ b/core/src/commands/cmd_forget.rs
@@ -33,7 +33,7 @@ impl ToExitCode for ForgetError {
 }
 
 // Define argument groups for mutual exclusivity and multiple selection
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[clap(group = ArgGroup::new("policy").multiple(false))] // Either forget OR retention_rules, but not both
 #[clap(group = ArgGroup::new("retention_rules").multiple(true))] // Allow multiple --keep-* rules
 #[clap(

--- a/core/src/commands/cmd_init.rs
+++ b/core/src/commands/cmd_init.rs
@@ -27,8 +27,7 @@ impl ToExitCode for InitError {
     }
 }
 
-#[derive(Args, Debug)]
-#[clap(about = "Initialize a new repository")]
+#[derive(Args, Debug, Clone)]
 pub struct CmdArgs {}
 
 const INIT_MSG: &str = "init";

--- a/core/src/commands/cmd_key.rs
+++ b/core/src/commands/cmd_key.rs
@@ -53,11 +53,11 @@ pub enum KeySubcommand {
     ChangePassword(PasswordChangeArgs),
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(about = "Create and manage keys")]
 pub struct CmdArgs {
     #[command(subcommand)]
-    subcommand: KeySubcommand,
+    pub subcommand: KeySubcommand,
 }
 
 pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {

--- a/core/src/commands/cmd_log.rs
+++ b/core/src/commands/cmd_log.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::GlobalArgs;
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(about = "Show all snapshots present in the repository")]
 #[clap(group = ArgGroup::new("filter").multiple(false))]
 pub struct CmdArgs {

--- a/core/src/commands/cmd_ls.rs
+++ b/core/src/commands/cmd_ls.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use clap::Args;
 use colored::Colorize;
 
@@ -150,14 +150,21 @@ async fn ls_recursive(path: &Path, node: &Node, repo: &Repository, args: &CmdArg
     if node.is_dir() && args.recursive {
         stack.push((path.to_path_buf(), node.clone()));
     } else if node.is_dir() {
-        let mut tree = Tree::load_from_repo(repo, node.tree.as_ref().unwrap()).await?;
+        let tree_id = node
+            .tree
+            .as_ref()
+            .ok_or_else(|| anyhow!("Directory node missing tree ID: {}", node.name))?;
+        let mut tree = Tree::load_from_repo(repo, tree_id).await?;
         tree.nodes.sort_unstable_by(|a, b| a.name.cmp(&b.name));
         print_tree(&tree, args);
         return Ok(());
     }
 
     while let Some((parent_path, node)) = stack.pop() {
-        let tree_id = node.tree.as_ref().unwrap();
+        let tree_id = node
+            .tree
+            .as_ref()
+            .ok_or_else(|| anyhow!("Directory node missing tree ID: {}", node.name))?;
         let current_path = parent_path.join(&node.name);
 
         let mut tree = Tree::load_from_repo(repo, tree_id).await?;

--- a/core/src/commands/cmd_rebuild_index.rs
+++ b/core/src/commands/cmd_rebuild_index.rs
@@ -18,7 +18,7 @@ use crate::{
     utils::{self},
 };
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(about = "Rebuild the index by scanning all existing packs")]
 pub struct CmdArgs {
     /// Dry run

--- a/core/src/commands/cmd_recall.rs
+++ b/core/src/commands/cmd_recall.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 // Define argument groups for mutual exclusivity and multiple selection
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[clap(about = "Recall forgotten snapshots")]
 pub struct CmdArgs {
     #[arg(value_parser)]

--- a/core/src/commands/cmd_rechunk.rs
+++ b/core/src/commands/cmd_rechunk.rs
@@ -18,7 +18,7 @@ use crate::{
     utils::{self},
 };
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(about = "Rechunk all snapshots")]
 #[clap(long_about = "Rechunk all snapshots using the current chunker and parameters.")]
 pub struct CmdArgs {}

--- a/core/src/commands/cmd_restore.rs
+++ b/core/src/commands/cmd_restore.rs
@@ -59,7 +59,7 @@ impl std::fmt::Display for Strategy {
     }
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(
     about = "Restore a snapshot in a target path",
     long_about = "Restore a snapshot in a target path. Running this command in \

--- a/core/src/commands/cmd_snapshot.rs
+++ b/core/src/commands/cmd_snapshot.rs
@@ -51,7 +51,7 @@ impl ToExitCode for SnapshotError {
     }
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(group = ArgGroup::new("scan_mode").multiple(false))]
 #[clap(about = "Create a new snapshot")]
 pub struct CmdArgs {

--- a/core/src/commands/cmd_stats.rs
+++ b/core/src/commands/cmd_stats.rs
@@ -24,7 +24,7 @@ use crate::{
     utils::{self, collections::IdSet},
 };
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(about = "Show repository statistics")]
 pub struct CmdArgs {
     /// Parse pack footers for physical statistics (expensive)

--- a/core/src/commands/cmd_sync.rs
+++ b/core/src/commands/cmd_sync.rs
@@ -37,7 +37,7 @@ impl ToExitCode for SyncError {
     }
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(about = "Synchronize a repository in a different location")]
 pub struct CmdArgs {
     /// Destination path

--- a/core/src/commands/cmd_unlock.rs
+++ b/core/src/commands/cmd_unlock.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::GlobalArgs;
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(about = "Remove existing locks")]
 pub struct CmdArgs {
     #[clap(short, long, default_value_t = false)]

--- a/core/src/commands/cmd_verify.rs
+++ b/core/src/commands/cmd_verify.rs
@@ -40,7 +40,7 @@ impl ToExitCode for VerifyError {
     }
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 #[clap(
     about = "Verify the integrity of the data stored in the repository",
     long_about = "Verify the integrity of the data stored in the repository. \

--- a/core/src/commands/mod.rs
+++ b/core/src/commands/mod.rs
@@ -32,8 +32,9 @@ pub mod cmd_bundle;
 pub mod cmd_cache;
 pub mod cmd_cat;
 pub mod cmd_clean;
-mod cmd_completion;
-pub mod cmd_diff;
+pub mod cmd_completion;
+mod cmd_diff;
+
 pub mod cmd_find;
 pub mod cmd_forget;
 pub mod cmd_init;

--- a/core/src/fs/mod.rs
+++ b/core/src/fs/mod.rs
@@ -131,7 +131,9 @@ pub fn calculate_lcp(paths: &[PathBuf], strict_prefix: bool) -> PathBuf {
             break 'outer;
         }
 
-        let first_comp = current_components[0].as_ref().unwrap();
+        let first_comp = current_components[0]
+            .as_ref()
+            .expect("All components checked for None above");
         let all_match = current_components[1..]
             .iter()
             .all(|comp_opt| comp_opt.as_ref().is_some_and(|comp| comp.eq(first_comp)));

--- a/core/tests/integration_tests/mod.rs
+++ b/core/tests/integration_tests/mod.rs
@@ -126,6 +126,722 @@ impl TestContext {
     pub async fn init_repo(&self) -> Result<()> {
         init_repo(&self.auth, self.repo_path.clone()).await
     }
+
+    /// Creates a default Snapshot CmdArgs builder.
+    pub fn snapshot_builder(&self, paths: Vec<PathBuf>) -> SnapshotBuilder {
+        SnapshotBuilder::new(paths)
+    }
+
+    /// Run a snapshot command with the given paths and default options.
+    pub async fn snapshot(&self, paths: Vec<PathBuf>) -> Result<()> {
+        self.snapshot_builder(paths).run(&self.global).await
+    }
+
+    /// Creates a default Restore CmdArgs builder.
+    pub fn restore_builder(&self, target: PathBuf) -> RestoreBuilder {
+        RestoreBuilder::new(target)
+    }
+
+    /// Creates a default Init CmdArgs builder.
+    pub fn init_builder(&self) -> InitBuilder {
+        InitBuilder::new()
+    }
+
+    /// Creates a default RebuildIndex CmdArgs builder.
+    pub fn rebuild_index_builder(&self) -> RebuildIndexBuilder {
+        RebuildIndexBuilder::new()
+    }
+
+    /// Creates a default Rechunk CmdArgs builder.
+    pub fn rechunk_builder(&self) -> RechunkBuilder {
+        RechunkBuilder::new()
+    }
+
+    /// Creates a default Amend CmdArgs builder.
+    pub fn amend_builder(&self) -> AmendBuilder {
+        AmendBuilder::new()
+    }
+
+    /// Creates a default Bundle CmdArgs builder.
+    pub fn bundle_builder(&self) -> BundleBuilder {
+        BundleBuilder::new()
+    }
+
+    /// Creates a default Forget CmdArgs builder.
+    pub fn forget_builder(&self) -> ForgetBuilder {
+        ForgetBuilder::new()
+    }
+
+    /// Creates a default Clean CmdArgs builder.
+    pub fn clean_builder(&self) -> CleanBuilder {
+        CleanBuilder::new()
+    }
+
+    /// Creates a default Verify CmdArgs builder.
+    pub fn verify_builder(&self) -> VerifyBuilder {
+        VerifyBuilder::new()
+    }
+
+    /// Creates a default Recall CmdArgs builder.
+    pub fn recall_builder(&self, id: String) -> RecallBuilder {
+        RecallBuilder::new(id)
+    }
+
+    /// Creates a default Unlock CmdArgs builder.
+    pub fn unlock_builder(&self) -> UnlockBuilder {
+        UnlockBuilder::new()
+    }
+
+    /// Creates a default Sync CmdArgs builder.
+    pub fn sync_builder(&self, target: String) -> SyncBuilder {
+        SyncBuilder::new(target)
+    }
+
+    /// Creates a default Log CmdArgs builder.
+    pub fn log_builder(&self) -> LogBuilder {
+        LogBuilder::new()
+    }
+
+    /// Creates a default Stats CmdArgs builder.
+    pub fn stats_builder(&self) -> StatsBuilder {
+        StatsBuilder::new()
+    }
+
+    /// Creates a default Cat CmdArgs builder.
+    pub fn cat_builder(&self, object: mapache::commands::cmd_cat::Object) -> CatBuilder {
+        CatBuilder::new(object)
+    }
+
+    /// Run the mapache binary with the given arguments and return the output.
+    /// Automatically adds --repo and --auth-file as global arguments if supported.
+    pub fn run_mapache(&self, args: &[&str]) -> Result<std::process::Output> {
+        if args.is_empty() {
+            return run_bin(args);
+        }
+
+        // Commands that do NOT support global arguments
+        let no_global = matches!(args[0], "completion" | "bundle");
+
+        let mut final_args = vec![args[0]];
+        if !no_global {
+            final_args.extend_from_slice(&[
+                "--repo",
+                self.repo_path.to_str().unwrap(),
+                "--auth-file",
+                self.auth_file_path.to_str().unwrap(),
+            ]);
+        }
+        final_args.extend_from_slice(&args[1..]);
+        run_bin(&final_args)
+    }
+
+    /// Run the mapache binary and return stdout as a String.
+    pub fn run_mapache_ok(&self, args: &[&str]) -> Result<String> {
+        let output = self.run_mapache(args)?;
+        assert!(
+            output.status.success(),
+            "Command failed: mapache {}\nstdout: {}\nstderr: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        Ok(String::from_utf8(output.stdout)?)
+    }
+
+    /// Get all snapshot IDs in the repository, sorted by creation time.
+    pub fn get_snapshot_ids(&self) -> Result<Vec<String>> {
+        use mapache::repository::repo::SNAPSHOTS_DIR;
+        let snapshots_dir = self.repo_path.join(SNAPSHOTS_DIR);
+        let mut snapshots = std::fs::read_dir(&snapshots_dir)?
+            .map(|res| res.map(|e| e.path()))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Sort by metadata modified time to get chronological order
+        snapshots.sort_by_key(|p| std::fs::metadata(p).and_then(|m| m.modified()).unwrap());
+
+        Ok(snapshots
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap().to_string())
+            .collect())
+    }
+}
+
+#[derive(Clone)]
+pub struct InitBuilder {
+    pub args: mapache::commands::cmd_init::CmdArgs,
+}
+
+impl InitBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::cmd_init;
+        Self {
+            args: cmd_init::CmdArgs {},
+        }
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_init::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct VerifyBuilder {
+    pub args: mapache::commands::cmd_verify::CmdArgs,
+}
+
+impl VerifyBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::cmd_verify;
+        Self {
+            args: cmd_verify::CmdArgs {
+                read_packs: false,
+                parallel: 4,
+                with_cache: false,
+                fail_early: false,
+                sample: None,
+            },
+        }
+    }
+
+    pub fn read_packs(mut self, read_packs: bool) -> Self {
+        self.args.read_packs = read_packs;
+        self
+    }
+
+    pub fn parallel(mut self, parallel: usize) -> Self {
+        self.args.parallel = parallel;
+        self
+    }
+
+    pub fn fail_early(mut self, fail_early: bool) -> Self {
+        self.args.fail_early = fail_early;
+        self
+    }
+
+    pub fn sample(mut self, sample: Option<f64>) -> Self {
+        self.args.sample = sample;
+        self
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_verify::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct RecallBuilder {
+    pub args: mapache::commands::cmd_recall::CmdArgs,
+}
+
+impl RecallBuilder {
+    pub fn new(id: String) -> Self {
+        use mapache::commands::cmd_recall;
+        Self {
+            args: cmd_recall::CmdArgs { id },
+        }
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_recall::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct SnapshotBuilder {
+    pub args: mapache::commands::cmd_snapshot::CmdArgs,
+}
+
+impl SnapshotBuilder {
+    pub fn new(paths: Vec<PathBuf>) -> Self {
+        use mapache::commands::{UseSnapshot, cmd_snapshot};
+        Self {
+            args: cmd_snapshot::CmdArgs {
+                paths,
+                as_root: false,
+                exclude: None,
+                exclude_file: None,
+                tags_str: String::new(),
+                description: None,
+                no_parent: false,
+                skip_if_unchanged: false,
+                no_scan: false,
+                parent: UseSnapshot::Latest,
+                num_readers: 2,
+                num_packers: 2,
+                dry_run: false,
+            },
+        }
+    }
+
+    pub fn dry_run(mut self, dry_run: bool) -> Self {
+        self.args.dry_run = dry_run;
+        self
+    }
+
+    pub fn exclude(mut self, exclude: Vec<String>) -> Self {
+        self.args.exclude = Some(exclude);
+        self
+    }
+
+    pub fn no_parent(mut self, no_parent: bool) -> Self {
+        self.args.no_parent = no_parent;
+        self
+    }
+
+    pub fn skip_if_unchanged(mut self, skip: bool) -> Self {
+        self.args.skip_if_unchanged = skip;
+        self
+    }
+
+    pub fn no_scan(mut self, no_scan: bool) -> Self {
+        self.args.no_scan = no_scan;
+        self
+    }
+
+    pub fn root(mut self, as_root: bool) -> Self {
+        self.args.as_root = as_root;
+        self
+    }
+
+    pub fn tags(mut self, tags: String) -> Self {
+        self.args.tags_str = tags;
+        self
+    }
+
+    pub fn description(mut self, description: String) -> Self {
+        self.args.description = Some(description);
+        self
+    }
+
+    pub fn parent(mut self, parent: mapache::commands::UseSnapshot) -> Self {
+        self.args.parent = parent;
+        self
+    }
+
+    pub fn num_readers(mut self, num: usize) -> Self {
+        self.args.num_readers = num;
+        self
+    }
+
+    pub fn num_packers(mut self, num: usize) -> Self {
+        self.args.num_packers = num;
+        self
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_snapshot::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct RestoreBuilder {
+    pub args: mapache::commands::cmd_restore::CmdArgs,
+}
+
+impl RestoreBuilder {
+    pub fn new(target: PathBuf) -> Self {
+        use mapache::commands::{UseSnapshot, cmd_restore};
+        use mapache::restorer::Strategy;
+        Self {
+            args: cmd_restore::CmdArgs {
+                sparse: false,
+                target,
+                snapshot: UseSnapshot::Latest,
+                dry_run: false,
+                verify: false,
+                include: None,
+                exclude: None,
+                include_file: None,
+                exclude_file: None,
+                strip_prefix: false,
+                strategy: Strategy::Skip,
+                quit_on_error: true,
+                delete: false,
+                no_preserve_root: false,
+            },
+        }
+    }
+
+    pub fn strip_prefix(mut self, strip: bool) -> Self {
+        self.args.strip_prefix = strip;
+        self
+    }
+
+    pub fn exclude(mut self, exclude: Vec<String>) -> Self {
+        self.args.exclude = Some(exclude);
+        self
+    }
+
+    pub fn include(mut self, include: Vec<String>) -> Self {
+        self.args.include = Some(include);
+        self
+    }
+
+    pub fn dry_run(mut self, dry_run: bool) -> Self {
+        self.args.dry_run = dry_run;
+        self
+    }
+
+    pub fn verify(mut self, verify: bool) -> Self {
+        self.args.verify = verify;
+        self
+    }
+
+    pub fn delete(mut self, delete: bool) -> Self {
+        self.args.delete = delete;
+        self
+    }
+
+    pub fn strategy(mut self, strategy: mapache::restorer::Strategy) -> Self {
+        self.args.strategy = strategy;
+        self
+    }
+
+    pub fn sparse(mut self, sparse: bool) -> Self {
+        self.args.sparse = sparse;
+        self
+    }
+
+    pub fn quit_on_error(mut self, quit: bool) -> Self {
+        self.args.quit_on_error = quit;
+        self
+    }
+
+    pub fn no_preserve_root(mut self, no_preserve: bool) -> Self {
+        self.args.no_preserve_root = no_preserve;
+        self
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_restore::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct AmendBuilder {
+    pub args: mapache::commands::cmd_amend::CmdArgs,
+}
+
+impl AmendBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::{UseSnapshot, cmd_amend};
+        Self {
+            args: cmd_amend::CmdArgs {
+                snapshot: UseSnapshot::Latest,
+                all: false,
+                keep_old: false,
+                tags_str: None,
+                clear_tags: false,
+                description: None,
+                clear_description: false,
+                exclude: None,
+                exclude_file: None,
+            },
+        }
+    }
+
+    pub fn exclude(mut self, exclude: Vec<String>) -> Self {
+        self.args.exclude = Some(exclude);
+        self
+    }
+
+    pub fn clear_tags(mut self, clear: bool) -> Self {
+        self.args.clear_tags = clear;
+        self
+    }
+
+    pub fn clear_description(mut self, clear: bool) -> Self {
+        self.args.clear_description = clear;
+        self
+    }
+
+    pub fn tags(mut self, tags: String) -> Self {
+        self.args.tags_str = Some(tags);
+        self
+    }
+
+    pub fn description(mut self, description: String) -> Self {
+        self.args.description = Some(description);
+        self
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_amend::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct BundleBuilder {
+    pub args: mapache::commands::cmd_bundle::CmdArgs,
+}
+
+impl BundleBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::cmd_bundle;
+        Self {
+            args: cmd_bundle::CmdArgs::default(),
+        }
+    }
+
+    pub fn bundle(mut self, bundle: bool) -> Self {
+        self.args.bundle = bundle;
+        self
+    }
+
+    pub fn extract(mut self, extract: bool) -> Self {
+        self.args.extract = extract;
+        self
+    }
+
+    pub fn input(mut self, input: Vec<PathBuf>) -> Self {
+        self.args.input = input;
+        self
+    }
+
+    pub fn output(mut self, output: PathBuf) -> Self {
+        self.args.output = Some(output);
+        self
+    }
+
+    pub fn password(mut self, password: String) -> Self {
+        self.args.internal_password = Some(password);
+        self
+    }
+
+    pub async fn run(self) -> Result<()> {
+        mapache::commands::cmd_bundle::run(&self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct ForgetBuilder {
+    pub args: mapache::commands::cmd_forget::CmdArgs,
+}
+
+impl ForgetBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::cmd_forget;
+        Self {
+            args: cmd_forget::CmdArgs {
+                forget: Vec::new(),
+                force: false,
+                keep_last: None,
+                keep_within: None,
+                keep_yearly: None,
+                keep_monthly: None,
+                keep_weekly: None,
+                keep_daily: None,
+                run_gc: false,
+                dry_run: false,
+                tolerance: 0.0,
+                tags_str: None,
+                keep_tags_str: None,
+            },
+        }
+    }
+
+    pub fn forget(mut self, forget: Vec<String>) -> Self {
+        self.args.forget = forget;
+        self
+    }
+
+    pub fn force(mut self, force: bool) -> Self {
+        self.args.force = force;
+        self
+    }
+
+    pub fn keep_last(mut self, count: usize) -> Self {
+        self.args.keep_last = Some(count);
+        self
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_forget::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct CleanBuilder {
+    pub args: mapache::commands::cmd_clean::CmdArgs,
+}
+
+impl CleanBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::cmd_clean;
+        Self {
+            args: cmd_clean::CmdArgs {
+                tolerance: 0.0,
+                dry_run: false,
+                no_repack: false,
+            },
+        }
+    }
+
+    pub fn tolerance(mut self, tolerance: f32) -> Self {
+        self.args.tolerance = tolerance;
+        self
+    }
+
+    pub fn dry_run(mut self, dry_run: bool) -> Self {
+        self.args.dry_run = dry_run;
+        self
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_clean::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct LogBuilder {
+    pub args: mapache::commands::cmd_log::CmdArgs,
+}
+
+impl LogBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::cmd_log;
+        Self {
+            args: cmd_log::CmdArgs {
+                snapshot: None,
+                dropped: false,
+                all: false,
+                compact: false,
+                tags_str: None,
+            },
+        }
+    }
+
+    pub fn compact(mut self, compact: bool) -> Self {
+        self.args.compact = compact;
+        self
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_log::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct StatsBuilder {
+    pub args: mapache::commands::cmd_stats::CmdArgs,
+}
+
+impl StatsBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::cmd_stats;
+        Self {
+            args: cmd_stats::CmdArgs { full: false },
+        }
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_stats::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct CatBuilder {
+    pub args: mapache::commands::cmd_cat::CmdArgs,
+}
+
+impl CatBuilder {
+    pub fn new(object: mapache::commands::cmd_cat::Object) -> Self {
+        use mapache::commands::cmd_cat;
+        Self {
+            args: cmd_cat::CmdArgs { object },
+        }
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_cat::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct SyncBuilder {
+    pub args: mapache::commands::cmd_sync::CmdArgs,
+}
+
+impl SyncBuilder {
+    pub fn new(target: String) -> Self {
+        use mapache::commands::cmd_sync;
+        Self {
+            args: cmd_sync::CmdArgs {
+                target,
+                delete: false,
+                dst_ssh_privatekey: None,
+                dry_run: false,
+            },
+        }
+    }
+
+    pub fn delete(mut self, delete: bool) -> Self {
+        self.args.delete = delete;
+        self
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_sync::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct RebuildIndexBuilder {
+    pub args: mapache::commands::cmd_rebuild_index::CmdArgs,
+}
+
+impl RebuildIndexBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::cmd_rebuild_index;
+        Self {
+            args: cmd_rebuild_index::CmdArgs { dry_run: false },
+        }
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_rebuild_index::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct RechunkBuilder {
+    pub args: mapache::commands::cmd_rechunk::CmdArgs,
+}
+
+impl RechunkBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::cmd_rechunk;
+        Self {
+            args: cmd_rechunk::CmdArgs {},
+        }
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_rechunk::run(global, &self.args).await
+    }
+}
+
+#[derive(Clone)]
+pub struct UnlockBuilder {
+    pub args: mapache::commands::cmd_unlock::CmdArgs,
+}
+
+impl UnlockBuilder {
+    pub fn new() -> Self {
+        use mapache::commands::cmd_unlock;
+        Self {
+            args: cmd_unlock::CmdArgs { force: false },
+        }
+    }
+
+    pub fn force(mut self, force: bool) -> Self {
+        self.args.force = force;
+        self
+    }
+
+    pub async fn run(self, global: &GlobalArgs) -> Result<()> {
+        mapache::commands::cmd_unlock::run(global, &self.args).await
+    }
 }
 
 async fn init_repo(auth: &Auth, repo_path: PathBuf) -> Result<()> {

--- a/core/tests/integration_tests/test_cmd_amend.rs
+++ b/core/tests/integration_tests/test_cmd_amend.rs
@@ -3,13 +3,11 @@
 mod tests {
     use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
 
-    use anyhow::{Context, Result};
+    use anyhow::Result;
     use mapache::{
         backend::localfs::LocalFS,
-        commands::{self, UseSnapshot, cmd_amend, cmd_restore, cmd_snapshot},
         mapache::defaults::TEST_REPO_CONFIG,
         repository::{repo::Repository, snapshot::SnapshotStream},
-        restorer::Strategy,
     };
 
     use crate::integration_tests::{TestContext, assert_times_equal};
@@ -18,78 +16,36 @@ mod tests {
     async fn test_amend_exclude() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .await?;
 
         let excluded_paths = vec![
             "2".to_string(),
             "file.txt".to_string(),
             "0/00/file00.txt".to_string(),
         ];
-        let amend_args = cmd_amend::CmdArgs {
-            snapshot: UseSnapshot::Latest,
-            all: false,
-            keep_old: false,
-            tags_str: None,
-            clear_tags: false,
-            description: None,
-            clear_description: false,
-            exclude: Some(excluded_paths.clone()),
-            exclude_file: None,
-        };
-        commands::cmd_amend::run(&ctx.global, &amend_args)
-            .await
-            .context("Failed to run cmd_amend")?;
+
+        ctx.amend_builder()
+            .exclude(excluded_paths.clone())
+            .run(&ctx.global)
+            .await?;
 
         // Run restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await?;
 
         let paths = vec![
             PathBuf::from("0"),
@@ -118,7 +74,7 @@ mod tests {
             }
 
             // We excluded some paths, so the size of directories will not be consistent
-            if !restore_path.is_dir() {
+            if !restored_path.is_dir() {
                 assert_eq!(restored_meta.len(), backup_meta.len());
             }
 
@@ -139,7 +95,7 @@ mod tests {
     async fn test_amend_tags_and_description() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         let backend = Arc::new(LocalFS::new(ctx.repo_path.clone()));
 
@@ -150,40 +106,19 @@ mod tests {
                 .await?;
         test_repo_lock_handle.unlock().await;
 
-        // Run snapshot twice
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("0")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: "tag0,tag1".to_string(),
-            description: Some(String::from("This snapshot will be amended")),
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        // Run snapshot with tags and description
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("0")])
+            .tags("tag0,tag1".to_string())
+            .description("This snapshot will be amended".to_string())
+            .run(&ctx.global)
+            .await?;
 
-        let amend_args = cmd_amend::CmdArgs {
-            snapshot: UseSnapshot::Latest,
-            all: false,
-            keep_old: false,
-            tags_str: None,
-            clear_tags: true,
-            description: None,
-            clear_description: true,
-            exclude: None,
-            exclude_file: None,
-        };
-        commands::cmd_amend::run(&ctx.global, &amend_args)
-            .await
-            .context("Failed to run cmd_amend (1/2)")?;
+        // Clear tags and description
+        ctx.amend_builder()
+            .clear_tags(true)
+            .clear_description(true)
+            .run(&ctx.global)
+            .await?;
 
         let snapshot_stream = SnapshotStream::new(repo.clone()).await?;
         let (_, snapshot) = snapshot_stream
@@ -194,20 +129,12 @@ mod tests {
         assert!(snapshot.tags.is_empty());
         assert!(snapshot.description.is_none());
 
-        let amend_args = cmd_amend::CmdArgs {
-            snapshot: UseSnapshot::Latest,
-            all: false,
-            keep_old: false,
-            tags_str: Some("new_tag".to_string()),
-            clear_tags: false,
-            description: Some(String::from("This description is new")),
-            clear_description: false,
-            exclude: None,
-            exclude_file: None,
-        };
-        commands::cmd_amend::run(&ctx.global, &amend_args)
-            .await
-            .context("Failed to run cmd_amend (2/2)")?;
+        // Set new tags and description
+        ctx.amend_builder()
+            .tags("new_tag".to_string())
+            .description("This description is new".to_string())
+            .run(&ctx.global)
+            .await?;
 
         let snapshot_stream = SnapshotStream::new(repo.clone()).await?;
         let (_, snapshot) = snapshot_stream
@@ -222,6 +149,7 @@ mod tests {
         assert_eq!(
             snapshot
                 .description
+                .as_ref()
                 .expect("The description should not be None"),
             "This description is new"
         );

--- a/core/tests/integration_tests/test_cmd_bundle.rs
+++ b/core/tests/integration_tests/test_cmd_bundle.rs
@@ -1,43 +1,35 @@
 use crate::integration_tests::{TestContext, assert_times_equal};
 use anyhow::Result;
-use mapache::commands::cmd_bundle;
 
 #[tokio::test]
 async fn test_bundle_and_extract() -> Result<()> {
     let mut ctx = TestContext::new().await?;
     ctx.setup_backup_data()?;
-    let backup_data_path = ctx.backup_data_path.as_ref().unwrap();
+    let backup_data_path = ctx.backup_data_path.clone().unwrap();
 
     let bundle_path = ctx._tmp_dir.path().join("test_bundle.mapache");
     let extract_path = ctx._tmp_dir.path().join("extracted");
 
-    let bundle_args = cmd_bundle::CmdArgs {
-        bundle: true,
-        input: vec![backup_data_path.clone()],
-        output: Some(bundle_path.clone()),
-        compression_level: mapache::commands::Compression::Balanced,
-        readers: 2,
-        internal_password: Some("test_password".to_string()),
-        ..Default::default()
-    };
+    ctx.bundle_builder()
+        .bundle(true)
+        .input(vec![backup_data_path.clone()])
+        .output(bundle_path.clone())
+        .password("test_password".to_string())
+        .run()
+        .await?;
 
-    cmd_bundle::run(&bundle_args).await?;
     assert!(bundle_path.exists());
 
-    let extract_args = cmd_bundle::CmdArgs {
-        extract: true,
-        input: vec![bundle_path.clone()],
-        output: Some(extract_path.clone()),
-        compression_level: mapache::commands::Compression::Balanced,
-        readers: 2,
-        internal_password: Some("test_password".to_string()),
-        ..Default::default()
-    };
-
-    cmd_bundle::run(&extract_args).await?;
+    ctx.bundle_builder()
+        .extract(true)
+        .input(vec![bundle_path.clone()])
+        .output(extract_path.clone())
+        .password("test_password".to_string())
+        .run()
+        .await?;
 
     let backup_dir_name = backup_data_path.file_name().unwrap();
-    verify_extracted_content(backup_data_path, &extract_path.join(backup_dir_name))?;
+    verify_extracted_content(&backup_data_path, &extract_path.join(backup_dir_name))?;
 
     Ok(())
 }

--- a/core/tests/integration_tests/test_cmd_cat.rs
+++ b/core/tests/integration_tests/test_cmd_cat.rs
@@ -2,52 +2,23 @@
 
 mod tests {
     use anyhow::Result;
-    use mapache::commands::{self, UseSnapshot, cmd_snapshot};
 
-    use crate::integration_tests::{TestContext, run_bin};
+    use crate::integration_tests::TestContext;
 
     #[tokio::test]
     async fn test_run_cat() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
-
-        // Init repo
+        // Init and snapshot
         ctx.init_repo().await?;
-
-        // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot(vec![backup_data_tmp_path.join("file.txt")])
+            .await?;
 
         // Test cmd_cat manifest via binary
-        let output = run_bin(&[
-            "cat",
-            "manifest",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ])?;
+        let stdout = ctx.run_mapache_ok(&["cat", "manifest"])?;
 
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
         assert!(stdout.contains("\"version\""));
         assert!(stdout.contains("\"id\""));
 

--- a/core/tests/integration_tests/test_cmd_clean.rs
+++ b/core/tests/integration_tests/test_cmd_clean.rs
@@ -3,13 +3,10 @@
 mod tests {
     use std::{path::PathBuf, sync::Arc};
 
-    use anyhow::{Context, Result};
+    use anyhow::Result;
     use mapache::{
-        backend::localfs::LocalFS,
-        commands::{self, UseSnapshot, cmd_clean, cmd_restore, cmd_snapshot},
-        mapache::defaults::TEST_REPO_CONFIG,
+        backend::localfs::LocalFS, mapache::defaults::TEST_REPO_CONFIG,
         repository::repo::Repository,
-        restorer::Strategy,
     };
 
     use crate::integration_tests::{TestContext, assert_times_equal};
@@ -18,111 +15,37 @@ mod tests {
     async fn test_gc_sanity_check() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot twice
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot (1/2)")?;
+        ctx.snapshot(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .await?;
 
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot (2/2)")?;
+        ctx.snapshot(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+        ])
+        .await?;
 
         // Keep the last snapshot
-        let forget_args = commands::cmd_forget::CmdArgs {
-            forget: Vec::new(),
-            force: false,
-            keep_last: Some(1),
-            keep_within: None,
-            keep_yearly: None,
-            keep_monthly: None,
-            keep_weekly: None,
-            keep_daily: None,
-            run_gc: false,
-            dry_run: false,
-            tolerance: 0.0_f32,
-            tags_str: Some(String::new()),
-            keep_tags_str: Some(String::new()),
-        };
-        commands::cmd_forget::run(&ctx.global, &forget_args)
-            .await
-            .context("Failed to run cmd_forget")?;
+        ctx.forget_builder().keep_last(1).run(&ctx.global).await?;
 
-        let gc_args = cmd_clean::CmdArgs {
-            tolerance: 0.0_f32,
-            dry_run: false,
-
-            no_repack: false,
-        };
-        commands::cmd_clean::run(&ctx.global, &gc_args)
-            .await
-            .context("Failed to run cmd_gc")?;
+        ctx.clean_builder().run(&ctx.global).await?;
 
         // Run restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await?;
 
         let paths = vec![
             PathBuf::from("0"),
@@ -163,92 +86,37 @@ mod tests {
     async fn test_clean_dry_run() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot twice
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot (1/2)")?;
+        ctx.snapshot(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .await?;
 
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot (2/2)")?;
+        ctx.snapshot(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+        ])
+        .await?;
 
         // Keep the last snapshot
-        let forget_args = commands::cmd_forget::CmdArgs {
-            forget: Vec::new(),
-            force: false,
-            keep_last: Some(1),
-            keep_within: None,
-            keep_yearly: None,
-            keep_monthly: None,
-            keep_weekly: None,
-            keep_daily: None,
-            run_gc: false,
-            dry_run: false,
-            tolerance: 0.0_f32,
-            tags_str: Some(String::new()),
-            keep_tags_str: Some(String::new()),
-        };
-        commands::cmd_forget::run(&ctx.global, &forget_args)
-            .await
-            .context("Failed to run cmd_forget")?;
+        ctx.forget_builder().keep_last(1).run(&ctx.global).await?;
 
         // Run cmd_clean and compare the repositories (using backend readdir)
         let backend = Arc::new(LocalFS::new(ctx.repo_path.clone()));
         let mut pre_clean_nodes =
             mapache::backend::read_backend_dir(backend.as_ref(), &PathBuf::new()).await?;
-        let gc_args = cmd_clean::CmdArgs {
-            tolerance: 0.0_f32,
-            dry_run: true, // DRY-RUN !
 
-            no_repack: false,
-        };
-        commands::cmd_clean::run(&ctx.global, &gc_args)
-            .await
-            .context("Failed to run cmd_gc")?;
+        ctx.clean_builder().dry_run(true).run(&ctx.global).await?;
+
         let mut post_clean_nodes =
             mapache::backend::read_backend_dir(backend.as_ref(), &PathBuf::new()).await?;
 
@@ -259,15 +127,9 @@ mod tests {
         // Now the same, but without dry-run, the repo changes
         let pre_clean_nodes =
             mapache::backend::read_backend_dir(backend.as_ref(), &PathBuf::new()).await?;
-        let gc_args = cmd_clean::CmdArgs {
-            tolerance: 0.0_f32,
-            dry_run: false, // No dry-run
 
-            no_repack: false,
-        };
-        commands::cmd_clean::run(&ctx.global, &gc_args)
-            .await
-            .context("Failed to run cmd_gc")?;
+        ctx.clean_builder().run(&ctx.global).await?;
+
         let post_clean_nodes =
             mapache::backend::read_backend_dir(backend.as_ref(), &PathBuf::new()).await?;
         assert_ne!(pre_clean_nodes, post_clean_nodes);
@@ -281,9 +143,6 @@ mod tests {
 
         // Set a small pack size to force multiple packs and repacking
         ctx.global.pack_size_mib = 1.0; // 1MiB packs
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
-
         ctx.init_repo().await?;
 
         let backup_path = ctx._tmp_dir.path().join("backup");
@@ -297,25 +156,10 @@ mod tests {
         std::fs::write(&file_a, &data_a)?;
         std::fs::write(&file_b, &data_b)?;
 
-        commands::cmd_snapshot::run(
-            &ctx.global,
-            &cmd_snapshot::CmdArgs {
-                paths: vec![backup_path.clone()],
-                as_root: true,
-                exclude: None,
-                exclude_file: None,
-                tags_str: String::new(),
-                description: None,
-                no_parent: false,
-                skip_if_unchanged: false,
-                no_scan: false,
-                parent: UseSnapshot::Latest,
-                num_readers: 1,
-                num_packers: 1,
-                dry_run: false,
-            },
-        )
-        .await?;
+        ctx.snapshot_builder(vec![backup_path.clone()])
+            .root(true)
+            .run(&ctx.global)
+            .await?;
 
         let snapshots_dir = ctx.repo_path.join("snapshots");
         let snapshots = std::fs::read_dir(&snapshots_dir)?
@@ -335,55 +179,24 @@ mod tests {
         let data_c = vec![2u8; 512 * 1024];
         std::fs::write(&file_c, &data_c)?;
 
-        commands::cmd_snapshot::run(
-            &ctx.global,
-            &cmd_snapshot::CmdArgs {
-                paths: vec![backup_path.clone()],
-                as_root: true,
-                exclude: None,
-                exclude_file: None,
-                tags_str: String::new(),
-                description: None,
-                no_parent: false,
-                skip_if_unchanged: false,
-                no_scan: false,
-                parent: UseSnapshot::Latest,
-                num_readers: 1,
-                num_packers: 1,
-                dry_run: false,
-            },
-        )
-        .await?;
+        ctx.snapshot_builder(vec![backup_path.clone()])
+            .root(true)
+            .run(&ctx.global)
+            .await?;
 
         // Forget Snapshot 1.
-        let forget_args = commands::cmd_forget::CmdArgs {
-            forget: vec![first_id],
-            force: true, // Permanent delete
-            tags_str: None,
-            keep_last: None,
-            keep_within: None,
-            keep_yearly: None,
-            keep_monthly: None,
-            keep_weekly: None,
-            keep_daily: None,
-            keep_tags_str: None,
-            dry_run: false,
-            run_gc: false,
-            tolerance: 0.0,
-        };
-        commands::cmd_forget::run(&ctx.global, &forget_args).await?;
+        ctx.forget_builder()
+            .forget(vec![first_id])
+            .force(true)
+            .run(&ctx.global)
+            .await?;
 
         // After forgetting Snapshot 1, file_b's blobs are now garbage.
         let objects_dir = ctx.repo_path.join("objects");
         let pre_gc_size = mapache::utils::dir_size(&objects_dir)?;
 
         // Run GC.
-        let gc_args = cmd_clean::CmdArgs {
-            tolerance: 0.0,
-            dry_run: false,
-            no_repack: false,
-        };
-        commands::cmd_clean::run(&ctx.global, &gc_args).await?;
+        ctx.clean_builder().run(&ctx.global).await?;
 
         let post_gc_size = mapache::utils::dir_size(&objects_dir)?;
 
@@ -396,35 +209,15 @@ mod tests {
         );
 
         // Verify Snapshot 2 is still valid and restorable.
-        let verify_args = commands::cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 1,
-            with_cache: false,
-            fail_early: false,
-            sample: None,
-        };
-        commands::cmd_verify::run(&ctx.global, &verify_args)
-            .await
-            .context("Verify failed after GC")?;
+        ctx.verify_builder()
+            .read_packs(true)
+            .run(&ctx.global)
+            .await?;
 
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = commands::cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args).await?;
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await?;
 
         assert!(restore_path.join("file_a.bin").exists());
         assert!(restore_path.join("file_c.bin").exists());
@@ -441,9 +234,6 @@ mod tests {
         let mut ctx = TestContext::new().await?;
 
         ctx.global.pack_size_mib = 16.0;
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
-
         ctx.init_repo().await?;
 
         let backup_path = ctx._tmp_dir.path().join("backup");
@@ -458,25 +248,10 @@ mod tests {
         std::fs::write(&file_b, &data_b)?;
 
         // Snapshot 1: {A, B}
-        commands::cmd_snapshot::run(
-            &ctx.global,
-            &cmd_snapshot::CmdArgs {
-                paths: vec![backup_path.clone()],
-                as_root: true,
-                exclude: None,
-                exclude_file: None,
-                tags_str: String::new(),
-                description: None,
-                no_parent: false,
-                skip_if_unchanged: false,
-                no_scan: false,
-                parent: UseSnapshot::Latest,
-                num_readers: 1,
-                num_packers: 1,
-                dry_run: false,
-            },
-        )
-        .await?;
+        ctx.snapshot_builder(vec![backup_path.clone()])
+            .root(true)
+            .run(&ctx.global)
+            .await?;
 
         let snapshots_dir = ctx.repo_path.join("snapshots");
         let snapshots = std::fs::read_dir(&snapshots_dir)?
@@ -491,43 +266,17 @@ mod tests {
 
         // Create Snapshot 2: {A} (B is deleted)
         std::fs::remove_file(&file_b)?;
-        commands::cmd_snapshot::run(
-            &ctx.global,
-            &cmd_snapshot::CmdArgs {
-                paths: vec![backup_path.clone()],
-                as_root: true,
-                exclude: None,
-                exclude_file: None,
-                tags_str: String::new(),
-                description: None,
-                no_parent: false,
-                skip_if_unchanged: false,
-                no_scan: false,
-                parent: UseSnapshot::Latest,
-                num_readers: 1,
-                num_packers: 1,
-                dry_run: false,
-            },
-        )
-        .await?;
+        ctx.snapshot_builder(vec![backup_path.clone()])
+            .root(true)
+            .run(&ctx.global)
+            .await?;
 
         // Forget Snapshot 1
-        let forget_args = commands::cmd_forget::CmdArgs {
-            forget: vec![first_id],
-            force: true,
-            tags_str: None,
-            keep_last: None,
-            keep_within: None,
-            keep_yearly: None,
-            keep_monthly: None,
-            keep_weekly: None,
-            keep_daily: None,
-            keep_tags_str: None,
-            dry_run: false,
-            run_gc: false,
-            tolerance: 0.0,
-        };
-        commands::cmd_forget::run(&ctx.global, &forget_args).await?;
+        ctx.forget_builder()
+            .forget(vec![first_id])
+            .force(true)
+            .run(&ctx.global)
+            .await?;
 
         // GC Logic: Ratio = garbage / 16MiB = 1MiB / 16MiB = 0.0625.
 
@@ -538,13 +287,7 @@ mod tests {
         let initial_packs = repo.list_packs().await?.len();
 
         // Run GC with tolerance 0.1 (10%). 6.25% < 10%, should KEEP the data pack.
-        // It will however delete the unused tree pack from Snapshot 1.
-        let gc_args_high = cmd_clean::CmdArgs {
-            tolerance: 0.1,
-            dry_run: false,
-            no_repack: false,
-        };
-        commands::cmd_clean::run(&ctx.global, &gc_args_high).await?;
+        ctx.clean_builder().tolerance(0.1).run(&ctx.global).await?;
 
         let (repo, _) =
             Repository::try_open_unlocked(&ctx.auth, None, backend.clone(), TEST_REPO_CONFIG)
@@ -559,23 +302,12 @@ mod tests {
         );
 
         // Run GC with tolerance 0.05 (5%). 6.25% > 5%, should REPACK the data pack.
-        let gc_args_low = cmd_clean::CmdArgs {
-            tolerance: 0.05,
-            dry_run: false,
-            no_repack: false,
-        };
-        commands::cmd_clean::run(&ctx.global, &gc_args_low).await?;
+        ctx.clean_builder().tolerance(0.05).run(&ctx.global).await?;
 
-        let verify_args = commands::cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 1,
-            with_cache: false,
-            fail_early: false,
-            sample: None,
-        };
-        commands::cmd_verify::run(&ctx.global, &verify_args)
-            .await
-            .context("Verify failed after low tolerance GC")?;
+        ctx.verify_builder()
+            .read_packs(true)
+            .run(&ctx.global)
+            .await?;
 
         Ok(())
     }

--- a/core/tests/integration_tests/test_cmd_completion.rs
+++ b/core/tests/integration_tests/test_cmd_completion.rs
@@ -1,24 +1,23 @@
 #![cfg(test)]
 
 mod tests {
-    use crate::integration_tests::run_bin;
+    use crate::integration_tests::TestContext;
     use anyhow::Result;
     use tempfile::tempdir;
 
     #[tokio::test]
     async fn test_run_completion_and_check_stdout() -> Result<()> {
+        let ctx = TestContext::new().await?;
         let tmp_dir = tempdir()?;
 
         // Test completion via binary
-        let output = run_bin(&[
+        ctx.run_mapache_ok(&[
             "completion",
             "--shell",
             "bash",
             "--path",
             &tmp_dir.path().to_string_lossy(),
         ])?;
-
-        assert!(output.status.success());
 
         // Depending on implementation, it might write to the file or stdout.
         // If it writes to the file, we check the file.

--- a/core/tests/integration_tests/test_cmd_diff.rs
+++ b/core/tests/integration_tests/test_cmd_diff.rs
@@ -1,95 +1,35 @@
 #![cfg(test)]
 
 mod tests {
+    use crate::integration_tests::TestContext;
     use anyhow::Result;
-    use mapache::commands::{self, UseSnapshot, cmd_snapshot};
-
-    use crate::integration_tests::{TestContext, run_bin};
 
     #[tokio::test]
     async fn test_run_diff() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
-
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot 1
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot(vec![backup_data_tmp_path.join("file.txt")])
+            .await?;
 
         // Run snapshot 2 (modified)
         let file_path = backup_data_tmp_path.join("file.txt");
         std::fs::write(&file_path, "modified content")?;
 
-        let snapshot_args_2 = cmd_snapshot::CmdArgs {
-            paths: vec![file_path],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args_2).await?;
+        ctx.snapshot(vec![file_path]).await?;
 
         // Get IDs
-        let snapshots_dir = ctx.repo_path.join("snapshots");
-        let snapshots = std::fs::read_dir(&snapshots_dir)?
-            .map(|res| res.map(|e| e.path()))
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(snapshots.len(), 2);
-
-        let id1 = snapshots[0]
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string();
-        let id2 = snapshots[1]
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string();
+        let ids = ctx.get_snapshot_ids()?;
+        assert_eq!(ids.len(), 2);
 
         // Test cmd_diff via binary
-        let output = run_bin(&[
-            "diff",
-            &id1,
-            &id2,
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ])?;
+        let stdout = ctx.run_mapache_ok(&["diff", &ids[0], &ids[1]])?;
 
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
         assert!(stdout.contains("M  file.txt") || stdout.contains("m  file.txt"));
         assert!(stdout.contains("Files"));
         assert!(stdout.contains("Size"));

--- a/core/tests/integration_tests/test_cmd_find.rs
+++ b/core/tests/integration_tests/test_cmd_find.rs
@@ -1,68 +1,29 @@
 #![cfg(test)]
 
 mod tests {
+    use crate::integration_tests::TestContext;
     use anyhow::Result;
-    use mapache::commands::{self, UseSnapshot, cmd_snapshot};
-
-    use crate::integration_tests::{TestContext, run_bin};
 
     #[tokio::test]
     async fn test_run_find() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
-
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot(vec![backup_data_tmp_path.join("file.txt")])
+            .await?;
 
         // Test cmd_find via binary
-        let output = run_bin(&[
-            "find",
-            "file.txt",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ])?;
-
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
+        let stdout = ctx.run_mapache_ok(&["find", "file.txt"])?;
         assert!(stdout.contains("Found in snapshot"));
         assert!(stdout.contains("file.txt"));
 
         // Test cmd_find non-existent
-        let output = run_bin(&[
-            "find",
-            "non-existent.file",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ])?;
-
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
+        let stdout = ctx.run_mapache_ok(&["find", "non-existent.file"])?;
         assert!(!stdout.contains("Found in snapshot"));
 
         Ok(())

--- a/core/tests/integration_tests/test_cmd_forget.rs
+++ b/core/tests/integration_tests/test_cmd_forget.rs
@@ -1,12 +1,8 @@
 #![cfg(test)]
 
 mod tests {
-    use anyhow::{Context, Result};
-    use mapache::{
-        commands::{self, UseSnapshot, cmd_forget, cmd_recall, cmd_snapshot},
-        repository::repo::SNAPSHOTS_DIR,
-        utils,
-    };
+    use anyhow::Result;
+    use mapache::{repository::repo::SNAPSHOTS_DIR, utils};
 
     use crate::integration_tests::TestContext;
 
@@ -14,83 +10,34 @@ mod tests {
     async fn test_cmd_forget_and_recall() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
-
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
-        // Run snapshot 1
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: "tag1".to_string(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        // Run snapshots
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("file.txt")])
+            .tags("tag1".to_string())
+            .run(&ctx.global)
+            .await?;
 
-        // Run snapshot 2
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: "tag2".to_string(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("file.txt")])
+            .tags("tag2".to_string())
+            .run(&ctx.global)
+            .await?;
 
         let snapshots_dir = ctx.repo_path.join(SNAPSHOTS_DIR);
         assert_eq!(utils::count_files(&snapshots_dir)?, 2);
 
         // Get ID of one snapshot to forget
-        let snapshots = std::fs::read_dir(&snapshots_dir)?
-            .map(|res| res.map(|e| e.path()))
-            .collect::<Result<Vec<_>, _>>()?;
-        let first_id = snapshots[0]
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string();
+        let ids = ctx.get_snapshot_ids()?;
+        let first_id = &ids[0];
 
-        // Test cmd_forget with keep_last
-        let forget_args = cmd_forget::CmdArgs {
-            forget: vec![first_id.clone()],
-            force: false,
-            tags_str: None,
-            keep_last: None,
-            keep_within: None,
-            keep_yearly: None,
-            keep_monthly: None,
-            keep_weekly: None,
-            keep_daily: None,
-            keep_tags_str: None,
-            dry_run: false,
-            run_gc: false,
-            tolerance: 10.0,
-        };
-        commands::cmd_forget::run(&ctx.global, &forget_args)
-            .await
-            .context("cmd_forget failed")?;
+        // Test cmd_forget
+        ctx.forget_builder()
+            .forget(vec![first_id.clone()])
+            .run(&ctx.global)
+            .await?;
 
         let snapshots = std::fs::read_dir(&snapshots_dir)?
             .map(|res| res.map(|e| e.path()))
@@ -103,12 +50,9 @@ mod tests {
         assert_eq!(dropped_count, 1);
 
         // Test cmd_recall
-        let recall_args = cmd_recall::CmdArgs {
-            id: first_id.clone(),
-        };
-        commands::cmd_recall::run(&ctx.global, &recall_args)
-            .await
-            .context("cmd_recall failed")?;
+        ctx.recall_builder(first_id.clone())
+            .run(&ctx.global)
+            .await?;
 
         let snapshots = std::fs::read_dir(&snapshots_dir)?
             .map(|res| res.map(|e| e.path()))
@@ -121,24 +65,11 @@ mod tests {
         assert_eq!(snapshots.len(), 2);
 
         // Test cmd_forget with force
-        let forget_args = cmd_forget::CmdArgs {
-            forget: vec![first_id],
-            force: true,
-            tags_str: None,
-            keep_last: None,
-            keep_within: None,
-            keep_yearly: None,
-            keep_monthly: None,
-            keep_weekly: None,
-            keep_daily: None,
-            keep_tags_str: None,
-            dry_run: false,
-            run_gc: true,
-            tolerance: 10.0,
-        };
-        commands::cmd_forget::run(&ctx.global, &forget_args)
-            .await
-            .context("cmd_forget force failed")?;
+        ctx.forget_builder()
+            .forget(vec![first_id.clone()])
+            .force(true)
+            .run(&ctx.global)
+            .await?;
 
         assert_eq!(utils::count_files(&snapshots_dir)?, 1);
 

--- a/core/tests/integration_tests/test_cmd_init.rs
+++ b/core/tests/integration_tests/test_cmd_init.rs
@@ -4,9 +4,7 @@ mod tests {
     use std::sync::Arc;
 
     use mapache::{
-        backend::localfs::LocalFS,
-        commands::{self, cmd_init::CmdArgs},
-        mapache::defaults::TEST_REPO_CONFIG,
+        backend::localfs::LocalFS, mapache::defaults::TEST_REPO_CONFIG,
         repository::repo::Repository,
     };
 
@@ -18,10 +16,9 @@ mod tests {
     async fn test_init() -> Result<()> {
         let ctx = TestContext::new().await?;
 
-        let args = CmdArgs {};
-
         // Init repo
-        commands::cmd_init::run(&ctx.global, &args)
+        ctx.init_builder()
+            .run(&ctx.global)
             .await
             .context("Failed to run cmd_init")?;
 
@@ -60,10 +57,9 @@ mod tests {
         ctx.global.key = Some(keyfile_path.clone());
         mapache::mapache::global::set_global_opts_with_args(&ctx.global);
 
-        let args = CmdArgs {};
-
         // Init repo
-        commands::cmd_init::run(&ctx.global, &args)
+        ctx.init_builder()
+            .run(&ctx.global)
             .await
             .context("Failed to run cmd_init")?;
 

--- a/core/tests/integration_tests/test_cmd_key.rs
+++ b/core/tests/integration_tests/test_cmd_key.rs
@@ -4,7 +4,7 @@ mod tests {
     use anyhow::Result;
     use mapache::repository::repo::KEYS_DIR;
 
-    use crate::integration_tests::{TestContext, run_bin};
+    use crate::integration_tests::TestContext;
 
     #[tokio::test]
     async fn test_run_key_subcommands_and_check_stdout() -> Result<()> {
@@ -16,17 +16,8 @@ mod tests {
         ctx.init_repo().await?;
 
         // Test key list
-        let output = run_bin(&[
-            "key",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-            "list",
-        ])?;
+        let stdout = ctx.run_mapache_ok(&["key", "list"])?;
 
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
         assert!(stdout.contains("mapachito"));
         assert!(stdout.contains("Key ID"));
 
@@ -39,17 +30,8 @@ mod tests {
         let key_id = keys[0].file_name().unwrap().to_str().unwrap().to_string();
 
         // Verification of 'delete' subcommand
-        let output = run_bin(&[
-            "key",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-            "delete",
-            &key_id,
-        ])?;
+        ctx.run_mapache_ok(&["key", "delete", &key_id])?;
 
-        assert!(output.status.success());
         assert!(!keys_dir.join(&key_id).exists());
 
         Ok(())

--- a/core/tests/integration_tests/test_cmd_lock.rs
+++ b/core/tests/integration_tests/test_cmd_lock.rs
@@ -1,9 +1,8 @@
 #![cfg(test)]
 
 mod tests {
-    use anyhow::{Context, Result};
+    use anyhow::Result;
     use mapache::{
-        commands::{self, cmd_unlock},
         mapache::defaults::TEST_REPO_CONFIG,
         repository::repo::{LOCKS_DIR, Repository},
     };
@@ -14,9 +13,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cmd_unlock() -> Result<()> {
-        let mut ctx = TestContext::new().await?;
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
+        let ctx = TestContext::new().await?;
 
         // Init repo
         ctx.init_repo().await?;
@@ -34,17 +31,11 @@ mod tests {
         assert_eq!(mapache::utils::count_files(&locks_dir)?, 1);
 
         // Test cmd_unlock without force (should not delete as it's not expired)
-        let unlock_args = cmd_unlock::CmdArgs { force: false };
-        commands::cmd_unlock::run(&ctx.global, &unlock_args)
-            .await
-            .context("cmd_unlock failed")?;
+        ctx.unlock_builder().run(&ctx.global).await?;
         assert_eq!(mapache::utils::count_files(&locks_dir)?, 1);
 
         // Test cmd_unlock with force
-        let unlock_args_force = cmd_unlock::CmdArgs { force: true };
-        commands::cmd_unlock::run(&ctx.global, &unlock_args_force)
-            .await
-            .context("cmd_unlock force failed")?;
+        ctx.unlock_builder().force(true).run(&ctx.global).await?;
         assert_eq!(mapache::utils::count_files(&locks_dir)?, 0);
 
         lock_handle.unlock().await;

--- a/core/tests/integration_tests/test_cmd_log.rs
+++ b/core/tests/integration_tests/test_cmd_log.rs
@@ -1,69 +1,34 @@
 #![cfg(test)]
 
 mod tests {
+    use crate::integration_tests::TestContext;
     use anyhow::Result;
-    use mapache::commands::{self, UseSnapshot, cmd_snapshot};
-
-    use crate::integration_tests::{TestContext, run_bin};
 
     #[tokio::test]
     async fn test_run_log() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
-
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: "tag1".to_string(),
-            description: Some("test description".to_string()),
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("file.txt")])
+            .tags("tag1".to_string())
+            .description("test description".to_string())
+            .run(&ctx.global)
+            .await?;
 
         // Test cmd_log via binary
-        let output = run_bin(&[
-            "log",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ])?;
-
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
+        let stdout = ctx.run_mapache_ok(&["log"])?;
         assert!(stdout.contains("Date:"));
         assert!(stdout.contains("tag1"));
         assert!(stdout.contains("test description"));
         assert!(stdout.contains("1 snapshots"));
 
         // Test cmd_log --compact
-        let output = run_bin(&[
-            "log",
-            "--compact",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ])?;
-
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
+        let stdout = ctx.run_mapache_ok(&["log", "--compact"])?;
         assert!(stdout.contains("tag1"));
 
         Ok(())

--- a/core/tests/integration_tests/test_cmd_ls.rs
+++ b/core/tests/integration_tests/test_cmd_ls.rs
@@ -2,70 +2,29 @@
 
 mod tests {
     use anyhow::Result;
-    use mapache::commands::{self, UseSnapshot, cmd_snapshot};
 
-    use crate::integration_tests::{TestContext, run_bin};
+    use crate::integration_tests::TestContext;
 
     #[tokio::test]
     async fn test_run_ls() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
-
-        // Init repo
+        // Init and snapshot
         ctx.init_repo().await?;
+        ctx.snapshot(vec![backup_data_tmp_path.join("file.txt")])
+            .await?;
 
-        // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
-
-        // Test cmd_ls via binary to check output
-        let output = run_bin(&[
-            "ls",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-            "latest",
-        ])?;
-
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
+        // Test cmd_ls
+        let stdout = ctx.run_mapache_ok(&["ls", "latest"])?;
         assert!(stdout.contains("file.txt"));
 
         // Test cmd_ls -l
-        let output = run_bin(&[
-            "ls",
-            "-l",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-            "latest",
-        ])?;
-
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
+        let stdout = ctx.run_mapache_ok(&["ls", "-l", "latest"])?;
         assert!(stdout.contains("file.txt"));
 
-        #[cfg(not(windows))] // This file will have no permission metadata on Windows
+        #[cfg(not(windows))]
         assert!(stdout.contains("-rw"));
 
         Ok(())

--- a/core/tests/integration_tests/test_cmd_rebuild_index.rs
+++ b/core/tests/integration_tests/test_cmd_rebuild_index.rs
@@ -3,13 +3,9 @@
 mod tests {
     use std::{path::PathBuf, sync::Arc};
 
-    use anyhow::{Context, Ok, Result};
+    use anyhow::{Context, Result};
 
-    use mapache::{
-        backend::localfs::LocalFS,
-        commands::{self, UseSnapshot, cmd_rebuild_index, cmd_snapshot, cmd_verify},
-        repository::repo::INDEX_DIR,
-    };
+    use mapache::{backend::localfs::LocalFS, repository::repo::INDEX_DIR};
 
     use crate::integration_tests::{TestContext, delete_all_files_from};
 
@@ -17,58 +13,40 @@ mod tests {
     async fn test_rebuild_index() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
-        let verify_args = cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 8,
-            with_cache: false,
-            fail_early: true,
-            sample: None,
-        };
-        let first_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
-        assert!(first_verify_result.is_ok(), "First verify should pass");
+        let verify_builder = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(8)
+            .fail_early(true);
+
+        assert!(
+            verify_builder.clone().run(&ctx.global).await.is_ok(),
+            "First verify should pass"
+        );
 
         let backend = Arc::new(LocalFS::new(ctx.repo_path.clone()));
 
         // Rebuild index and verify
-        // This time there is an old index that will be replaced.
-        let rebuild_index_args = cmd_rebuild_index::CmdArgs { dry_run: false };
-        commands::cmd_rebuild_index::run(&ctx.global, &rebuild_index_args)
-            .await
-            .context("Failed to run cmd_rebuild_index")?;
+        ctx.rebuild_index_builder().run(&ctx.global).await?;
 
-        let final_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
         assert!(
-            final_verify_result.is_ok(),
+            verify_builder.clone().run(&ctx.global).await.is_ok(),
             "Verify should pass after index is rebuilt"
         );
 
@@ -76,22 +54,17 @@ mod tests {
         delete_all_files_from(backend.as_ref(), &PathBuf::from(INDEX_DIR))
             .await
             .context("Failed to remove the index")?;
-        let second_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+
         assert!(
-            second_verify_result.is_err(),
+            verify_builder.clone().run(&ctx.global).await.is_err(),
             "Verify should fail without an index"
         );
 
         // Rebuild index and verify
-        // This time there's no old index.
-        let rebuild_index_args = cmd_rebuild_index::CmdArgs { dry_run: false };
-        commands::cmd_rebuild_index::run(&ctx.global, &rebuild_index_args)
-            .await
-            .context("Failed to run cmd_rebuild_index")?;
+        ctx.rebuild_index_builder().run(&ctx.global).await?;
 
-        let final_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
         assert!(
-            final_verify_result.is_ok(),
+            verify_builder.run(&ctx.global).await.is_ok(),
             "Verify should pass after index is rebuilt"
         );
 

--- a/core/tests/integration_tests/test_cmd_rechunk.rs
+++ b/core/tests/integration_tests/test_cmd_rechunk.rs
@@ -1,58 +1,31 @@
 #![cfg(test)]
 
 mod tests {
-    use anyhow::{Context, Result};
-    use mapache::commands::{self, UseSnapshot, cmd_rechunk, cmd_snapshot, cmd_verify};
-
     use crate::integration_tests::TestContext;
+    use anyhow::Result;
 
     #[tokio::test]
     async fn test_cmd_rechunk() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
-
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot(vec![backup_data_tmp_path.join("file.txt")])
+            .await?;
 
         // Run rechunk
-        let rechunk_args = cmd_rechunk::CmdArgs {};
-        commands::cmd_rechunk::run(&ctx.global, &rechunk_args)
-            .await
-            .context("cmd_rechunk failed")?;
+        ctx.rechunk_builder().run(&ctx.global).await?;
 
         // Verify repo
-        let verify_args = cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 1,
-            with_cache: false,
-            fail_early: true,
-            sample: None,
-        };
-        commands::cmd_verify::run(&ctx.global, &verify_args)
-            .await
-            .context("verify failed after rechunk")?;
+        ctx.verify_builder()
+            .read_packs(true)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await?;
 
         Ok(())
     }

--- a/core/tests/integration_tests/test_cmd_restore.rs
+++ b/core/tests/integration_tests/test_cmd_restore.rs
@@ -6,12 +6,9 @@ mod tests {
         time::{Duration, SystemTime},
     };
 
-    use anyhow::{Context, Result};
+    use anyhow::Result;
     use filetime::{FileTime, set_file_times};
-    use mapache::{
-        commands::{self, UseSnapshot, cmd_restore, cmd_snapshot},
-        restorer::Strategy,
-    };
+    use mapache::restorer::Strategy;
 
     use crate::integration_tests::{TestContext, assert_times_equal};
 
@@ -19,66 +16,35 @@ mod tests {
     async fn test_restore_with_filter() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: Some(vec![
-                backup_data_tmp_path
-                    .join("0/01")
-                    .to_string_lossy()
-                    .into_owned(),
-            ]),
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .exclude(vec![
+            backup_data_tmp_path
+                .join("0/01")
+                .to_string_lossy()
+                .into_owned(),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
         // Run restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: Some(vec!["0".to_string(), "1".to_string()]),
-            exclude: Some(vec![
-                String::from("0/00/file00.txt"),
-                String::from("0/*.txt"),
-            ]),
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .include(vec!["0".to_string(), "1".to_string()])
+            .exclude(vec!["0/00/file00.txt".to_string(), "0/*.txt".to_string()])
+            .run(&ctx.global)
+            .await?;
 
         let restored_paths = vec![
             PathBuf::from("0"),
@@ -127,58 +93,28 @@ mod tests {
     async fn test_restore_dry_run() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
         // Run restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: true,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .dry_run(true)
+            .run(&ctx.global)
+            .await?;
 
         assert!(!restore_path.exists());
 
@@ -189,61 +125,32 @@ mod tests {
     async fn test_restore_strip_prefix() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
         // Run restore 1
         let restore_path = ctx._tmp_dir.path().join("restore1");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: Some(vec![
+        ctx.restore_builder(restore_path.clone())
+            .include(vec![
                 "0/file0.txt".to_string(),
                 "0/00/file00.txt".to_string(),
-            ]),
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: true,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore 1")?;
+            ])
+            .strip_prefix(true)
+            .run(&ctx.global)
+            .await?;
 
         let restored_paths = vec![PathBuf::from("file0.txt"), PathBuf::from("00/file00.txt")];
         for path in &restored_paths {
@@ -253,26 +160,11 @@ mod tests {
 
         // Run restore 2
         let restore_path = ctx._tmp_dir.path().join("restore2");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: Some(vec!["0/00/file00.txt".to_string()]),
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: true,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore 2")?;
+        ctx.restore_builder(restore_path.clone())
+            .include(vec!["0/00/file00.txt".to_string()])
+            .strip_prefix(true)
+            .run(&ctx.global)
+            .await?;
 
         let restored_paths = vec![PathBuf::from("file00.txt")];
         for path in &restored_paths {
@@ -287,58 +179,29 @@ mod tests {
     async fn test_restore_delete_default() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
         // Run restore to create base files
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Overwrite,
-
-            quit_on_error: false,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore (1/2)")?;
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .quit_on_error(false)
+            .run(&ctx.global)
+            .await?;
 
         // Create extra files
         std::fs::create_dir_all(restore_path.join("0"))?;
@@ -359,26 +222,12 @@ mod tests {
         );
 
         // Restore with --delete
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Overwrite,
-
-            quit_on_error: false,
-            delete: true,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore (2/2)")?;
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .quit_on_error(false)
+            .delete(true)
+            .run(&ctx.global)
+            .await?;
 
         let paths = vec![
             PathBuf::from("0"),
@@ -418,58 +267,29 @@ mod tests {
     async fn test_restore_delete_default_with_include() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
         // Run restore to create base files
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Overwrite,
-
-            quit_on_error: false,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore (1/2)")?;
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .quit_on_error(false)
+            .run(&ctx.global)
+            .await?;
 
         // Create extra files
         std::fs::create_dir_all(restore_path.join("0"))?;
@@ -490,26 +310,13 @@ mod tests {
         );
 
         // Restore with --delete
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: Some(vec!["0".to_string()]),
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Overwrite,
-
-            quit_on_error: false,
-            delete: true,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore (2/2)")?;
+        ctx.restore_builder(restore_path.clone())
+            .include(vec!["0".to_string()])
+            .strategy(Strategy::Overwrite)
+            .quit_on_error(false)
+            .delete(true)
+            .run(&ctx.global)
+            .await?;
 
         let paths = vec![
             PathBuf::from("0"),
@@ -545,58 +352,30 @@ mod tests {
     async fn test_restore_delete_no_preserve_root() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
         // Run restore to create base files
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Overwrite,
-
-            quit_on_error: false,
-            delete: false,
-            no_preserve_root: true,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore (1/2)")?;
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .quit_on_error(false)
+            .no_preserve_root(true)
+            .run(&ctx.global)
+            .await?;
 
         // Create extra files
         std::fs::create_dir_all(restore_path.join("0"))?;
@@ -617,26 +396,13 @@ mod tests {
         );
 
         // Restore with --delete
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Overwrite,
-
-            quit_on_error: false,
-            delete: true,
-            no_preserve_root: true,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore (2/2)")?;
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .quit_on_error(false)
+            .delete(true)
+            .no_preserve_root(true)
+            .run(&ctx.global)
+            .await?;
 
         let paths = vec![
             PathBuf::from("0"),
@@ -676,51 +442,24 @@ mod tests {
     async fn test_restore_with_conflict_resolution() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo and create Snapshot 1
         ctx.init_repo().await?;
 
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("0")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::from("S1"),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot S1")?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("0")])
+            .tags(String::from("S1"))
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         let restore_path = ctx._tmp_dir.path().join("restore_conflicts");
-        let restore_args_initial = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip, // Strategy doesn't matter for initial restore
-
-            quit_on_error: false,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args_initial)
-            .await
-            .context("Failed to run initial cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .quit_on_error(false)
+            .run(&ctx.global)
+            .await?;
 
         let file_to_overwrite = restore_path.join("0").join("file0.txt");
         let file_to_skip = restore_path.join("0").join("00").join("file00.txt");
@@ -738,26 +477,12 @@ mod tests {
         set_file_times(&file_to_overwrite, filetime, filetime)?;
         set_file_times(&file_to_skip, filetime, filetime)?;
 
-        let restore_args_overwrite = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: Some(vec!["0/file0.txt".to_string()]),
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Overwrite,
-
-            quit_on_error: false,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args_overwrite)
-            .await
-            .context("Failed to run cmd_restore Overwrite")?;
+        ctx.restore_builder(restore_path.clone())
+            .include(vec!["0/file0.txt".to_string()])
+            .strategy(Strategy::Overwrite)
+            .quit_on_error(false)
+            .run(&ctx.global)
+            .await?;
 
         // Verify that the file was overwritten
         assert_eq!(
@@ -765,26 +490,12 @@ mod tests {
             original_content
         );
 
-        let restore_args_skip = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: Some(vec!["0/00/file00.txt".to_string()]),
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: false,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args_skip)
-            .await
-            .context("Failed to run cmd_restore Skip")?;
+        ctx.restore_builder(restore_path.clone())
+            .include(vec!["0/00/file00.txt".to_string()])
+            .strategy(Strategy::Skip)
+            .quit_on_error(false)
+            .run(&ctx.global)
+            .await?;
 
         // Verify that the local change was kept (skipped)
         assert_eq!(std::fs::read_to_string(&file_to_skip)?, new_content_skip);
@@ -826,42 +537,18 @@ mod tests {
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_path.clone()],
-            as_root: true,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_path.clone()])
+            .root(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         // Restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args).await?;
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await?;
 
         // Verify file xattr
         let restored_file_path = restore_path.join("file_with_xattr.txt");
@@ -901,46 +588,20 @@ mod tests {
         // Init repo and snapshot
         ctx.init_repo().await?;
 
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![file_path.clone()],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![file_path.clone()])
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         // Test 1: Restore with sparse allocation (default)
         let restore_sparse_path = ctx._tmp_dir.path().join("restore_sparse");
-        let restore_args_sparse = cmd_restore::CmdArgs {
-            sparse: true,
-            target: restore_sparse_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Overwrite,
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args_sparse)
-            .await
-            .context("Failed to restore with sparse allocation")?;
+        ctx.restore_builder(restore_sparse_path.clone())
+            .sparse(true)
+            .strategy(Strategy::Overwrite)
+            .run(&ctx.global)
+            .await?;
 
         let restored_sparse_file = restore_sparse_path.join("large_file.bin");
         assert!(
@@ -956,25 +617,11 @@ mod tests {
 
         // Test 2: Restore with eager allocation
         let restore_eager_path = ctx._tmp_dir.path().join("restore_eager");
-        let restore_args_eager = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_eager_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Overwrite,
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args_eager)
-            .await
-            .context("Failed to restore with eager allocation")?;
+        ctx.restore_builder(restore_eager_path.clone())
+            .sparse(false)
+            .strategy(Strategy::Overwrite)
+            .run(&ctx.global)
+            .await?;
 
         let restored_eager_file = restore_eager_path.join("large_file.bin");
         assert!(
@@ -1026,46 +673,19 @@ mod tests {
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![file_path.clone()],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![file_path.clone()])
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         // Run restore to create base file
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let mut restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Overwrite,
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run initial cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .run(&ctx.global)
+            .await?;
 
         let restored_file = restore_path.join("file.txt");
         assert_eq!(std::fs::read_to_string(&restored_file)?, original_content);
@@ -1086,10 +706,11 @@ mod tests {
         // We might have some precision issues depending on platform, but set_file_times should help.
 
         // Run restore again WITHOUT verify. It should skip because size and mtime match.
-        restore_args.verify = false;
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run second cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .verify(false)
+            .run(&ctx.global)
+            .await?;
 
         assert_eq!(std::fs::read_to_string(&restored_file)?, modified_content);
 
@@ -1100,9 +721,11 @@ mod tests {
         let future_time = FileTime::from_unix_time(different_filetime.unix_seconds() + 1000, 0);
         set_file_times(&restored_file, future_time, future_time)?;
 
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run third cmd_restore (automatic verify on mtime mismatch)")?;
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .verify(false)
+            .run(&ctx.global)
+            .await?;
 
         // It should have restored original content because hashes didn't match.
         assert_eq!(std::fs::read_to_string(&restored_file)?, original_content);
@@ -1116,13 +739,18 @@ mod tests {
         // Modify backup data file to force an overwrite (change content)
         std::fs::write(&file_path, "New original content")?;
         // Snapshot again
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![file_path.clone()])
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         // Restore with overwrite strategy. It should succeed despite the file being readonly.
-        restore_args.strategy = Strategy::Overwrite;
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to overwrite readonly file")?;
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .run(&ctx.global)
+            .await?;
 
         assert_eq!(
             std::fs::read_to_string(&restored_file)?,

--- a/core/tests/integration_tests/test_cmd_snapshot.rs
+++ b/core/tests/integration_tests/test_cmd_snapshot.rs
@@ -3,22 +3,16 @@
 mod tests {
     use std::path::PathBuf;
 
-    use anyhow::{Context, Result};
-    use mapache::{
-        commands::{self, UseSnapshot, cmd_restore, cmd_snapshot},
-        fs,
-        repository::repo::SNAPSHOTS_DIR,
-        restorer::Strategy,
-        utils,
-    };
+    use anyhow::Result;
+    use mapache::{commands::UseSnapshot, repository::repo::SNAPSHOTS_DIR, utils};
 
-    use crate::integration_tests::{TestContext, assert_times_equal, run_bin};
+    use crate::integration_tests::{TestContext, assert_times_equal};
 
     #[tokio::test]
     async fn test_snapshot() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
@@ -29,54 +23,22 @@ mod tests {
         assert_eq!(utils::count_files(&index_dir)?, 0);
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .await?;
+
         assert_eq!(utils::count_files(&snapshots_dir)?, 1);
         assert_ne!(utils::count_files(&index_dir)?, 0);
 
         // Run restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await?;
 
         let paths = vec![
             PathBuf::from("0"),
@@ -124,35 +86,21 @@ mod tests {
     async fn test_snapshot_dry_run() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: true,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .dry_run(true)
+        .run(&ctx.global)
+        .await?;
 
         // `snapshots` directory should be empty
         let snapshots_dir = ctx.repo_path.join("snapshots");
@@ -164,25 +112,7 @@ mod tests {
 
         // Run restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-
-        let restore_result = commands::cmd_restore::run(&ctx.global, &restore_args).await;
+        let restore_result = ctx.restore_builder(restore_path).run(&ctx.global).await;
         assert!(restore_result.is_err());
 
         Ok(())
@@ -192,67 +122,36 @@ mod tests {
     async fn test_snapshot_with_exclude() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: Some(vec![
-                backup_data_tmp_path
-                    .join("0/01")
-                    .to_string_lossy()
-                    .into_owned(),
-                backup_data_tmp_path
-                    .join("0/00/*.txt")
-                    .to_string_lossy()
-                    .into_owned(),
-            ]),
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .exclude(vec![
+            backup_data_tmp_path
+                .join("0/01")
+                .to_string_lossy()
+                .into_owned(),
+            backup_data_tmp_path
+                .join("0/00/*.txt")
+                .to_string_lossy()
+                .into_owned(),
+        ])
+        .run(&ctx.global)
+        .await?;
 
         // Run restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await?;
 
         let paths = vec![
             PathBuf::from("0"),
@@ -282,7 +181,7 @@ mod tests {
                 assert_eq!(std::fs::read(&restored_path)?, std::fs::read(&backup_path)?);
             }
 
-            if !restore_path.is_dir() {
+            if !restored_path.is_dir() {
                 // Excluded paths decrease the size of parent directories.
                 // We only test the size of files in this case
                 assert_eq!(restored_meta.len(), backup_meta.len());
@@ -301,7 +200,7 @@ mod tests {
     async fn test_snapshot_twice() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
@@ -310,82 +209,36 @@ mod tests {
         assert_eq!(utils::count_files(&snapshots_dir)?, 0);
 
         // Run snapshot (1st)
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: Some(vec![
-                backup_data_tmp_path
-                    .join("0/01")
-                    .to_string_lossy()
-                    .into_owned(),
-            ]),
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot 1")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .exclude(vec![
+            backup_data_tmp_path
+                .join("0/01")
+                .to_string_lossy()
+                .into_owned(),
+        ])
+        .run(&ctx.global)
+        .await?;
         assert_eq!(utils::count_files(&snapshots_dir)?, 1);
 
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot 2")?;
+        // Run snapshot (2nd)
+        ctx.snapshot(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .await?;
         assert_eq!(utils::count_files(&snapshots_dir)?, 2);
 
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await?;
 
         let paths = vec![
             PathBuf::from("0"),
@@ -429,53 +282,22 @@ mod tests {
     async fn test_snapshot_folder_as_root() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("0")],
-            as_root: true,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("0")])
+            .root(true)
+            .run(&ctx.global)
+            .await?;
 
         // Run restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await?;
 
         let paths = vec![
             PathBuf::from("file0.txt"),
@@ -492,7 +314,7 @@ mod tests {
             // The source folder still has the "0" folder
             let backup_path = backup_data_tmp_path.join("0").join(path);
             let restored_path = restore_path.join(path);
-            assert!(fs::path_exists(&restored_path).await);
+            assert!(restored_path.exists());
 
             let restored_meta = restored_path.symlink_metadata()?;
             let backup_meta = backup_path.symlink_metadata()?;
@@ -516,58 +338,25 @@ mod tests {
     async fn test_snapshot_intermediate_paths() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1/10/file10.txt"), // 1/10 should be included as intermediate_paths
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1/10/file10.txt"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .await?;
 
         // Run restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args)
-            .await
-            .context("Failed to run cmd_restore")?;
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await?;
 
         let paths = vec![
             PathBuf::from("0"),
@@ -611,7 +400,7 @@ mod tests {
     async fn test_snapshot_skip_if_unchanged() -> Result<()> {
         let mut ctx = TestContext::new().await?;
         ctx.setup_backup_data()?;
-        let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
+        let backup_data_tmp_path = ctx.backup_data_path.clone().unwrap();
 
         // Init repo
         ctx.init_repo().await?;
@@ -620,35 +409,19 @@ mod tests {
         assert_eq!(utils::count_files(&snapshots_dir)?, 0);
 
         // Run snapshot (1st)
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
+        let builder = ctx
+            .snapshot_builder(vec![
                 backup_data_tmp_path.join("0"),
                 backup_data_tmp_path.join("1"),
                 backup_data_tmp_path.join("2"),
                 backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: true,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
+            ])
+            .skip_if_unchanged(true);
 
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot 1")?;
+        builder.clone().run(&ctx.global).await?;
         assert_eq!(utils::count_files(&snapshots_dir)?, 1);
 
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot 2")?;
+        builder.run(&ctx.global).await?;
         assert_eq!(utils::count_files(&snapshots_dir)?, 1);
 
         Ok(())
@@ -656,45 +429,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_snapshot_metadata_and_check_log() -> Result<()> {
-        let mut ctx = TestContext::new().await?;
+        let ctx = TestContext::new().await?;
         let backup_data_tmp_path = ctx._tmp_dir.path().join("backup");
         std::fs::create_dir(&backup_data_tmp_path)?;
         std::fs::write(backup_data_tmp_path.join("test.txt"), "content")?;
 
         ctx.init_repo().await?;
 
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
-
         // Run snapshot with tags and description
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("test.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: "important,work".to_string(),
-            description: Some("Detailed backup description".to_string()),
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("test.txt")])
+            .tags("important,work".to_string())
+            .description("Detailed backup description".to_string())
+            .run(&ctx.global)
+            .await?;
 
         // Verify via binary log output
-        let output = run_bin(&[
-            "log",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ])?;
+        let stdout = ctx.run_mapache_ok(&["log"])?;
 
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
         assert!(stdout.contains("Tags: important, work"));
         assert!(stdout.contains("Detailed backup description"));
 
@@ -703,52 +454,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_snapshot_empty_dirs_and_restore() -> Result<()> {
-        let mut ctx = TestContext::new().await?;
+        let ctx = TestContext::new().await?;
         let backup_path = ctx._tmp_dir.path().join("backup");
         let empty_dir = backup_path.join("empty_folder");
         std::fs::create_dir_all(&empty_dir)?;
 
         ctx.init_repo().await?;
 
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
-
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_path.clone()],
-            as_root: true,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_path.clone()])
+            .root(true)
+            .run(&ctx.global)
+            .await?;
 
         // Restore
         let restore_path = ctx._tmp_dir.path().join("restore");
-        let restore_args = cmd_restore::CmdArgs {
-            sparse: false,
-            target: restore_path.clone(),
-            snapshot: UseSnapshot::Latest,
-            dry_run: false,
-            verify: false,
-            include: None,
-            exclude: None,
-            include_file: None,
-            exclude_file: None,
-            strip_prefix: false,
-            strategy: Strategy::Skip,
-            quit_on_error: true,
-            delete: false,
-            no_preserve_root: false,
-        };
-        commands::cmd_restore::run(&ctx.global, &restore_args).await?;
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await?;
 
         assert!(restore_path.join("empty_folder").is_dir());
 
@@ -757,36 +479,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_snapshot_manual_parent() -> Result<()> {
-        let mut ctx = TestContext::new().await?;
+        let ctx = TestContext::new().await?;
         let backup_path = ctx._tmp_dir.path().join("backup");
         std::fs::create_dir_all(&backup_path)?;
         std::fs::write(backup_path.join("f1.txt"), "v1")?;
 
         ctx.init_repo().await?;
 
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
-
         // Snapshot 1
-        commands::cmd_snapshot::run(
-            &ctx.global,
-            &cmd_snapshot::CmdArgs {
-                paths: vec![backup_path.clone()],
-                as_root: true,
-                exclude: None,
-                exclude_file: None,
-                tags_str: String::new(),
-                description: None,
-                no_parent: false,
-                skip_if_unchanged: false,
-                no_scan: false,
-                parent: UseSnapshot::Latest,
-                num_readers: 1,
-                num_packers: 1,
-                dry_run: false,
-            },
-        )
-        .await?;
+        ctx.snapshot_builder(vec![backup_path.clone()])
+            .root(true)
+            .run(&ctx.global)
+            .await?;
 
         let snapshots_dir = ctx.repo_path.join(SNAPSHOTS_DIR);
         let snapshots = std::fs::read_dir(&snapshots_dir)?
@@ -800,58 +504,25 @@ mod tests {
             .to_string();
 
         // Snapshot 2 with manual parent
-        commands::cmd_snapshot::run(
-            &ctx.global,
-            &cmd_snapshot::CmdArgs {
-                paths: vec![backup_path.clone()],
-                as_root: true,
-                exclude: None,
-                exclude_file: None,
-                tags_str: String::new(),
-                description: None,
-                no_parent: false,
-                skip_if_unchanged: false,
-                no_scan: false,
-                parent: UseSnapshot::SnapshotId(first_id.clone()),
-                num_readers: 1,
-                num_packers: 1,
-                dry_run: false,
-            },
-        )
-        .await?;
+        ctx.snapshot_builder(vec![backup_path.clone()])
+            .root(true)
+            .parent(UseSnapshot::SnapshotId(first_id.clone()))
+            .run(&ctx.global)
+            .await?;
 
-        // Verify parent ID via cat
-        let _output = run_bin(&[
-            "cat",
-            "snapshot:latest",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ]);
-
+        // Find the one that is NOT first_id
         let snapshots = std::fs::read_dir(&snapshots_dir)?
             .map(|res| res.map(|e| e.path()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        // Find the one that is NOT first_id
         let second_id = snapshots
             .iter()
             .map(|p| p.file_name().unwrap().to_str().unwrap().to_string())
             .find(|id| id != &first_id)
             .unwrap();
 
-        let output = run_bin(&[
-            "cat",
-            &format!("snapshot:{}", second_id),
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ])?;
-
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
+        // Verify parent ID via cat
+        let stdout = ctx.run_mapache_ok(&["cat", &format!("snapshot:{}", second_id)])?;
         assert!(stdout.contains(&format!("\"parent\": \"{}\"", first_id)));
 
         Ok(())

--- a/core/tests/integration_tests/test_cmd_stats.rs
+++ b/core/tests/integration_tests/test_cmd_stats.rs
@@ -2,9 +2,8 @@
 
 mod tests {
     use anyhow::Result;
-    use mapache::commands::{self, UseSnapshot, cmd_snapshot};
 
-    use crate::integration_tests::{TestContext, run_bin};
+    use crate::integration_tests::TestContext;
 
     #[tokio::test]
     async fn test_run_stats() -> Result<()> {
@@ -12,57 +11,27 @@ mod tests {
         ctx.setup_backup_data()?;
         let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
 
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
-
         // Init repo
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("file.txt")])
+            .no_parent(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         // Test cmd_stats via binary
-        let output = run_bin(&[
-            "stats",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ])?;
+        let stdout = ctx.run_mapache_ok(&["stats"])?;
 
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
         assert!(stdout.contains("Packs:"));
         assert!(stdout.contains("Snapshots:"));
         assert!(stdout.contains("1 snapshot"));
 
         // Test cmd_stats --json
-        let output = run_bin(&[
-            "stats",
-            "--json",
-            "--repo",
-            &ctx.repo_path.to_string_lossy(),
-            "--auth-file",
-            &ctx.auth_file_path.to_string_lossy(),
-        ])?;
+        let stdout = ctx.run_mapache_ok(&["stats", "--json"])?;
 
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout)?;
         let json: serde_json::Value = serde_json::from_str(&stdout)?;
         assert_eq!(json["msg_type"], "stats");
         assert_eq!(json["snapshots"]["count"], 1);

--- a/core/tests/integration_tests/test_cmd_sync.rs
+++ b/core/tests/integration_tests/test_cmd_sync.rs
@@ -3,13 +3,9 @@
 mod tests {
     use std::{path::PathBuf, sync::Arc};
 
-    use anyhow::{Context, Result};
+    use anyhow::Result;
     use mapache::{
         backend::{self, BackendNode, StorageBackend, localfs::LocalFS},
-        commands::{
-            self, UseSnapshot, cmd_snapshot,
-            cmd_sync::{self},
-        },
         repository::repo::LOCKS_DIR,
     };
 
@@ -25,42 +21,22 @@ mod tests {
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
         let dst_repo_path = ctx._tmp_dir.path().join("sync_dst");
-        let sync_args = cmd_sync::CmdArgs {
-            target: dst_repo_path.to_string_lossy().to_string(),
-            delete: false,
-            dst_ssh_privatekey: None,
-            dry_run: false,
-        };
-        cmd_sync::run(&ctx.global, &sync_args)
-            .await
-            .context("Failed to run cmd_sync")?;
+        ctx.sync_builder(dst_repo_path.to_string_lossy().to_string())
+            .run(&ctx.global)
+            .await?;
 
-        let src_backend = Arc::new(LocalFS::new(ctx.repo_path));
+        let src_backend = Arc::new(LocalFS::new(ctx.repo_path.clone()));
         let dst_backend = Arc::new(LocalFS::new(dst_repo_path));
 
         let forward_cmp = |n0: &BackendNode, n1: &BackendNode| n0.path().cmp(n1.path());
@@ -94,33 +70,19 @@ mod tests {
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
         let dst_repo_path = ctx._tmp_dir.path().join("sync_dst");
 
-        let src_backend = Arc::new(LocalFS::new(ctx.repo_path));
+        let src_backend = Arc::new(LocalFS::new(ctx.repo_path.clone()));
         let dst_backend = Arc::new(LocalFS::new(dst_repo_path.clone()));
         dst_backend.create().await?;
 
@@ -141,15 +103,10 @@ mod tests {
             b"Dummy content",
         )?;
 
-        let sync_args = cmd_sync::CmdArgs {
-            target: dst_repo_path.to_string_lossy().to_string(),
-            delete: true,
-            dst_ssh_privatekey: None,
-            dry_run: false,
-        };
-        cmd_sync::run(&ctx.global, &sync_args)
-            .await
-            .context("Failed to run cmd_sync")?;
+        ctx.sync_builder(dst_repo_path.to_string_lossy().to_string())
+            .delete(true)
+            .run(&ctx.global)
+            .await?;
 
         let forward_cmp = |n0: &BackendNode, n1: &BackendNode| n0.path().cmp(n1.path());
         let mut src_nodes: Vec<BackendNode> =
@@ -182,37 +139,17 @@ mod tests {
         ctx.init_repo().await?;
 
         // Run snapshot to generate some files
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("file.txt")])
+            .no_scan(true)
+            .run(&ctx.global)
+            .await?;
 
         let dst_repo_path = ctx._tmp_dir.path().join("sync_dst_size");
-        let sync_args = cmd_sync::CmdArgs {
-            target: dst_repo_path.to_string_lossy().to_string(),
-            delete: false,
-            dst_ssh_privatekey: None,
-            dry_run: false,
-        };
 
         // First sync
-        cmd_sync::run(&ctx.global, &sync_args)
-            .await
-            .context("Failed to run first cmd_sync")?;
+        ctx.sync_builder(dst_repo_path.to_string_lossy().to_string())
+            .run(&ctx.global)
+            .await?;
 
         // Find a pack file in the destination and corrupt its size
         let objects_dir = dst_repo_path.join("objects");
@@ -242,11 +179,11 @@ mod tests {
         assert!(corrupted, "Could not find any pack file to corrupt");
 
         // Second sync: should detect size difference and fix it
-        cmd_sync::run(&ctx.global, &sync_args)
-            .await
-            .context("Failed to run second cmd_sync")?;
+        ctx.sync_builder(dst_repo_path.to_string_lossy().to_string())
+            .run(&ctx.global)
+            .await?;
 
-        let src_backend = Arc::new(LocalFS::new(ctx.repo_path));
+        let src_backend = Arc::new(LocalFS::new(ctx.repo_path.clone()));
         let dst_backend = Arc::new(LocalFS::new(dst_repo_path));
 
         let forward_cmp = |n0: &BackendNode, n1: &BackendNode| n0.path().cmp(n1.path());

--- a/core/tests/integration_tests/test_cmd_verify.rs
+++ b/core/tests/integration_tests/test_cmd_verify.rs
@@ -12,7 +12,6 @@ mod tests {
 
     use mapache::{
         backend::{BackendNode, localfs::LocalFS, read_backend_dir},
-        commands::{self, UseSnapshot, cmd_snapshot, cmd_verify},
         repository::repo::{INDEX_DIR, OBJECTS_DIR},
     };
 
@@ -28,38 +27,23 @@ mod tests {
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
-        let verify_args = cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 8,
-            with_cache: false,
-            fail_early: true,
-            sample: None,
-        };
-        let first_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let first_verify_result = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(8)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await;
         assert!(first_verify_result.is_ok(), "First verify should pass");
 
         let backend = Arc::new(LocalFS::new(ctx.repo_path.clone()));
@@ -68,7 +52,13 @@ mod tests {
         delete_all_files_from(backend.as_ref(), &PathBuf::from(INDEX_DIR))
             .await
             .context("Failed to remove the index")?;
-        let second_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let second_verify_result = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(8)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await;
         assert!(
             second_verify_result.is_err(),
             "Verify should fail without an index"
@@ -87,38 +77,23 @@ mod tests {
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
-        let verify_args = cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 8,
-            with_cache: false,
-            fail_early: true,
-            sample: None,
-        };
-        let first_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let first_verify_result = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(8)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await;
         assert!(first_verify_result.is_ok(), "Verify should pass");
 
         let backend = Arc::new(LocalFS::new(ctx.repo_path.clone()));
@@ -127,7 +102,13 @@ mod tests {
         delete_all_files_from(backend.as_ref(), &PathBuf::from(OBJECTS_DIR))
             .await
             .context("Failed to remove the objects")?;
-        let second_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let second_verify_result = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(8)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await;
         assert!(
             second_verify_result.is_err(),
             "Verify should fail without the packs"
@@ -146,38 +127,23 @@ mod tests {
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![
-                backup_data_tmp_path.join("0"),
-                backup_data_tmp_path.join("1"),
-                backup_data_tmp_path.join("2"),
-                backup_data_tmp_path.join("file.txt"),
-            ],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 2,
-            num_packers: 2,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
-            .await
-            .context("Failed to run cmd_snapshot")?;
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+            backup_data_tmp_path.join("2"),
+            backup_data_tmp_path.join("file.txt"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await?;
 
-        let verify_args = cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 8,
-            with_cache: false,
-            fail_early: true,
-            sample: None,
-        };
-        let first_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let first_verify_result = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(8)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await;
         assert!(first_verify_result.is_ok(), "Verify should pass");
 
         let backend = Arc::new(LocalFS::new(ctx.repo_path.clone()));
@@ -208,7 +174,13 @@ mod tests {
             file.seek(SeekFrom::Start(0))?;
             file.write_all(&first_byte)?;
 
-            let bit_flip_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+            let bit_flip_verify_result = ctx
+                .verify_builder()
+                .read_packs(true)
+                .parallel(8)
+                .fail_early(true)
+                .run(&ctx.global)
+                .await;
             assert!(
                 bit_flip_verify_result.is_err(),
                 "Verify should fail because of bit-flip (decryption error)"
@@ -219,7 +191,13 @@ mod tests {
         delete_all_files_from(backend.as_ref(), &PathBuf::from(OBJECTS_DIR))
             .await
             .context("Failed to remove the objects")?;
-        let second_verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let second_verify_result = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(8)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await;
         assert!(
             second_verify_result.is_err(),
             "Verify should fail without the packs (no root tree)"
@@ -234,38 +212,26 @@ mod tests {
         ctx.setup_backup_data()?;
         let backup_data_tmp_path = ctx.backup_data_path.as_ref().unwrap();
 
-        ctx.global.verbosity = Some(1);
-        mapache::mapache::global::set_global_opts_with_args(&ctx.global);
-
         ctx.init_repo().await?;
 
         // Run snapshot
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("file.txt")])
+            .no_parent(true)
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         // Verify with 50% sample
-        let verify_args = cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 1,
-            with_cache: false,
-            fail_early: true,
-            sample: Some(50.0),
-        };
-        let verify_result = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let verify_result = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(1)
+            .fail_early(true)
+            .sample(Some(50.0))
+            .run(&ctx.global)
+            .await;
         assert!(verify_result.is_ok(), "Verify with sample should pass");
 
         Ok(())

--- a/core/tests/integration_tests/test_corrupt_repo.rs
+++ b/core/tests/integration_tests/test_corrupt_repo.rs
@@ -6,10 +6,7 @@ mod tests {
     use anyhow::{Context, Result};
     use rand::RngExt;
 
-    use mapache::{
-        commands::{self, UseSnapshot, cmd_snapshot, cmd_verify},
-        repository::repo::{OBJECTS_DIR, SNAPSHOTS_DIR},
-    };
+    use mapache::repository::repo::{OBJECTS_DIR, SNAPSHOTS_DIR};
 
     use crate::integration_tests::{TestContext, set_write_permission};
 
@@ -21,32 +18,20 @@ mod tests {
 
         ctx.init_repo().await?;
 
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("file.txt")])
+            .no_parent(true)
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         // Verify initial state
-        let verify_args = cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 1,
-            with_cache: false,
-            fail_early: true,
-            sample: None,
-        };
-        commands::cmd_verify::run(&ctx.global, &verify_args)
+        ctx.verify_builder()
+            .read_packs(true)
+            .parallel(1)
+            .fail_early(true)
+            .run(&ctx.global)
             .await
             .context("Initial verify failed")?;
 
@@ -69,7 +54,13 @@ mod tests {
 
         assert!(deleted, "Should have deleted at least one pack file");
 
-        let res = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let res = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(1)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await;
         assert!(res.is_err(), "Verify should fail when an object is missing");
 
         Ok(())
@@ -83,22 +74,13 @@ mod tests {
 
         ctx.init_repo().await?;
 
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("file.txt")])
+            .no_parent(true)
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         // Corrupt snapshot file (make it unparseable)
         let snapshots_path = ctx.repo_path.join(SNAPSHOTS_DIR);
@@ -117,14 +99,13 @@ mod tests {
 
         assert!(corrupted, "Should have corrupted a snapshot file");
 
-        let verify_args = cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 1,
-            with_cache: false,
-            fail_early: true,
-            sample: None,
-        };
-        let res = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let res = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(1)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await;
         assert!(
             res.is_err(),
             "Verify should fail when a snapshot is corrupt/unreadable"
@@ -141,22 +122,13 @@ mod tests {
 
         ctx.init_repo().await?;
 
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.join("file.txt")],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.join("file.txt")])
+            .no_parent(true)
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         // Flip a bit in the middle of the snapshot file
         let snapshots_path = ctx.repo_path.join(SNAPSHOTS_DIR);
@@ -175,14 +147,13 @@ mod tests {
 
         assert!(corrupted, "Should have flipped a bit in a snapshot file");
 
-        let verify_args = cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 1,
-            with_cache: false,
-            fail_early: true,
-            sample: None,
-        };
-        let res = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let res = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(1)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await;
         assert!(
             res.is_err(),
             "Verify should fail when a snapshot has bit-flips"
@@ -200,22 +171,13 @@ mod tests {
         ctx.init_repo().await?;
 
         // Create a snapshot with enough data to ensure a pack is created
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.clone()],
-            as_root: false,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: true,
-            skip_if_unchanged: false,
-            no_scan: true,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+        ctx.snapshot_builder(vec![backup_data_tmp_path.clone()])
+            .no_parent(true)
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
 
         // Corrupt pack files randomly
         let objects_path = ctx.repo_path.join(OBJECTS_DIR);
@@ -265,15 +227,13 @@ mod tests {
             "At least one pack should have been corrupted"
         );
 
-        let verify_args = cmd_verify::CmdArgs {
-            read_packs: true,
-            parallel: 1,
-            with_cache: false,
-            fail_early: true,
-            sample: None,
-        };
-
-        let res = commands::cmd_verify::run(&ctx.global, &verify_args).await;
+        let res = ctx
+            .verify_builder()
+            .read_packs(true)
+            .parallel(1)
+            .fail_early(true)
+            .run(&ctx.global)
+            .await;
         assert!(
             res.is_err(),
             "Verify should fail when a pack file is corrupt"

--- a/core/tests/integration_tests/test_lock_cleanup.rs
+++ b/core/tests/integration_tests/test_lock_cleanup.rs
@@ -49,77 +49,45 @@ async fn test_lock_handle_drop() -> Result<()> {
 
 #[tokio::test]
 async fn test_commands_lock_cleanup() -> Result<()> {
-    use mapache::commands::*;
-
     let mut ctx = TestContext::new().await?;
     ctx.init_repo().await?;
     let locks_dir = ctx.repo_path.join(LOCKS_DIR);
 
     // Snapshot
     ctx.setup_backup_data()?;
-    let snapshot_args = cmd_snapshot::CmdArgs {
-        paths: vec![ctx.backup_data_path.as_ref().unwrap().clone()],
-        as_root: false,
-        exclude: None,
-        exclude_file: None,
-        tags_str: "[]".to_string(),
-        description: None,
-        no_parent: false,
-        no_scan: false,
-        skip_if_unchanged: false,
-        parent: UseSnapshot::Latest,
-        num_readers: 1,
-        num_packers: 1,
-        dry_run: false,
-    };
-    cmd_snapshot::run(&ctx.global, &snapshot_args).await?;
+    ctx.snapshot_builder(vec![ctx.backup_data_path.as_ref().unwrap().clone()])
+        .tags("[]".to_string())
+        .num_readers(1)
+        .num_packers(1)
+        .run(&ctx.global)
+        .await?;
     wait_for_no_locks(&locks_dir).await?;
 
     // Get the snapshot ID
-    let snapshot_id_hex = {
-        let backend = Arc::new(mapache::backend::localfs::LocalFS::new(
-            ctx.repo_path.clone(),
-        ));
-        let (repo, _) =
-            Repository::try_open_unlocked(&ctx.auth, None, backend, TEST_REPO_CONFIG).await?;
-        let ids = repo.list_snapshot_ids().await?;
-        ids.first()
-            .expect("Snapshot should have been created")
-            .to_hex()
-    };
+    let snapshot_id_hex = ctx
+        .get_snapshot_ids()?
+        .first()
+        .cloned()
+        .expect("Snapshot should have been created");
 
     // Log
-    let log_args = cmd_log::CmdArgs {
-        snapshot: None,
-        dropped: false,
-        all: false,
-        compact: true,
-        tags_str: None,
-    };
-    cmd_log::run(&ctx.global, &log_args).await?;
+    ctx.log_builder().compact(true).run(&ctx.global).await?;
     wait_for_no_locks(&locks_dir).await?;
 
     // Stats
-    let stats_args = cmd_stats::CmdArgs { full: false };
-    cmd_stats::run(&ctx.global, &stats_args).await?;
+    ctx.stats_builder().run(&ctx.global).await?;
     wait_for_no_locks(&locks_dir).await?;
 
     // Verify
-    let verify_args = cmd_verify::CmdArgs {
-        read_packs: false,
-        parallel: 1,
-        with_cache: false,
-        fail_early: false,
-        sample: None,
-    };
-    cmd_verify::run(&ctx.global, &verify_args).await?;
+    ctx.verify_builder().run(&ctx.global).await?;
     wait_for_no_locks(&locks_dir).await?;
 
     // Cat
-    let cat_args = cmd_cat::CmdArgs {
-        object: cmd_cat::Object::Snapshot(snapshot_id_hex.clone()),
-    };
-    cmd_cat::run(&ctx.global, &cat_args).await?;
+    ctx.cat_builder(mapache::commands::cmd_cat::Object::Snapshot(
+        snapshot_id_hex.clone(),
+    ))
+    .run(&ctx.global)
+    .await?;
     wait_for_no_locks(&locks_dir).await?;
 
     Ok(())

--- a/core/tests/integration_tests/test_permission_denied.rs
+++ b/core/tests/integration_tests/test_permission_denied.rs
@@ -5,11 +5,8 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     use anyhow::{Context, Result};
-    use mapache::{
-        commands::{self, UseSnapshot, cmd_snapshot},
-        repository::repo::SNAPSHOTS_DIR,
-        utils,
-    };
+    use mapache::repository::repo::SNAPSHOTS_DIR;
+    use mapache::utils;
 
     use crate::integration_tests::TestContext;
 
@@ -43,23 +40,9 @@ mod tests {
         ctx.init_repo().await?;
 
         // Run snapshot - this should now SUCCEED and skip the inaccessible dir
-        let snapshot_args = cmd_snapshot::CmdArgs {
-            paths: vec![backup_data_tmp_path.clone()],
-            as_root: true,
-            exclude: None,
-            exclude_file: None,
-            tags_str: String::new(),
-            description: None,
-            no_parent: false,
-            skip_if_unchanged: false,
-            no_scan: false,
-            parent: UseSnapshot::Latest,
-            num_readers: 1,
-            num_packers: 1,
-            dry_run: false,
-        };
-
-        commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
+        ctx.snapshot_builder(vec![backup_data_tmp_path.clone()])
+            .root(true)
+            .run(&ctx.global)
             .await
             .context("Snapshot should succeed by skipping inaccessible paths")?;
 


### PR DESCRIPTION
Replace inline CmdArgs construction in integration tests with  type-safe builder pattern (SnapshotBuilder, VerifyBuilder, etc.)