### PR TITLE
feat: add hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`hooks`**: Added pre/post hook support for `snapshot`, `restore`,  `forget`,
+  `clean`, and `verify` commands. Hooks are configured in the TOML config file
+  and receive `MAPACHE_COMMAND`, `MAPACHE_REPOSITORY`, and `MAPACHE_RESULT`
+  environment variables. Optional timeout per hook. Skipped on `--dry-run`.
+
 ## v0.5.1
 
 ### Fixed

--- a/crates/mapache/Cargo.toml
+++ b/crates/mapache/Cargo.toml
@@ -51,6 +51,7 @@ tokio = { version = "1.52", features = [
   "sync",
   "time",
   "signal",
+  "process",
 ] }
 tokio-stream = "0.1.18"
 toml = "1.1.2"

--- a/crates/mapache/src/commands/cmd_clean.rs
+++ b/crates/mapache/src/commands/cmd_clean.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use crate::{
     backend::new_backend_with_prompt,
     commands::{self, GlobalArgs, ToExitCode, cleanup::CleanupHandler, fail, with_repository_lock},
-    common::defaults::DEFAULT_GC_TOLERANCE,
+    common::{defaults::DEFAULT_GC_TOLERANCE, hooks},
     repository::{gc, lock::LockHandle, repo::Repository},
     ui::{
         self,
@@ -55,7 +55,7 @@ pub struct CmdArgs {
 
 pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     tracing::info!(target: "clean", "Starting clean command");
-    with_repository_lock(
+    let repo_result = with_repository_lock(
         global_args.auth_file.as_ref(),
         global_args.key.as_ref(),
         new_backend_with_prompt(global_args.backend_options(args.dry_run))
@@ -71,11 +71,26 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
         global_args.retry_lock_duration,
         global_args.no_lock,
         |repo, _, lock_handle| async move {
+            if !args.dry_run {
+                // Run pre-hook: abort command if it fails
+                hooks::run_pre(hooks::clean(), "clean", &global_args.repo).await?;
+            }
+
             run_with_repo(global_args.json, args, repo, lock_handle).await
         },
     )
-    .await
-    .map_err(|e| {
+    .await;
+
+    let result_str = match &repo_result {
+        Ok(_) => "success".to_string(),
+        Err(e) => format!("{e}"),
+    };
+    if !args.dry_run {
+        // Run post-hook: warning on failure, always continues
+        hooks::run_post(hooks::clean(), "clean", &global_args.repo, &result_str).await;
+    }
+
+    repo_result.map_err(|e| {
         if e.is::<commands::error::MapacheError>() {
             e
         } else {

--- a/crates/mapache/src/commands/cmd_forget.rs
+++ b/crates/mapache/src/commands/cmd_forget.rs
@@ -11,7 +11,7 @@ use crate::{
         self, GlobalArgs, Merge, ToExitCode, cleanup::CleanupHandler, fail, parse_tags,
         with_repository_lock,
     },
-    common::{ContentIdType, ID, defaults::DEFAULT_GC_TOLERANCE},
+    common::{ContentIdType, ID, defaults::DEFAULT_GC_TOLERANCE, hooks},
     repository::{
         repo::{REPO_DROPPED_EXTENSION, Repository},
         retention::{RetentionRule, apply_retention_rules, filter_snapshots_by_hosts},
@@ -263,7 +263,7 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     let run_gc = args.run_gc;
     let json_output = global_args.json;
 
-    with_repository_lock(
+    let repo_result = with_repository_lock(
         global_args.auth_file.as_ref(),
         global_args.key.as_ref(),
         new_backend_with_prompt(global_args.backend_options(dry_run))
@@ -289,6 +289,12 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
                 )
             })?;
             cleanup_handler.add_lock(lock_handle.clone());
+
+            if !dry_run {
+                // Run pre-hook: abort command if it fails
+                hooks::run_pre(hooks::forget(), "forget", &global_args.repo).await?;
+            }
+
             forget_phase(repo.clone(), args, json_output, &cleanup_handler).await?;
             drop(cleanup_handler);
 
@@ -312,7 +318,18 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             Ok(())
         },
     )
-    .await
+    .await;
+
+    let result_str = match &repo_result {
+        Ok(_) => "success".to_string(),
+        Err(e) => format!("{e}"),
+    };
+    if !dry_run {
+        // Run post-hook: warning on failure, always continues
+        hooks::run_post(hooks::forget(), "forget", &global_args.repo, &result_str).await;
+    }
+
+    repo_result
 }
 
 /// Forget phase: load snapshots, apply retention/forget rules, mark or delete

--- a/crates/mapache/src/commands/cmd_restore.rs
+++ b/crates/mapache/src/commands/cmd_restore.rs
@@ -18,7 +18,7 @@ use crate::{
         self, GlobalArgs, Merge, ToExitCode, UseSnapshot, cleanup::CleanupHandler, fail,
         find_use_snapshot, with_repository_lock,
     },
-    common::defaults::SHORT_SNAPSHOT_ID_LEN,
+    common::{defaults::SHORT_SNAPSHOT_ID_LEN, hooks},
     fs::{
         calculate_lcp,
         filter::{
@@ -227,8 +227,9 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     tracing::info!(target: "restore", "Starting restore command");
 
     let json_output = global_args.json;
+    let dry_run = args.dry_run;
 
-    with_repository_lock(
+    let repo_result = with_repository_lock(
         global_args.auth_file.as_ref(),
         global_args.key.as_ref(),
         new_backend_with_prompt(global_args.backend_options(false))
@@ -307,6 +308,12 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             };
 
             let start = Instant::now();
+
+            if !dry_run {
+                // Run pre-hook: abort command if it fails
+                hooks::run_pre(hooks::restore(), "restore", &global_args.repo).await?;
+            }
+
             run_with_repo(
                 repo,
                 lock_handle,
@@ -321,8 +328,18 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             Ok(())
         },
     )
-    .await
-    .map_err(|e| {
+    .await;
+
+    let result_str = match &repo_result {
+        Ok(_) => "success".to_string(),
+        Err(e) => format!("{e}"),
+    };
+    if !dry_run {
+        // Run post-hook: warning on failure, always continues
+        hooks::run_post(hooks::restore(), "restore", &global_args.repo, &result_str).await;
+    }
+
+    repo_result.map_err(|e| {
         if e.is::<commands::error::MapacheError>() {
             e
         } else {

--- a/crates/mapache/src/commands/cmd_snapshot.rs
+++ b/crates/mapache/src/commands/cmd_snapshot.rs
@@ -20,6 +20,7 @@ use crate::{
     common::{
         self, ContentIdType, ID, config,
         defaults::{DEFAULT_SNAPSHOT_READERS, SHORT_SNAPSHOT_ID_LEN},
+        hooks,
         vars::{PASSWORD_ENVVAR, USERNAME_ENVVAR, get_envvar},
     },
     fs::{
@@ -284,10 +285,11 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
     };
 
     let dry_run = args.dry_run;
+
     let num_readers = args.num_readers.unwrap_or(DEFAULT_SNAPSHOT_READERS);
     let json_output = global_args.json;
 
-    with_repository_lock(
+    let repo_result = with_repository_lock(
         global_args.auth_file.as_ref(),
         global_args.key.as_ref(),
         new_backend_with_prompt(global_args.backend_options(dry_run))
@@ -331,6 +333,11 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             } else {
                 snapshot::make_event_sender(None, None, num_readers)
             };
+
+            if !dry_run {
+                // Run pre-hook: abort command if it fails
+                hooks::run_pre(hooks::snapshot(), "snapshot", &global_args.repo).await?;
+            }
 
             let result = run_with_repo(
                 repo,
@@ -400,7 +407,24 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
             Ok(())
         },
     )
-    .await
+    .await;
+
+    let result_str = match &repo_result {
+        Ok(_) => "success".to_string(),
+        Err(e) => format!("{e}"),
+    };
+    if !dry_run {
+        // Run post-hook: warning on failure, always continues
+        hooks::run_post(
+            hooks::snapshot(),
+            "snapshot",
+            &global_args.repo,
+            &result_str,
+        )
+        .await;
+    }
+
+    repo_result
 }
 
 pub struct SnapshotCompletion {

--- a/crates/mapache/src/commands/cmd_verify.rs
+++ b/crates/mapache/src/commands/cmd_verify.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 use crate::{
     backend::new_backend_with_prompt,
     commands::{self, GlobalArgs, ToExitCode, cleanup::CleanupHandler, fail, with_repository_lock},
-    common::{ID, defaults::UI_RATE_ESTIMATOR_WINDOW, global::GlobalOpts},
+    common::{ID, defaults::UI_RATE_ESTIMATOR_WINDOW, global::GlobalOpts, hooks},
     fs::tree::SerializedNodeStream,
     repository::{
         lock::LockHandle,
@@ -141,7 +141,7 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
         );
     }
 
-    with_repository_lock(
+    let repo_result = with_repository_lock(
         global_args.auth_file.as_ref(),
         global_args.key.as_ref(),
         new_backend_with_prompt(global_args.backend_options(false))
@@ -161,11 +161,22 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<()> {
         global_args.retry_lock_duration,
         global_args.no_lock,
         |repo, secure_storage, lock_handle| async move {
+            // Run pre-hook: abort command if it fails
+            hooks::run_pre(hooks::verify(), "verify", &global_args.repo).await?;
+
             run_with_repo(repo, secure_storage, lock_handle, args, json_out).await
         },
     )
-    .await
-    .map_err(|e| {
+    .await;
+
+    let result_str = match &repo_result {
+        Ok(_) => "success".to_string(),
+        Err(e) => format!("{e}"),
+    };
+    // Run post-hook: warning on failure, always continues
+    hooks::run_post(hooks::verify(), "verify", &global_args.repo, &result_str).await;
+
+    repo_result.map_err(|e| {
         if e.is::<commands::error::MapacheError>() {
             e
         } else {

--- a/crates/mapache/src/commands/mod.rs
+++ b/crates/mapache/src/commands/mod.rs
@@ -15,6 +15,7 @@ use crate::{
             MAX_CONFIGURABLE_PACK_SIZE_MIB, MIN_CONFIGURABLE_PACK_SIZE_MIB, init_runtime_defaults,
         },
         global::{THIS_MAPACHE_VERSION, set_global_opts_with_args},
+        hooks,
     },
     repository::{
         keys::KeyManagerError,
@@ -593,6 +594,9 @@ pub async fn parse_and_run() -> i32 {
 
     // Initialize runtime defaults from config
     init_runtime_defaults(config.runtime.as_ref());
+
+    // Initialize hooks from config
+    hooks::init(config.hooks.unwrap_or_default());
 
     macro_rules! with_global {
         ($cmd:ident, $variant:ident) => {{

--- a/crates/mapache/src/common/config.rs
+++ b/crates/mapache/src/common/config.rs
@@ -139,6 +139,61 @@ impl RuntimeConfig {
     }
 }
 
+/// Definition of a single hook (pre or post).
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(default, deny_unknown_fields)]
+pub struct HookDef {
+    /// Shell command to execute.
+    pub command: String,
+    /// Timeout in seconds. If the hook runs longer than this, it is killed.
+    /// `None` means no timeout.
+    pub timeout: Option<u64>,
+}
+
+/// Pre/post hooks for a specific command.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(default, deny_unknown_fields)]
+pub struct CommandHooks {
+    /// Hook executed before the command starts.
+    /// If the command fails (non-zero exit), the command is aborted.
+    pub pre: Option<HookDef>,
+    /// Hook executed after the command finishes, regardless of success/failure.
+    /// Receives MAPACHE_RESULT = "success" or error message.
+    pub post: Option<HookDef>,
+}
+
+/// Hooks configuration (the `[hooks]` section in TOML).
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(default, deny_unknown_fields)]
+pub struct HooksConfig {
+    pub snapshot: Option<CommandHooks>,
+    pub restore: Option<CommandHooks>,
+    pub forget: Option<CommandHooks>,
+    pub clean: Option<CommandHooks>,
+    pub verify: Option<CommandHooks>,
+}
+
+impl HooksConfig {
+    pub(crate) fn template() -> Self {
+        Self {
+            snapshot: Some(CommandHooks {
+                pre: Some(HookDef {
+                    command: "echo 'starting snapshot'".into(),
+                    timeout: None,
+                }),
+                post: Some(HookDef {
+                    command: "echo 'snapshot finished: $MAPACHE_RESULT'".into(),
+                    timeout: None,
+                }),
+            }),
+            restore: None,
+            forget: None,
+            clean: None,
+            verify: None,
+        }
+    }
+}
+
 /// Top-level config structure. Sections map to command names.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(default, deny_unknown_fields)]
@@ -153,6 +208,8 @@ pub struct MapacheConfig {
     pub forget: Option<commands::cmd_forget::CmdArgs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<RuntimeConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hooks: Option<HooksConfig>,
 }
 
 impl MapacheConfig {
@@ -163,6 +220,7 @@ impl MapacheConfig {
             snapshot: Some(commands::cmd_snapshot::CmdArgs::template()),
             restore: Some(commands::cmd_restore::CmdArgs::template()),
             forget: Some(commands::cmd_forget::CmdArgs::template()),
+            hooks: Some(HooksConfig::template()),
         }
     }
 }

--- a/crates/mapache/src/common/hooks.rs
+++ b/crates/mapache/src/common/hooks.rs
@@ -1,0 +1,254 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::common::config::{CommandHooks, HooksConfig};
+
+static HOOKS: OnceLock<HooksConfig> = OnceLock::new();
+
+const DEFAULT_HOOKS: HooksConfig = HooksConfig {
+    snapshot: None,
+    restore: None,
+    forget: None,
+    clean: None,
+    verify: None,
+};
+
+pub(crate) fn init(hooks: HooksConfig) {
+    let _ = HOOKS.set(hooks);
+}
+
+pub(crate) fn config() -> &'static HooksConfig {
+    HOOKS.get().unwrap_or(&DEFAULT_HOOKS)
+}
+
+macro_rules! hook_accessor {
+    ($name:ident) => {
+        pub(crate) fn $name() -> Option<&'static CommandHooks> {
+            config().$name.as_ref()
+        }
+    };
+}
+
+hook_accessor!(snapshot);
+hook_accessor!(restore);
+hook_accessor!(forget);
+hook_accessor!(clean);
+hook_accessor!(verify);
+
+/// Run the pre-hook. Fails (aborts the command) if the hook exits non-zero.
+pub(crate) async fn run_pre(
+    cmd_hooks: Option<&CommandHooks>,
+    command_name: &str,
+    repo: &str,
+) -> Result<()> {
+    let Some(hook) = cmd_hooks.and_then(|h| h.pre.as_ref()) else {
+        return Ok(());
+    };
+
+    if hook.command.is_empty() {
+        return Ok(());
+    }
+
+    let timeout = hook.timeout.map(Duration::from_secs);
+    if let Err(e) = run_hook(&hook.command, command_name, repo, None, timeout).await {
+        tracing::error!(target: "hooks", "pre-hook failed: {e}");
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+/// Run the post-hook. Warnings are logged on failure.
+pub(crate) async fn run_post(
+    cmd_hooks: Option<&CommandHooks>,
+    command_name: &str,
+    repo: &str,
+    result: &str,
+) {
+    let Some(hook) = cmd_hooks.and_then(|h| h.post.as_ref()) else {
+        return;
+    };
+
+    if hook.command.is_empty() {
+        return;
+    }
+
+    let timeout = hook.timeout.map(Duration::from_secs);
+    if let Err(e) = run_hook(&hook.command, command_name, repo, Some(result), timeout).await {
+        tracing::warn!(target: "hooks", "post-hook warning: {e}");
+    }
+}
+
+async fn run_hook(
+    shell_command: &str,
+    command_name: &str,
+    repo: &str,
+    result: Option<&str>,
+    timeout_duration: Option<Duration>,
+) -> Result<()> {
+    tracing::info!(target: "hooks", "Running hook for {command_name}");
+
+    let mut child = if cfg!(windows) {
+        let mut c = Command::new("cmd");
+        c.arg("/C").arg(shell_command);
+        c
+    } else {
+        let mut c = Command::new("sh");
+        c.arg("-c").arg(shell_command);
+        c
+    };
+    child.env("MAPACHE_COMMAND", command_name);
+    child.env("MAPACHE_REPOSITORY", repo);
+
+    if let Some(r) = result {
+        child.env("MAPACHE_RESULT", r);
+    }
+
+    let mut child = child
+        .spawn()
+        .with_context(|| format!("Failed to execute hook for {command_name}"))?;
+
+    let status = match timeout_duration {
+        Some(t) => match timeout(t, child.wait()).await {
+            Ok(Ok(status)) => status,
+            Ok(Err(e)) => return Err(e).context(format!("Hook process for {command_name} failed")),
+            Err(_) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                anyhow::bail!("Hook for {command_name} timed out after {}s", t.as_secs());
+            }
+        },
+        None => child
+            .wait()
+            .await
+            .context(format!("Hook process for {command_name} failed"))?,
+    };
+
+    if !status.success() {
+        let code = status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "signal".to_string());
+        anyhow::bail!("Hook for {command_name} exited with {code}");
+    }
+
+    Ok(())
+}
+
+#[cfg(all(test, not(target_os = "windows")))]
+mod tests {
+    use super::*;
+    use crate::common::config::HookDef;
+
+    fn pre_hooks(command: &str) -> CommandHooks {
+        CommandHooks {
+            pre: Some(HookDef {
+                command: command.into(),
+                timeout: None,
+            }),
+            post: None,
+        }
+    }
+
+    fn post_hooks(command: &str) -> CommandHooks {
+        CommandHooks {
+            pre: None,
+            post: Some(HookDef {
+                command: command.into(),
+                timeout: None,
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_hook() {
+        assert!(run_hook("true", "cmd", "repo", None, None).await.is_ok());
+        assert!(run_hook("false", "cmd", "repo", None, None).await.is_err());
+        assert!(
+            run_hook(
+                "sleep 5",
+                "cmd",
+                "repo",
+                None,
+                Some(Duration::from_millis(100)),
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_hook_env() {
+        assert!(
+            run_hook(
+                r#"test "$MAPACHE_COMMAND" = mycmd"#,
+                "mycmd",
+                "repo",
+                None,
+                None,
+            )
+            .await
+            .is_ok()
+        );
+        assert!(
+            run_hook(
+                r#"test "$MAPACHE_REPOSITORY" = myrepo"#,
+                "cmd",
+                "myrepo",
+                None,
+                None,
+            )
+            .await
+            .is_ok()
+        );
+        assert!(
+            run_hook(
+                r#"test "$MAPACHE_RESULT" = success"#,
+                "cmd",
+                "repo",
+                Some("success"),
+                None,
+            )
+            .await
+            .is_ok()
+        );
+        assert!(
+            run_hook(
+                r#"test -z "${MAPACHE_RESULT-}" "#,
+                "cmd",
+                "repo",
+                None,
+                None,
+            )
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_pre() {
+        assert!(run_pre(None, "cmd", "repo").await.is_ok());
+        assert!(run_pre(Some(&pre_hooks("")), "cmd", "repo").await.is_ok());
+        assert!(
+            run_pre(Some(&pre_hooks("true")), "cmd", "repo")
+                .await
+                .is_ok()
+        );
+        assert!(
+            run_pre(Some(&pre_hooks("false")), "cmd", "repo")
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_post() {
+        run_post(None, "cmd", "repo", "success").await;
+        run_post(Some(&post_hooks("")), "cmd", "repo", "success").await;
+        run_post(Some(&post_hooks("false")), "cmd", "repo", "success").await;
+    }
+}

--- a/crates/mapache/src/common/mod.rs
+++ b/crates/mapache/src/common/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod config;
 pub mod defaults;
 pub mod global;
 pub mod hash;
+pub(crate) mod hooks;
 pub mod traits;
 pub mod vars;
 

--- a/crates/mapache/tests/integration_tests/mod.rs
+++ b/crates/mapache/tests/integration_tests/mod.rs
@@ -42,6 +42,7 @@ mod test_cmd_stats;
 mod test_cmd_sync;
 mod test_cmd_verify;
 mod test_corrupt_repo;
+mod test_hooks;
 mod test_lock_cleanup;
 mod test_permission_denied;
 mod test_zeroize;

--- a/crates/mapache/tests/integration_tests/test_hooks.rs
+++ b/crates/mapache/tests/integration_tests/test_hooks.rs
@@ -1,0 +1,406 @@
+#![cfg(test)]
+#![cfg(not(target_os = "windows"))]
+
+mod tests {
+    use std::path::PathBuf;
+
+    use anyhow::Result;
+    use tempfile::tempdir;
+
+    use mapache::repository::repo::SNAPSHOTS_DIR;
+
+    use crate::{
+        integration_tests::{INTEGRATION_TEST_DATA, TestContext},
+        synthetic::{Dataset, SyntheticData},
+    };
+
+    struct HookTest {
+        ctx: TestContext,
+        config_dir: tempfile::TempDir,
+    }
+
+    impl HookTest {
+        async fn new() -> Result<Self> {
+            let mut test_ctx = TestContext::new().await?;
+            let dataset = Dataset::new().with_structure(INTEGRATION_TEST_DATA);
+            let synthetic = SyntheticData::new(dataset);
+            test_ctx.setup_backup_data(&synthetic)?;
+            test_ctx.init_repo().await?;
+            let config_dir = tempdir()?;
+            std::fs::write(config_dir.path().join("config.toml"), b"")?;
+            Ok(Self {
+                ctx: test_ctx,
+                config_dir,
+            })
+        }
+
+        fn config_path(&self) -> PathBuf {
+            self.config_dir.path().join("config.toml")
+        }
+
+        fn write_config(&self, toml_content: &str) {
+            std::fs::write(self.config_path(), toml_content).unwrap();
+        }
+
+        fn marker(&self, name: &str) -> PathBuf {
+            self.config_dir.path().join(name)
+        }
+
+        fn run(&self, args: &[&str]) -> Result<std::process::Output> {
+            let bin = env!("CARGO_BIN_EXE_mapache");
+            let mut cmd = std::process::Command::new(bin);
+            cmd.arg("--with-config");
+            cmd.arg(self.config_path());
+            cmd.arg(args[0]);
+            cmd.arg("--quiet");
+            cmd.arg("--repo");
+            cmd.arg(&self.ctx.repo_path);
+            cmd.arg("--auth-file");
+            cmd.arg(&self.ctx.auth_file_path);
+            for a in &args[1..] {
+                cmd.arg(a);
+            }
+            cmd.arg("--no-cache");
+            let output = cmd.output()?;
+            if !output.status.success() {
+                eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+            }
+            Ok(output)
+        }
+
+        async fn create_snapshot(&self) -> Result<()> {
+            let backup_dir = self.ctx.backup_data_path.clone().unwrap();
+            let result = self.run(&[
+                "snapshot",
+                &backup_dir.join("0").to_string_lossy(),
+                &backup_dir.join("1").to_string_lossy(),
+                &backup_dir.join("file.txt").to_string_lossy(),
+            ])?;
+            assert!(result.status.success(), "baseline snapshot must succeed");
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_success() -> Result<()> {
+        let harness = HookTest::new().await?;
+        let backup_dir = harness.ctx.backup_data_path.clone().unwrap();
+        let path_0 = &backup_dir.join("0").to_string_lossy().to_string();
+        let path_file = &backup_dir.join("file.txt").to_string_lossy().to_string();
+
+        let pre_marker = harness.marker("snap_pre");
+        harness.write_config(&format!(
+            "[hooks.snapshot.pre]\ncommand = \"touch {}\"\n",
+            pre_marker.display()
+        ));
+        assert!(
+            harness
+                .run(&["snapshot", path_0, path_file])?
+                .status
+                .success()
+        );
+        assert!(pre_marker.exists(), "pre-hook should run");
+
+        let post_marker = harness.marker("snap_post");
+        harness.write_config(&format!(
+            "[hooks.snapshot.post]\ncommand = \"touch {}\"\n",
+            post_marker.display()
+        ));
+        assert!(
+            harness
+                .run(&["snapshot", path_0, path_file])?
+                .status
+                .success()
+        );
+        assert!(post_marker.exists(), "post-hook should run");
+
+        let result_file = harness.marker("snap_result");
+        harness.write_config(&format!(
+            "[hooks.snapshot.post]\ncommand = \"echo $MAPACHE_RESULT > {}\"\n",
+            result_file.display()
+        ));
+        assert!(
+            harness
+                .run(&["snapshot", path_0, path_file])?
+                .status
+                .success()
+        );
+        assert_eq!(std::fs::read_to_string(&result_file)?.trim(), "success");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_failure_and_timeout() -> Result<()> {
+        let harness = HookTest::new().await?;
+        let backup_dir = harness.ctx.backup_data_path.clone().unwrap();
+
+        // pre-hook fails → command aborted
+        harness.write_config("[hooks.snapshot.pre]\ncommand = \"false\"\n");
+        let output = harness.run(&["snapshot", &backup_dir.join("0").to_string_lossy()])?;
+        assert!(!output.status.success(), "pre-hook should abort");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("pre-hook failed") || stderr.contains("exited with"));
+
+        // timeout
+        harness.write_config("[hooks.snapshot.pre]\ncommand = \"sleep 10\"\ntimeout = 1\n");
+        let output = harness.run(&["snapshot", &backup_dir.join("0").to_string_lossy()])?;
+        assert!(!output.status.success(), "should timeout");
+        assert!(String::from_utf8_lossy(&output.stderr).contains("timed out"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_dry_run() -> Result<()> {
+        let harness = HookTest::new().await?;
+        let backup_dir = harness.ctx.backup_data_path.clone().unwrap();
+        let path_0 = &backup_dir.join("0").to_string_lossy().to_string();
+        let path_file = &backup_dir.join("file.txt").to_string_lossy().to_string();
+
+        let pre_marker = harness.marker("snap_dry_pre");
+        harness.write_config(&format!(
+            "[hooks.snapshot.pre]\ncommand = \"touch {}\"\n",
+            pre_marker.display()
+        ));
+        assert!(
+            harness
+                .run(&["snapshot", "--dry-run", path_0, path_file])?
+                .status
+                .success()
+        );
+        assert!(!pre_marker.exists(), "pre-hook should not run on dry-run");
+
+        let post_marker = harness.marker("snap_dry_post");
+        harness.write_config(&format!(
+            "[hooks.snapshot.post]\ncommand = \"touch {}\"\n",
+            post_marker.display()
+        ));
+        assert!(
+            harness
+                .run(&["snapshot", "--dry-run", path_0, path_file])?
+                .status
+                .success()
+        );
+        assert!(!post_marker.exists(), "post-hook should not run on dry-run");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn restore_hooks() -> Result<()> {
+        let harness = HookTest::new().await?;
+        harness.create_snapshot().await?;
+        let snapshot_ids = harness.ctx.get_snapshot_ids()?;
+        let snapshot_id = &snapshot_ids[0];
+
+        // pre-hook → ok
+        let pre_marker = harness.marker("rest_pre");
+        harness.write_config(&format!(
+            "[hooks.restore.pre]\ncommand = \"touch {}\"\n",
+            pre_marker.display()
+        ));
+        let restore_dir = harness.ctx._tmp_dir.path().join("r1");
+        assert!(
+            harness
+                .run(&[
+                    "restore",
+                    snapshot_id,
+                    "--target",
+                    &restore_dir.to_string_lossy()
+                ])?
+                .status
+                .success()
+        );
+        assert!(pre_marker.exists());
+
+        // pre-hook → fail
+        harness.write_config("[hooks.restore.pre]\ncommand = \"false\"\n");
+        let restore_dir_2 = harness.ctx._tmp_dir.path().join("r2");
+        assert!(
+            !harness
+                .run(&[
+                    "restore",
+                    snapshot_id,
+                    "--target",
+                    &restore_dir_2.to_string_lossy()
+                ])?
+                .status
+                .success()
+        );
+
+        // post-hook → ok
+        let post_marker = harness.marker("rest_post");
+        harness.write_config(&format!(
+            "[hooks.restore.post]\ncommand = \"touch {}\"\n",
+            post_marker.display()
+        ));
+        let restore_dir_3 = harness.ctx._tmp_dir.path().join("r3");
+        assert!(
+            harness
+                .run(&[
+                    "restore",
+                    snapshot_id,
+                    "--target",
+                    &restore_dir_3.to_string_lossy()
+                ])?
+                .status
+                .success()
+        );
+        assert!(post_marker.exists());
+
+        // post-hook → MAPACHE_RESULT
+        let result_file = harness.marker("rest_res");
+        harness.write_config(&format!(
+            "[hooks.restore.post]\ncommand = \"echo $MAPACHE_RESULT > {}\"\n",
+            result_file.display()
+        ));
+        let restore_dir_4 = harness.ctx._tmp_dir.path().join("r4");
+        assert!(
+            harness
+                .run(&[
+                    "restore",
+                    snapshot_id,
+                    "--target",
+                    &restore_dir_4.to_string_lossy()
+                ])?
+                .status
+                .success()
+        );
+        assert_eq!(std::fs::read_to_string(&result_file)?.trim(), "success");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn forget_hooks() -> Result<()> {
+        let harness = HookTest::new().await?;
+        harness.create_snapshot().await?;
+
+        // pre-hook → ok
+        let pre_marker = harness.marker("forget_pre");
+        harness.write_config(&format!(
+            "[hooks.forget.pre]\ncommand = \"touch {}\"\n",
+            pre_marker.display()
+        ));
+        let snapshot_id = &harness.ctx.get_snapshot_ids()?[0];
+        let output = harness.run(&["forget", "--force", snapshot_id])?;
+        assert!(output.status.success());
+        assert!(pre_marker.exists());
+        assert_eq!(
+            std::fs::read_dir(harness.ctx.repo_path.join(SNAPSHOTS_DIR))?.count(),
+            0
+        );
+
+        // pre-hook → fail
+        harness.create_snapshot().await?;
+        let snapshot_id = &harness.ctx.get_snapshot_ids()?[0];
+        harness.write_config("[hooks.forget.pre]\ncommand = \"false\"\n");
+        let output = harness.run(&["forget", "--force", snapshot_id])?;
+        assert!(!output.status.success());
+
+        // post-hook → ok
+        harness.create_snapshot().await?;
+        let post_marker = harness.marker("forget_post");
+        harness.write_config(&format!(
+            "[hooks.forget.post]\ncommand = \"touch {}\"\n",
+            post_marker.display()
+        ));
+        let snapshot_id = &harness.ctx.get_snapshot_ids()?[0];
+        assert!(
+            harness
+                .run(&["forget", "--force", snapshot_id])?
+                .status
+                .success()
+        );
+        assert!(post_marker.exists());
+
+        // post-hook → MAPACHE_RESULT
+        harness.create_snapshot().await?;
+        let result_file = harness.marker("forget_res");
+        harness.write_config(&format!(
+            "[hooks.forget.post]\ncommand = \"echo $MAPACHE_RESULT > {}\"\n",
+            result_file.display()
+        ));
+        let snapshot_id = &harness.ctx.get_snapshot_ids()?[0];
+        assert!(
+            harness
+                .run(&["forget", "--force", snapshot_id])?
+                .status
+                .success()
+        );
+        assert_eq!(std::fs::read_to_string(&result_file)?.trim(), "success");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn clean_hooks() -> Result<()> {
+        let harness = HookTest::new().await?;
+        harness.create_snapshot().await?;
+
+        let pre_marker = harness.marker("clean_pre");
+        harness.write_config(&format!(
+            "[hooks.clean.pre]\ncommand = \"touch {}\"\n",
+            pre_marker.display()
+        ));
+        assert!(harness.run(&["clean"])?.status.success());
+        assert!(pre_marker.exists());
+
+        harness.write_config("[hooks.clean.pre]\ncommand = \"false\"\n");
+        assert!(!harness.run(&["clean"])?.status.success());
+
+        let post_marker = harness.marker("clean_post");
+        harness.write_config(&format!(
+            "[hooks.clean.post]\ncommand = \"touch {}\"\n",
+            post_marker.display()
+        ));
+        assert!(harness.run(&["clean"])?.status.success());
+        assert!(post_marker.exists());
+
+        let result_file = harness.marker("clean_res");
+        harness.write_config(&format!(
+            "[hooks.clean.post]\ncommand = \"echo $MAPACHE_RESULT > {}\"\n",
+            result_file.display()
+        ));
+        assert!(harness.run(&["clean"])?.status.success());
+        assert_eq!(std::fs::read_to_string(&result_file)?.trim(), "success");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn verify_hooks() -> Result<()> {
+        let harness = HookTest::new().await?;
+        harness.create_snapshot().await?;
+
+        let pre_marker = harness.marker("verify_pre");
+        harness.write_config(&format!(
+            "[hooks.verify.pre]\ncommand = \"touch {}\"\n",
+            pre_marker.display()
+        ));
+        assert!(harness.run(&["verify"])?.status.success());
+        assert!(pre_marker.exists());
+
+        harness.write_config("[hooks.verify.pre]\ncommand = \"false\"\n");
+        assert!(!harness.run(&["verify"])?.status.success());
+
+        let post_marker = harness.marker("verify_post");
+        harness.write_config(&format!(
+            "[hooks.verify.post]\ncommand = \"touch {}\"\n",
+            post_marker.display()
+        ));
+        assert!(harness.run(&["verify"])?.status.success());
+        assert!(post_marker.exists());
+
+        let result_file = harness.marker("verify_res");
+        harness.write_config(&format!(
+            "[hooks.verify.post]\ncommand = \"echo $MAPACHE_RESULT > {}\"\n",
+            result_file.display()
+        ));
+        assert!(harness.run(&["verify"])?.status.success());
+        assert_eq!(std::fs::read_to_string(&result_file)?.trim(), "success");
+
+        Ok(())
+    }
+}

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -11,22 +11,23 @@
 3. [Quick Start](#3-quick-start)
 4. [Concepts](#4-concepts)
 5. [Configuration](#5-configuration)
-6. [Repository Management](#6-repository-management)
-7. [Taking Snapshots](#7-taking-snapshots)
-8. [Restoring Data](#8-restoring-data)
-9. [Exploring Snapshots](#9-exploring-snapshots)
-10. [Retention Policies](#10-retention-policies)
-11. [Maintenance](#11-maintenance)
-12. [Security & Key Management](#12-security--key-management)
-13. [Bundle Files](#13-bundle-files)
-14. [FUSE Mount](#14-fuse-mount)
-15. [Snapshot Lifecycle](#15-snapshot-lifecycle)
-16. [Experimental TUI](#16-experimental-tui)
-17. [Shell Completions](#17-shell-completions)
-18. [Environment Variables](#18-environment-variables)
-19. [Global Options Reference](#19-global-options-reference)
-20. [Full Command Reference](#20-full-command-reference)
-21. [Troubleshooting & FAQ](#21-troubleshooting--faq)
+6. [Hooks](#6-hooks)
+7. [Repository Management](#7-repository-management)
+8. [Taking Snapshots](#8-taking-snapshots)
+9. [Restoring Data](#9-restoring-data)
+10. [Exploring Snapshots](#10-exploring-snapshots)
+11. [Retention Policies](#11-retention-policies)
+12. [Maintenance](#12-maintenance)
+13. [Security & Key Management](#13-security--key-management)
+14. [Bundle Files](#14-bundle-files)
+15. [FUSE Mount](#15-fuse-mount)
+16. [Snapshot Lifecycle](#16-snapshot-lifecycle)
+17. [Experimental TUI](#17-experimental-tui)
+18. [Shell Completions](#18-shell-completions)
+19. [Environment Variables](#19-environment-variables)
+20. [Global Options Reference](#20-global-options-reference)
+21. [Full Command Reference](#21-full-command-reference)
+22. [Troubleshooting & FAQ](#22-troubleshooting--faq)
 
 ---
 
@@ -325,7 +326,84 @@ failing.
 
 ---
 
-## 6. Repository Management
+## 6. Hooks
+
+Mapache supports running custom shell scripts before and after certain commands.
+This is useful for notifications, logging, mounting/unmounting filesystems,
+or any pre/post processing.
+
+### Configuration
+
+Hooks are defined in the TOML config file under `[hooks.<command>]` sections:
+
+```toml
+[hooks.snapshot.pre]
+command = "echo 'Starting snapshot'"
+timeout = 300
+
+[hooks.snapshot.post]
+command = "/usr/local/bin/notify.sh"
+```
+
+Each hook can specify:
+
+| Field | Type | Description |
+|---|---|---|
+| `command` | string | Shell command to execute (required) |
+| `timeout` | integer | Max runtime in seconds (optional; no timeout if omitted) |
+
+### Pre and Post Hooks
+
+- **Pre hooks** run before the command starts. If the hook exits with a non-zero
+  status, the command is **aborted** immediately.
+- **Post hooks** run after the command finishes, regardless of success or
+  failure. Non-zero exit status only logs a warning — the command is not
+  affected.
+
+### Supported Commands
+
+Hooks can be configured for: `snapshot`, `restore`, `forget`, `clean`, and
+`verify`.
+
+### Environment Variables
+
+The following variables are passed to every hook script:
+
+| Variable | Description |
+|---|---|
+| `MAPACHE_COMMAND` | The mapache command being run (e.g. `snapshot`, `restore`) |
+| `MAPACHE_REPOSITORY` | The repository URL |
+| `MAPACHE_RESULT` | (Post hooks only) `"success"` or the error message if the command failed |
+
+### Dry Run
+
+When a command is run with `--dry-run`, hooks are **not executed**.
+
+### Example
+
+```toml
+[hooks.snapshot.pre]
+command = "df -h /backup > /tmp/disk-space-before.txt"
+
+[hooks.snapshot.post]
+command = """
+  if [ "$MAPACHE_RESULT" = "success" ]; then
+    curl -s -X POST https://hooks.example.com/backup-ok \
+      -d "repo=$MAPACHE_REPOSITORY&cmd=$MAPACHE_COMMAND"
+  fi
+"""
+
+[hooks.clean.pre]
+command = "/usr/local/bin/maintenance-start.sh"
+timeout = 60
+
+[hooks.clean.post]
+command = "/usr/local/bin/maintenance-end.sh"
+```
+
+---
+
+## 7. Repository Management
 
 ### `init` — Initialize a Repository
 
@@ -461,7 +539,7 @@ The command will:
 
 ---
 
-## 7. Taking Snapshots
+## 8. Taking Snapshots
 
 ### Basic Usage
 
@@ -595,7 +673,7 @@ After a successful snapshot, mapache displays:
 
 ---
 
-## 8. Restoring Data
+## 9. Restoring Data
 
 ### Basic Usage
 
@@ -691,7 +769,7 @@ Displays progress, a summary of errors and warnings, and total duration.
 
 ---
 
-## 9. Exploring Snapshots
+## 10. Exploring Snapshots
 
 ### `log` — List Snapshots
 
@@ -815,7 +893,7 @@ manual inspection.
 
 ---
 
-## 10. Retention Policies
+## 11. Retention Policies
 
 ### `forget` — Remove Snapshots
 
@@ -875,7 +953,7 @@ Shows which snapshots would be kept and removed without making changes.
 
 ---
 
-## 11. Maintenance
+## 12. Maintenance
 
 ### `clean` — Garbage Collection
 
@@ -947,7 +1025,7 @@ Requires an exclusive lock. May take significant time on large repositories.
 
 ---
 
-## 12. Security & Key Management
+## 13. Security & Key Management
 
 Mapache uses a dual-layer encryption model:
 
@@ -1016,7 +1094,7 @@ later with `--key-file` to authenticate without username/password.
 
 ---
 
-## 13. Bundle Files
+## 14. Bundle Files
 
 The `bundle` command creates, extracts, or mounts self-contained `.mapache`
 bundle files. Bundles are encrypted, deduplicated archives that can be
@@ -1068,7 +1146,7 @@ from the repository password.
 
 ---
 
-## 14. FUSE Mount
+## 15. FUSE Mount
 
 ### Mount a Repository (Unix only, `fuse` feature)
 
@@ -1105,7 +1183,7 @@ Press `Ctrl+C` to unmount.
 
 ---
 
-## 15. Snapshot Lifecycle
+## 16. Snapshot Lifecycle
 
 ### `amend` — Modify a Snapshot
 
@@ -1146,7 +1224,7 @@ extension) by `forget`. The snapshot is reactivated and will appear in
 
 ---
 
-## 16. Terminal User Interface
+## 17. Terminal User Interface
 
 ```bash
 mapache tui -r <URL>
@@ -1168,7 +1246,7 @@ Requires the `tui` feature (enabled by default) and a supported terminal.
 
 ---
 
-## 17. Shell Completions
+## 18. Shell Completions
 
 ```bash
 mapache completion --shell bash --path /etc/bash_completion.d/
@@ -1182,7 +1260,7 @@ include: `bash`, `zsh`, `fish`, `powershell`, `elvish`, and `nushell`.
 
 ---
 
-## 18. Environment Variables
+## 19. Environment Variables
 
 | Variable | Description |
 |---|---|
@@ -1200,7 +1278,7 @@ authentication prompts are skipped.
 
 ---
 
-## 19. Global Options Reference
+## 20. Global Options Reference
 
 These options are available on most commands (exceptions: `bundle`, `cache`,
 `completion` do not use repository connection).
@@ -1261,7 +1339,7 @@ These options are available on most commands (exceptions: `bundle`, `cache`,
 
 ---
 
-## 20. Full Command Reference
+## 21. Full Command Reference
 
 ### `mapache init`
 Initialize a new backup repository.


### PR DESCRIPTION
Pre- and post-hooks are supported by the following commands:
  - snapshot
  - restore
  - forget
  - clean
  - verify