### PR TITLE
feat(restorer): optimize performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   subdirectory). Use a leading `/` to restrict the search to the root
   (`find /file.txt`).
 
+### Changed
+
+- **Restorer performance**: Optimized the restorer with a flattened parallel
+  pipeline, concurrent blob decoding, and JIT file initialization. This
+  improves restoration performance while maintaining a low memory footprint.
+
 ### Fixes
 
 - **Exit code on interrupt**: `snapshot`, `restore`, `sync`, `verify`, `forget`,

--- a/core/src/commands/cmd_restore.rs
+++ b/core/src/commands/cmd_restore.rs
@@ -447,8 +447,10 @@ pub async fn run_with_repo(
             String::new()
         };
         ui::cli::log!(
-            "{}Finished in {} with {} and {}",
+            "{}Restored {} ({}) in {} with {} and {}",
             prefix,
+            utils::format_count(progress_reporter.total_items(), "item", "items"),
+            utils::format_size_binary(progress_reporter.total_bytes(), 3),
             utils::pretty_print_duration(start.elapsed()),
             utils::format_count(progress_reporter.error_count(), "error", "errors"),
             utils::format_count(progress_reporter.warning_count(), "warning", "warnings"),

--- a/core/src/restorer/mod.rs
+++ b/core/src/restorer/mod.rs
@@ -108,6 +108,7 @@ pub(crate) struct Restorer {
     pub(crate) target_path: PathBuf,
     pub(crate) opts: RestoreOptions,
     pub(crate) buffers: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    pub(crate) initialized: Arc<Vec<std::sync::atomic::AtomicBool>>,
 }
 
 pub(crate) type PackMap = HashMap<ID, Vec<(ID, BlobRestoreRequest)>>;
@@ -115,12 +116,15 @@ pub(crate) type PackMap = HashMap<ID, Vec<(ID, BlobRestoreRequest)>>;
 pub(crate) struct FileRestorePlan {
     pub(crate) path: PathBuf,
     pub(crate) num_blobs: u32,
+    pub(crate) size: u64,
+    pub(crate) is_hardlink: bool,
 }
 
 pub(crate) struct RestorePlan {
     pub(crate) files: Arc<Vec<FileRestorePlan>>,
     pub(crate) packs: Arc<PackMap>,
     pub(crate) directories: Vec<(PathBuf, crate::fs::node::Metadata)>,
+    pub(crate) skipped_item_paths: Vec<PathBuf>,
     pub(crate) total_items: u64,
     pub(crate) total_bytes: u64,
     pub(crate) skipped_bytes: u64,
@@ -159,7 +163,14 @@ impl FileHandleCache {
         }
     }
 
-    fn get_handle(&mut self, file_idx: usize, path: &Path) -> Result<&File> {
+    fn get_handle(
+        &mut self,
+        file_idx: usize,
+        path: &Path,
+        plan: &FileRestorePlan,
+        initialized: &std::sync::atomic::AtomicBool,
+        restorer: &Restorer,
+    ) -> Result<&File> {
         if self.handles.contains_key(&file_idx) {
             self.touch(file_idx);
             return self
@@ -174,10 +185,52 @@ impl FileHandleCache {
             self.handles.remove(&oldest_key);
         }
 
-        let file = OpenOptions::new()
-            .write(true)
-            .open(path)
-            .with_context(|| format!("Failed to open file for writing: {}", path.display()))?;
+        let file = if !initialized.load(std::sync::atomic::Ordering::Acquire) {
+            if let Ok(m) = fs::symlink_metadata(path) {
+                if m.file_type().is_symlink() {
+                    fs::remove_file(path).with_context(|| {
+                        format!("Failed to remove symlink at {}", path.display())
+                    })?;
+                } else {
+                    restorer.clear_readonly_attribute(path)?;
+                }
+            }
+
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!("Failed to create parent directory for {}", path.display())
+                })?;
+            }
+
+            let mut f = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(path)
+                .with_context(|| format!("Failed to create/truncate file: {}", path.display()))?;
+
+            if plan.size > 0 {
+                if restorer.opts.preallocate {
+                    if let Err(e) = restorer.preallocate_file(&mut f, plan.size) {
+                        tracing::warn!(target: "restorer", "Failed to preallocate file {}: {e}", path.display());
+                    }
+                } else {
+                    // Default to sparse creation via set_len.
+                    // On most modern filesystems (NTFS, APFS, XFS, EXT4), this creates a sparse file.
+                    f.set_len(plan.size).with_context(|| {
+                        format!("Failed to set length for sparse file: {}", path.display())
+                    })?;
+                }
+            }
+
+            initialized.store(true, std::sync::atomic::Ordering::Release);
+            f
+        } else {
+            OpenOptions::new()
+                .write(true)
+                .open(path)
+                .with_context(|| format!("Failed to open file for writing: {}", path.display()))?
+        };
 
         self.handles.insert(file_idx, file);
         self.order.push_back(file_idx);
@@ -233,6 +286,7 @@ impl Restorer {
             progress_reporter,
             shutdown_signal,
             buffers: Arc::new(Mutex::new(VecDeque::with_capacity(num_buffers))),
+            initialized: Arc::new(Vec::new()),
         }
     }
 
