### PR TITLE
Optimize restore memory by eliminating file_batches accumulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - **Enhanced Retention Rules**: Added `--host` (multiple), `--keep-hourly`, and
   `--keep-min` flags to the forget command for more granular snapshot retention
   control.
+- **Memory-Efficient Restore**: Blobs are now written immediately after
+  decoding, reducing peak memory from O(all blobs in segment) to O(1 blob).
+  Cuts restore memory usage without sacrificing parallelism.
 
 ## v0.3.0
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ validation before relying on it for primary backups.
 ## Benchmarks
 
 This is a non-exhaustive set of benchmarks run on my development hardware. They
-serve as a baseline for comparing performance between versions, using restic as
-a base.
+serve as a baseline for comparing performance between versions, using restic
+v0.18.1 as a base.
 
-**Test environment:** Fedora 43, AMD Ryzen 9 3900X (24 threads), SanDisk Extreme
+**Test environment:** Fedora 44, AMD Ryzen 9 3900X (24 threads), SanDisk Extreme
 PRO NVMe.
 
 Each result is the average of 3 runs following a warmup run, all on local
@@ -86,25 +86,24 @@ Workloads:
 - **kernel** — Linux kernel source tree (~1.6 GB, 99'131 objects)
 - **enron** — Enron email corpus (~1.4 GB, 520'901 objects)
 
-### v0.3.0 baseline (vs restic v0.18.1)
 
-#### kernel
-
-| Tool    | Operation | Time   | CPU   | Peak RAM | Repo Size |
-|---------|-----------|--------|-------|----------|-----------|
-| mapache | backup    | 3.40s  | 1118% | 485 MB   | 304.1 MB  |
-| restic  | backup    | 4.45s  | 1058% | 575 MB   | 308.9 MB  |
-| mapache | restore   | 15.57s | 144%  | 715 MB   | —         |
-| restic  | restore   | 17.32s | 141%  | 242 MB   | —         |
-
-#### enron
+### kernel
 
 | Tool    | Operation | Time   | CPU   | Peak RAM | Repo Size |
 |---------|-----------|--------|-------|----------|-----------|
-| mapache | backup    | 8.23s  | 1055% | 512 MB   | 717.3 MB  |
-| restic  | backup    | 13.03s | 990%  | 426 MB   | 724.9 MB  |
-| mapache | restore   | 69.75s | 135%  | 543 MB   | —         |
-| restic  | restore   | 82.20s | 142%  | 418 MB   | —         |
+| mapache | backup    | 2.34s  | 1194% | 566 MB   | 304.1 MB  |
+| restic  | backup    | 3.66s  | 1246% | 612 MB   | 308.8 MB  |
+| mapache | restore   | 9.96s  | 117%  | 268 MB   | —         |
+| restic  | restore   | 10.57s | 133%  | 255 MB   | —         |
+
+### enron
+
+| Tool    | Operation | Time   | CPU   | Peak RAM | Repo Size |
+|---------|-----------|--------|-------|----------|-----------|
+| mapache | backup    | 5.54s  | 1162% | 594 MB   | 717.0 MB  |
+| restic  | backup    | 9.48s  | 1198% | 413 MB   | 724.9 MB  |
+| mapache | restore   | 32.90s | 127%  | 373 MB   | —         |
+| restic  | restore   | 41.62s | 114%  | 445 MB   | —         |
 
 ## Roadmap
 

--- a/core/src/restorer/mod.rs
+++ b/core/src/restorer/mod.rs
@@ -891,9 +891,6 @@ impl Restorer {
             for (pack_segment, segment_data) in segments {
                 let data_arc = Arc::new(segment_data);
 
-                // Group all blobs in this segment by target file_idx
-                let mut file_batches: HashMap<usize, Vec<(Vec<u8>, u64)>> = HashMap::new();
-
                 for (blob_id, locator, targets) in pack_segment.blobs {
                     let start = (locator.offset as u64 - pack_segment.min_offset) as usize;
                     let end = start + locator.length as usize;
@@ -903,62 +900,83 @@ impl Restorer {
                         .decode_owned(encoded_blob.to_vec())
                         .with_context(|| format!("Failed to decode blob {blob_id}"))?;
 
-                    for target in targets {
-                        file_batches
-                            .entry(target.file_idx)
-                            .or_default()
-                            .push((decoded_data.clone(), target.offset_in_file));
-                    }
-                }
+                    let raw_len = decoded_data.len() as u64;
 
-                // Process each file batch in parallel
-                let mut batch_stream = futures::stream::iter(file_batches)
-                    .map(|(file_idx, writes)| {
+                    if targets.len() == 1 {
+                        let target = &targets[0];
+                        let file_path = files[target.file_idx].path.clone();
+                        let offset = target.offset_in_file;
+                        let file_idx = target.file_idx;
                         let handle_cache = handle_cache.clone();
-                        let files = files.clone();
                         let progress_reporter = self.progress_reporter.clone();
                         let quit_on_error = self.opts.quit_on_error;
 
-                        async move {
-                            let write_result =
-                                spawn_blocking(move || -> Result<u64, anyhow::Error> {
-                                    let file_plan = &files[file_idx];
-                                    let mut cache_guard = handle_cache.get_shard(file_idx).lock();
-                                    let file = cache_guard.get_handle(file_idx, &file_plan.path)?;
-
-                                    let mut total_written = 0;
-                                    for (data, offset) in writes {
-                                        #[cfg(unix)]
-                                        file.write_at(&data, offset).map_err(|e| anyhow!(e))?;
-                                        #[cfg(windows)]
-                                        file.seek_write(&data, offset).map_err(|e| anyhow!(e))?;
-                                        total_written += data.len() as u64;
-                                    }
-                                    Ok(total_written)
-                                })
-                                .await
+                        let write_result = spawn_blocking(move || -> Result<u64, anyhow::Error> {
+                            let mut cache_guard = handle_cache.get_shard(file_idx).lock();
+                            let file = cache_guard.get_handle(file_idx, &file_path)?;
+                            #[cfg(unix)]
+                            file.write_at(&decoded_data, offset)
                                 .map_err(|e| anyhow!(e))?;
+                            #[cfg(windows)]
+                            file.seek_write(&decoded_data, offset)
+                                .map_err(|e| anyhow!(e))?;
+                            Ok(raw_len)
+                        })
+                        .await
+                        .map_err(|e| anyhow!(e))?;
 
-                            match write_result {
+                        match write_result {
+                            Ok(bytes) => {
+                                progress_reporter.processed_bytes(bytes);
+                            }
+                            Err(e) => {
+                                let err_msg =
+                                    format!("Failed to write to file index {file_idx}: {e}");
+                                if quit_on_error {
+                                    bail!(err_msg);
+                                }
+                                progress_reporter.error(&err_msg);
+                            }
+                        }
+                    } else {
+                        let shared_data = Arc::new(decoded_data);
+                        let mut write_handles = Vec::with_capacity(targets.len());
+
+                        for target in &targets {
+                            let data = shared_data.clone();
+                            let file_path = files[target.file_idx].path.clone();
+                            let offset = target.offset_in_file;
+                            let file_idx = target.file_idx;
+                            let handle_cache = handle_cache.clone();
+
+                            let handle = spawn_blocking(move || -> Result<u64, anyhow::Error> {
+                                let mut cache_guard = handle_cache.get_shard(file_idx).lock();
+                                let file = cache_guard.get_handle(file_idx, &file_path)?;
+                                #[cfg(unix)]
+                                file.write_at(&data, offset).map_err(|e| anyhow!(e))?;
+                                #[cfg(windows)]
+                                file.seek_write(&data, offset).map_err(|e| anyhow!(e))?;
+                                Ok(raw_len)
+                            });
+                            write_handles.push((file_idx, handle));
+                        }
+
+                        for (file_idx, handle) in write_handles {
+                            match handle.await.map_err(|e| anyhow!(e))? {
                                 Ok(bytes) => {
-                                    progress_reporter.processed_bytes(bytes);
+                                    self.progress_reporter.processed_bytes(bytes);
                                 }
                                 Err(e) => {
                                     let err_msg =
                                         format!("Failed to write to file index {file_idx}: {e}");
-                                    if quit_on_error {
+                                    if self.opts.quit_on_error {
                                         bail!(err_msg);
                                     }
-                                    progress_reporter.error(&err_msg);
+                                    self.progress_reporter.error(&err_msg);
                                 }
                             }
-                            Ok::<(), anyhow::Error>(())
                         }
-                    })
-                    .buffer_unordered(DEFAULT_RESTORE_BLOB_CONCURRENCY);
-
-                while let Some(res) = batch_stream.next().await {
-                    res?;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Write blobs immediately after decoding instead of accumulating all decoded blobs in a HashMap before writing. For shared blobs across multiple files, use Arc to avoid redundant copies. Reduces peak memory from O(all blobs in segment) to O(1 blob), cutting restore memory usage by ~300-400 MB on large datasets.