@@ -251,6 +305,29 @@ impl Restorer {
     pub(crate) fn return_buffer(&self, mut buf: Vec<u8>) {
         buf.clear();
         self.buffers.lock().push_back(buf);
+    }
+
+    /// Creates a shallow clone of the restorer for worker threads.
+    /// This is needed because Restorer contains Arc fields that we want to share.
+    pub(crate) fn clone_for_workers(&self) -> Self {
+        Self {
+            repo: self.repo.clone(),
+            progress_reporter: self.progress_reporter.clone(),
+            shutdown_signal: self.shutdown_signal.clone(),
+            target_path: self.target_path.clone(),
+            opts: RestoreOptions {
+                strategy: self.opts.strategy.clone(),
+                strip_prefix: self.opts.strip_prefix.clone(),
+                dry_run: self.opts.dry_run,
+                quit_on_error: self.opts.quit_on_error,
+                preallocate: self.opts.preallocate,
+                verify: self.opts.verify,
+                include: self.opts.include.clone(),
+                exclude: self.opts.exclude.clone(),
+            },
+            buffers: self.buffers.clone(),
+            initialized: self.initialized.clone(),
+        }
     }
 
     fn preallocate_file(&self, file: &mut File, length: u64) -> Result<()> {
@@ -378,13 +455,19 @@ impl Restorer {
             self.progress_reporter.processed_bytes(plan.skipped_bytes);
         }
 
+        for path in &plan.skipped_item_paths {
+            self.progress_reporter.processed_item(path);
+        }
+        for (path, _) in &plan.directories {
+            self.progress_reporter.processed_item(path);
+        }
+
         let plan_files = plan.files.clone();
-        let plan_packs = plan.packs.clone();
         let dry_run = self.opts.dry_run;
         let secure_storage = self.repo.secure_storage();
 
         tracing::info!(target: "restorer", "Restoring data packs");
-        self.restore_packs(plan_files, plan_packs, secure_storage, dry_run)
+        self.restore_packs(plan_files, plan.packs, secure_storage, dry_run)
             .await?;
 
         if !self.opts.dry_run && !plan.hardlinks.is_empty() {

--- a/core/src/restorer/pack_restorer.rs
+++ b/core/src/restorer/pack_restorer.rs
@@ -7,6 +7,7 @@ use std::os::windows::fs::FileExt;
 
 use anyhow::{Context, Result, anyhow, bail};
 use futures::StreamExt;
+use rayon::prelude::*;
 use tokio::task::spawn_blocking;
 
 use crate::{
@@ -16,6 +17,21 @@ use crate::{
 };
 
 use super::{BlobRestoreRequest, FileRestorePlan, PackMap, Restorer, ShardedFileHandleCache};
+
+struct DecodedBlob {
+    data: Vec<u8>,
+    targets: Vec<BlobRestoreRequest>,
+}
+
+struct RestoreContext {
+    handle_cache: Arc<ShardedFileHandleCache>,
+    files: Arc<Vec<FileRestorePlan>>,
+    remaining: Arc<Vec<std::sync::atomic::AtomicU32>>,
+    initialized: Arc<Vec<std::sync::atomic::AtomicBool>>,
+    restorer: Arc<Restorer>,
+    progress_reporter: Arc<dyn RestoreProgressReporter>,
+    quit_on_error: bool,
+}
 
 impl Restorer {
     pub(crate) async fn restore_packs(
@@ -45,8 +61,21 @@ impl Restorer {
                 .collect::<Vec<_>>(),
         );
 
-        for file in files.iter() {
-            if file.num_blobs == 0 {
+        let initialized = Arc::new(
+            (0..files.len())
+                .map(|_| std::sync::atomic::AtomicBool::new(false))
+                .collect::<Vec<_>>(),
+        );
+
+        let d = defaults::runtime();
+        let handle_cache = Arc::new(ShardedFileHandleCache::new(d.restore_max_open_files));
+
+        for (idx, file) in files.iter().enumerate() {
+            if file.num_blobs == 0 && !file.is_hardlink {
+                if !file.path.exists() || file.size == 0 {
+                    let mut cache_guard = handle_cache.get_shard(idx).lock();
+                    cache_guard.get_handle(idx, &file.path, file, &initialized[idx], self)?;
+                }
                 self.progress_reporter.processed_item(&file.path);
             }
         }
@@ -54,29 +83,21 @@ impl Restorer {
         self.progress_reporter
             .set_message("Restoring...".to_string());
 
-        let d = defaults::runtime();
-        let handle_cache = Arc::new(ShardedFileHandleCache::new(d.restore_max_open_files));
-        let mut packs_iter = packs.iter();
-        let quit_on_error = self.opts.quit_on_error;
-        let progress_reporter = self.progress_reporter.clone();
-        let shutdown_signal = self.shutdown_signal.clone();
+        let restorer_arc = Arc::new(self.clone_for_workers());
+        let ctx = Arc::new(RestoreContext {
+            handle_cache,
+            files,
+            remaining,
+            initialized,
+            restorer: restorer_arc,
+            progress_reporter: self.progress_reporter.clone(),
+            quit_on_error: self.opts.quit_on_error,
+        });
 
-        let mut download_stream = futures::stream::iter(std::iter::from_fn(|| {
-            packs_iter
-                .next()
-                .map(|(pack_id, blob_requests)| (*pack_id, blob_requests.clone()))
-        }))
-        .map(move |(pack_id, blob_requests)| {
-            let repo = self.repo.clone();
-            let secure_storage = secure_storage.clone();
-            let handle_cache = handle_cache.clone();
-            let files = files.clone();
-            let remaining = remaining.clone();
-            let progress_reporter = progress_reporter.clone();
-            let shutdown_signal = shutdown_signal.clone();
-            let d = d.clone();
-
-            async move {
+        let packs_map = Arc::try_unwrap(packs).unwrap_or_else(|arc| (*arc).clone());
+        let segments: Vec<_> = packs_map
+            .into_iter()
+            .flat_map(|(pack_id, blob_requests)| {
                 let mut blob_to_targets: HashMap<ID, Vec<BlobRestoreRequest>> = HashMap::new();
                 for (blob_id, req) in blob_requests {
                     blob_to_targets.entry(blob_id).or_default().push(req);
@@ -97,13 +118,19 @@ impl Restorer {
                     })
                     .collect();
 
-                let segments = loader::segment_blobs(pack_id, blobs_vec);
+                loader::segment_blobs(pack_id, blobs_vec)
+            })
+            .collect();
 
-                tracing::debug!(target: "restorer", "Processing {} segments from pack {} ({} bytes)", segments.len(), pack_id.to_short_hex(8),
-                    segments.iter().map(|s| s.source_len() as u64).sum::<u64>());
+        let mut download_stream = futures::stream::iter(segments)
+            .map(|segment| {
+                let repo = self.repo.clone();
+                let secure_storage = secure_storage.clone();
+                let ctx = ctx.clone();
+                let shutdown_signal = self.shutdown_signal.clone();
+                let d = d.clone();
 
-                let total_segments = segments.len();
-                for (segment_idx, segment) in segments.into_iter().enumerate() {
+                async move {
                     if shutdown_signal.load(Ordering::Acquire) {
                         bail!("Interrupted");
                     }
@@ -124,72 +151,87 @@ impl Restorer {
                         .await
                         .with_context(|| format!("Failed to read pack {}", segment.pack_id))?;
 
-                    tracing::debug!(target: "restorer", "Segment {}/{} from pack {} downloaded ({} bytes)",
-                        segment_idx + 1, total_segments, pack_id.to_short_hex(8), segment_data.len());
+                    tracing::debug!(target: "restorer", "Segment from pack {} downloaded ({} bytes)",
+                        segment.pack_id.to_short_hex(8), segment_data.len());
 
                     let data_arc = Arc::new(segment_data);
-                    let mut file_batches: HashMap<usize, Vec<(Vec<u8>, u64)>> = HashMap::new();
-                    let mut pending_decoded: u64 = 0;
+                    let mut blob_idx = 0;
+                    let blobs = segment.blobs;
 
-                    for (blob_id, locator, targets) in segment.blobs {
-                        let start = (locator.offset as u64 - segment.min_offset) as usize;
-                        let end = start + locator.length as usize;
-                        let encoded_blob = &data_arc[start..end];
+                    while blob_idx < blobs.len() {
+                        if shutdown_signal.load(Ordering::Acquire) {
+                            bail!("Interrupted");
+                        }
 
-                        let decoded_data = secure_storage
-                            .decode_owned(encoded_blob.to_vec())
-                            .with_context(|| format!("Failed to decode blob {blob_id}"))?;
+                        let mut batch = Vec::new();
+                        let mut batch_raw_size = 0;
+                        while blob_idx < blobs.len()
+                            && (batch.is_empty() || batch_raw_size < d.restore_decoded_budget)
+                        {
+                            batch_raw_size += blobs[blob_idx].1.raw_length as u64;
+                            batch.push(blobs[blob_idx].clone());
+                            blob_idx += 1;
+                        }
 
-                        let raw_len = decoded_data.len() as u64;
+                        let secure_storage_inner = secure_storage.clone();
+                        let data_arc_inner = data_arc.clone();
+                        let min_offset = segment.min_offset;
 
-                        if targets.len() == 1 {
-                            let target = &targets[0];
-                            file_batches
-                                .entry(target.file_idx)
-                                .or_default()
-                                .push((decoded_data, target.offset_in_file));
-                        } else {
-                            for target in &targets {
+                        let decoded_results: Vec<Result<DecodedBlob>> = spawn_blocking(move || {
+                            batch
+                                .into_par_iter()
+                                .map(|(blob_id, locator, targets)| {
+                                    let start = (locator.offset as u64 - min_offset) as usize;
+                                    let end = start + locator.length as usize;
+                                    let encoded_blob = &data_arc_inner[start..end];
+
+                                    let decoded_data = secure_storage_inner
+                                        .decode_owned(encoded_blob.to_vec())
+                                        .with_context(|| {
+                                            format!("Failed to decode blob {blob_id}")
+                                        })?;
+
+                                    Ok(DecodedBlob {
+                                        data: decoded_data,
+                                        targets,
+                                    })
+                                })
+                                .collect()
+                        })
+                        .await
+                        .map_err(|e| anyhow!(e))?;
+
+                        let mut file_batches: HashMap<usize, Vec<(Vec<u8>, u64)>> = HashMap::new();
+                        for res in decoded_results {
+                            let decoded = res?;
+                            if decoded.targets.len() == 1 {
+                                let target = &decoded.targets[0];
                                 file_batches
                                     .entry(target.file_idx)
                                     .or_default()
-                                    .push((decoded_data.clone(), target.offset_in_file));
+                                    .push((decoded.data, target.offset_in_file));
+                            } else {
+                                for target in &decoded.targets {
+                                    file_batches
+                                        .entry(target.file_idx)
+                                        .or_default()
+                                        .push((decoded.data.clone(), target.offset_in_file));
+                                }
                             }
                         }
 
-                        pending_decoded += raw_len;
-
-                        if pending_decoded >= d.restore_decoded_budget {
-                            Self::flush_file_batches(
-                                &mut file_batches,
-                                &handle_cache,
-                                &files,
-                                remaining.as_ref(),
-                                &progress_reporter,
-                                quit_on_error,
-                                d.restore_blob_concurrency,
-                            )
-                            .await?;
-                            pending_decoded = 0;
-                        }
+                        Self::flush_file_batches(
+                            &mut file_batches,
+                            &ctx,
+                            d.restore_blob_concurrency,
+                        )
+                        .await?;
                     }
 
-                    Self::flush_file_batches(
-                        &mut file_batches,
-                        &handle_cache,
-                        &files,
-                        remaining.as_ref(),
-                        &progress_reporter,
-                        quit_on_error,
-                        d.restore_blob_concurrency,
-                    )
-                    .await?;
+                    Ok::<(), anyhow::Error>(())
                 }
-
-                Ok::<(), anyhow::Error>(())
-            }
-        })
-        .buffer_unordered(d.restore_pack_prefetch);
+            })
+            .buffer_unordered(d.restore_pack_prefetch);
 
         while let Some(res) = download_stream.next().await {
             if self.shutdown_signal.load(Ordering::Acquire) {
@@ -205,11 +247,7 @@ impl Restorer {
     /// spawn_blocking, processing files concurrently.
     async fn flush_file_batches(
         file_batches: &mut HashMap<usize, Vec<(Vec<u8>, u64)>>,
-        handle_cache: &Arc<ShardedFileHandleCache>,
-        files: &Arc<Vec<FileRestorePlan>>,
-        remaining: &[std::sync::atomic::AtomicU32],
-        progress_reporter: &Arc<dyn RestoreProgressReporter>,
-        quit_on_error: bool,
+        ctx: &Arc<RestoreContext>,
         concurrency: usize,
     ) -> Result<()> {
         let batches = std::mem::take(file_batches);
@@ -218,15 +256,21 @@ impl Restorer {
             .map(|(file_idx, writes)| {
                 let num_blobs = writes.len().min(u32::MAX as usize) as u32;
                 let total_bytes: u64 = writes.iter().map(|(d, _)| d.len() as u64).sum();
-                let file_path = files[file_idx].path.clone();
-                let handle_cache = handle_cache.clone();
-                let files = files.clone();
-                let progress_reporter = progress_reporter.clone();
+                let ctx = ctx.clone();
 
                 async move {
+                    let file_path = ctx.files[file_idx].path.clone();
+                    let file_path_for_write = file_path.clone();
+                    let ctx_inner = ctx.clone();
                     let write_result = spawn_blocking(move || -> Result<u64, anyhow::Error> {
-                        let mut cache_guard = handle_cache.get_shard(file_idx).lock();
-                        let file = cache_guard.get_handle(file_idx, &file_path)?;
+                        let mut cache_guard = ctx_inner.handle_cache.get_shard(file_idx).lock();
+                        let file = cache_guard.get_handle(
+                            file_idx,
+                            &file_path_for_write,
+                            &ctx_inner.files[file_idx],
+                            &ctx_inner.initialized[file_idx],
+                            &ctx_inner.restorer,
+                        )?;
                         let mut written = 0u64;
                         for (data, offset) in writes {
                             let mut data_remaining = data.as_slice();
@@ -255,19 +299,19 @@ impl Restorer {
 
                     match write_result {
                         Ok(_bytes) => {
-                            progress_reporter.processed_bytes(total_bytes);
-                            if remaining[file_idx].fetch_sub(num_blobs, Ordering::Relaxed)
+                            ctx.progress_reporter.processed_bytes(total_bytes);
+                            if ctx.remaining[file_idx].fetch_sub(num_blobs, Ordering::Relaxed)
                                 == num_blobs
                             {
-                                progress_reporter.processed_item(&files[file_idx].path);
+                                ctx.progress_reporter.processed_item(&file_path);
                             }
                         }
                         Err(e) => {
                             let err_msg = format!("Failed to write to file index {file_idx}: {e}");
-                            if quit_on_error {
+                            if ctx.quit_on_error {
                                 bail!(err_msg);
                             }
-                            progress_reporter.error(&err_msg);
+                            ctx.progress_reporter.error(&err_msg);
                         }
                     }
 

--- a/core/src/restorer/planner.rs
+++ b/core/src/restorer/planner.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    fs::{self, File, OpenOptions},
+    fs::{self, File},
     path::Path,
     sync::{Arc, atomic::Ordering},
 };
@@ -34,6 +34,7 @@ impl Restorer {
     ) -> Result<RestorePlan> {
         let files = Arc::new(Mutex::new(Vec::new()));
         let directories = Arc::new(Mutex::new(Vec::new()));
+        let skipped_item_paths = Arc::new(Mutex::new(Vec::new()));
         let packs = Arc::new(dashmap::DashMap::<ID, Vec<(ID, BlobRestoreRequest)>>::new());
         let node_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let total_items = Arc::new(std::sync::atomic::AtomicU64::new(0));
@@ -53,6 +54,7 @@ impl Restorer {
                 let index = index.clone();
                 let files = files.clone();
                 let directories = directories.clone();
+                let skipped_item_paths = skipped_item_paths.clone();
                 let packs = packs.clone();
                 let node_count = node_count.clone();
                 let total_items = total_items.clone();
@@ -105,8 +107,10 @@ impl Restorer {
                     }
 
                     total_items.fetch_add(1, Ordering::Relaxed);
+                    let mut size_to_add = 0u64;
                     if node.is_file() {
-                        total_bytes.fetch_add(node.metadata.size, Ordering::Relaxed);
+                        size_to_add = node.metadata.size;
+                        total_bytes.fetch_add(size_to_add, Ordering::Relaxed);
                     }
 
                     let restore_path = match utils::secure_join(&self.target_path, &path) {
@@ -125,8 +129,9 @@ impl Restorer {
                         Ok(true) => {}
                         Ok(false) => {
                             if node.is_file() {
-                                skipped_bytes.fetch_add(node.metadata.size, Ordering::Relaxed);
+                                skipped_bytes.fetch_add(size_to_add, Ordering::Relaxed);
                             }
+                            skipped_item_paths.lock().push(restore_path);
                             return;
                         }
                         Err(e) => {
@@ -150,7 +155,7 @@ impl Restorer {
                             ));
                             return;
                         }
-                        directories.lock().push((restore_path, node.metadata));
+                        directories.lock().push((restore_path.clone(), node.metadata));
                         return;
                     }
 
@@ -178,6 +183,8 @@ impl Restorer {
                             files_lock.push(FileRestorePlan {
                                 path: restore_path.clone(),
                                 num_blobs: 0,
+                                size: node.metadata.size,
+                                is_hardlink: false,
                             });
                             idx
                         };
@@ -191,6 +198,7 @@ impl Restorer {
                                     let mut idx = hardlink_index.lock();
                                     if let Some(&primary_idx) = idx.get(&(dev, inode)) {
                                         hardlinks.lock().push((file_idx, primary_idx));
+                                        files.lock()[file_idx].is_hardlink = true;
                                         true
                                     } else {
                                         idx.insert((dev, inode), file_idx);
@@ -205,7 +213,6 @@ impl Restorer {
                         };
 
                         if is_hardlink_secondary {
-                            total_bytes.fetch_add(node.metadata.size, Ordering::Relaxed);
                             if !self.opts.dry_run
                                 && let Some(parent) = restore_path.parent()
                                 && let Err(e) = fs::create_dir_all(parent) {
@@ -230,64 +237,10 @@ impl Restorer {
                                 ));
                             }
 
-                            if self.opts.dry_run {
-                                return;
-                            }
-
-                            if let Some(parent) = restore_path.parent()
-                                && let Err(e) = fs::create_dir_all(parent)
-                            {
-                                progress_reporter.error(&format!(
-                                    "Failed to create parent directory for {}: {}",
-                                    restore_path.display(), e
-                                ));
-                            }
-
-                            if let Ok(m) = fs::symlink_metadata(&restore_path) {
-                                if m.file_type().is_symlink() {
-                                    if let Err(e) = fs::remove_file(&restore_path) {
-                                        progress_reporter.error(&format!(
-                                            "Failed to remove symlink {}: {}",
-                                            restore_path.display(), e
-                                        ));
-                                    }
-                                } else if let Err(e) = self.clear_readonly_attribute(&restore_path) {
-                                    progress_reporter.error(&format!(
-                                        "Failed to clear readonly attribute on {}: {}",
-                                        restore_path.display(), e
-                                    ));
-                                }
-                            }
-
-                            let mut file = match OpenOptions::new()
-                                .create(true).write(true).truncate(true)
-                                .open(&restore_path)
-                            {
-                                Ok(f) => f,
-                                Err(e) => {
-                                    progress_reporter.error(&format!(
-                                        "Failed to create file {}: {}", restore_path.display(), e
-                                    ));
-                                    return;
-                                }
-                            };
-
-                            if self.opts.preallocate {
-                                if let Err(e) = self.preallocate_file(&mut file, node.metadata.size) {
-                                    tracing::warn!(target: "restorer", "Failed to preallocate file {}: {e}", restore_path.display());
-                                }
-                            } else if let Err(e) = file.set_len(node.metadata.size) {
-                                tracing::warn!(target: "restorer", "Failed to set file length for {}: {e}", restore_path.display());
-                            }
-
                             files.lock()[file_idx].num_blobs = num_blobs;
                         }
                     } else if node.is_symlink() {
-                        files.lock().push(FileRestorePlan {
-                            path: restore_path.clone(),
-                            num_blobs: 0,
-                        });
-
+                        // Symlinks are restored immediately during planning.
                         if !self.opts.dry_run
                             && let Err(e) = super::node_restorer::restore_node_to_path(
                                 self,
@@ -300,6 +253,10 @@ impl Restorer {
                         {
                             progress_reporter.error(&e.to_string());
                         }
+                        // We must record symlinks in the plan to report them as processed items later.
+                        // However, we don't want them in `files` because `restore_packs` would treat them as files.
+                        // Let's reuse skipped_item_paths for now, as they only need to be reported as processed.
+                        skipped_item_paths.lock().push(restore_path);
                     }
                 }
             })
@@ -316,6 +273,11 @@ impl Restorer {
                 "Internal error: multiple Arc references to directories remained after planning",
             )?
             .into_inner();
+        let skipped_item_paths = Arc::into_inner(skipped_item_paths)
+            .context(
+                "Internal error: multiple Arc references to skipped_item_paths remained after planning",
+            )?
+            .into_inner();
         let packs_map = Arc::into_inner(packs)
             .context("Internal error: multiple Arc references to packs remained after planning")?
             .into_iter()
@@ -330,6 +292,7 @@ impl Restorer {
             files: Arc::new(files),
             packs: Arc::new(packs_map),
             directories,
+            skipped_item_paths,
             total_items: total_items.load(Ordering::Relaxed),
             total_bytes: total_bytes.load(Ordering::Relaxed),
             skipped_bytes: skipped_bytes.load(Ordering::Relaxed),
@@ -438,7 +401,7 @@ impl Restorer {
             let file = File::open(&local_path)?;
             let mut offset = 0;
 
-            const VERIFY_BUFFER_SIZE: usize = 64 * size::KiB as usize;
+            const VERIFY_BUFFER_SIZE: usize = size::MiB as usize;
             let mut buffer = vec![0u8; VERIFY_BUFFER_SIZE];
 
             for blob_id in blobs {


### PR DESCRIPTION
- Implemented a flattened parallel restoration pipeline for better I/O utilization.
- Added parallel blob decoding using Rayon.
- Moved file initialization (creation, truncation, preallocation) to a Just-in-Time model, speeding up the planning phase and reducing file-locking issues.
- Increased verification buffer size to 1 MiB for faster metadata-match validation.