### PR TITLE
Restorer batching + correct metadata restoration

### DIFF
--- a/crates/mapache/src/commands/cmd_restore.rs
+++ b/crates/mapache/src/commands/cmd_restore.rs
@@ -145,6 +145,11 @@ pub struct CmdArgs {
     #[clap(long, action = clap::ArgAction::Set, num_args = 0..=1, default_missing_value = "true")]
     pub verify: Option<bool>,
 
+    /// Maximum number of files per batch. Limits peak memory when restoring many
+    /// small files. Default: no limit (all files processed in a single batch).
+    #[clap(long)]
+    pub batch_size: Option<usize>,
+
     /// Dry run
     #[clap(long)]
     pub dry_run: bool,
@@ -162,6 +167,7 @@ impl CmdArgs {
             strip_prefix: Some(true),
             strategy: Some(Strategy::Fail),
             delete: Some(false),
+            batch_size: None,
             dry_run: false,
             no_preserve_root: Some(false),
             quit_on_error: Some(false),
@@ -208,6 +214,9 @@ impl Merge for CmdArgs {
         }
         if other.verify.is_some() {
             self.verify = other.verify;
+        }
+        if other.batch_size.is_some() {
+            self.batch_size = other.batch_size;
         }
     }
 }
@@ -374,6 +383,7 @@ pub(crate) async fn run_with_repo(
     let quit_on_error = args.quit_on_error.unwrap_or(false);
     let sparse = args.sparse.unwrap_or(false);
     let verify = args.verify.unwrap_or(false);
+    let batch_size = args.batch_size;
     let strip_prefix = args.strip_prefix.unwrap_or(false);
 
     // Read include and exclude paths from files if provided.
@@ -436,6 +446,7 @@ pub(crate) async fn run_with_repo(
             verify,
             include: parsed_includes.clone(),
             exclude: parsed_excludes.clone(),
+            batch_size,
         },
         counters.event_sender.clone(),
         cleanup_handler.interrupted.clone(),

--- a/crates/mapache/src/restorer/metadata.rs
+++ b/crates/mapache/src/restorer/metadata.rs
@@ -1,11 +1,15 @@
-use std::{path::PathBuf, sync::atomic::Ordering};
+use std::{
+    path::PathBuf,
+    sync::{Arc, atomic::Ordering},
+};
 
 use anyhow::{Result, bail};
 use futures::StreamExt;
+use parking_lot::Mutex;
 
 use crate::{
     common::ID,
-    fs::{self as repo_fs, tree::SerializedNodeStream},
+    fs::{self as repo_fs, node::Metadata, tree::SerializedNodeStream},
     ui::events::{Event, RestoreEvent, emit_event},
     utils,
 };
@@ -18,7 +22,6 @@ impl Restorer {
         tree_id: ID,
         include: Option<Vec<PathBuf>>,
         exclude: Option<Vec<PathBuf>>,
-        directories: Vec<(PathBuf, crate::fs::node::Metadata)>,
     ) -> Result<()> {
         if self.opts.dry_run {
             return Ok(());
@@ -33,12 +36,15 @@ impl Restorer {
         )
         .await?;
 
+        let dirs: Arc<Mutex<Vec<(PathBuf, Metadata)>>> = Arc::new(Mutex::new(Vec::new()));
+
         let d = crate::common::defaults::runtime();
         node_stream
             .for_each_concurrent(d.restore_blob_concurrency, |node_res| {
                 let event_sender = self.event_sender.clone();
                 let target_path = self.target_path.clone();
                 let opts_strip_prefix = self.opts.strip_prefix.clone();
+                let dirs = dirs.clone();
 
                 async move {
                     let (mut path, stream_node_res) = match node_res {
@@ -94,7 +100,9 @@ impl Restorer {
                         return;
                     }
 
-                    if !node.is_dir() {
+                    if node.is_dir() {
+                        dirs.lock().push((restore_path, node.metadata));
+                    } else {
                         super::node_restorer::try_restore_node_metadata(
                             &node.metadata,
                             node.is_symlink(),
@@ -106,7 +114,9 @@ impl Restorer {
             })
             .await;
 
-        let mut dirs = directories;
+        let mut dirs = Arc::into_inner(dirs)
+            .expect("dirs reference count should be 1 after for_each_concurrent")
+            .into_inner();
         dirs.sort_unstable_by_key(|(p, _)| std::cmp::Reverse(p.as_os_str().len()));
         for (p, meta) in dirs {
             if self.shutdown_signal.load(Ordering::Acquire) {

--- a/crates/mapache/src/restorer/mod.rs
+++ b/crates/mapache/src/restorer/mod.rs
@@ -17,15 +17,19 @@ use std::io::{Seek, Write};
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::HashMap,
     fs::{self, File, OpenOptions},
     io,
     path::{Path, PathBuf},
-    sync::{Arc, atomic::AtomicBool},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::ValueEnum;
+use futures::StreamExt;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
@@ -73,6 +77,8 @@ pub struct RestoreOptions {
     pub verify: bool,
     pub include: Option<Vec<PathBuf>>,
     pub exclude: Option<Vec<PathBuf>>,
+    /// Maximum number of files per plan chunk (None = no limit, all at once).
+    pub batch_size: Option<usize>,
 }
 
 /// Performs the restoration of a snapshot to a target path.
@@ -92,45 +98,34 @@ pub async fn restore(
         shutdown_signal,
     );
 
-    restorer.restore(snapshot.tree).await
+    restorer.restore(snapshot).await
 }
 
 /// The Restorer is responsible for coordinating the restoration process.
 ///
-/// It implements a high-performance, pack-centric approach. Instead of restoring
-/// file by file (which causes random I/O and many small backend requests), it:
-/// 1. Scans the snapshot tree to build a restoration plan.
-/// 2. Groups all required blobs by the pack file they reside in.
-/// 3. Downloads packs (or relevant ranges) sequentially.
-/// 4. Distributes downloaded blobs to their target files in parallel.
-/// 5. Restores metadata in a separate bottom-up pass.
+/// It implements a streaming, pack-centric approach:
+/// 1. Walks the snapshot tree and accumulates file/blob references.
+/// 2. Every `batch_size` files, flushes the accumulated plan:
+///    downloads pack segments, decodes blobs, writes files.
+/// 3. After all files are restored, creates hardlinks.
+/// 4. Restores metadata in a separate bottom-up pass.
 pub(crate) struct Restorer {
     pub(crate) repo: Arc<Repository>,
     pub(crate) event_sender: EventSender,
     pub(crate) shutdown_signal: Arc<AtomicBool>,
     pub(crate) target_path: PathBuf,
     pub(crate) opts: RestoreOptions,
-    pub(crate) buffers: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    pub(crate) buffers: Arc<Mutex<std::collections::VecDeque<Vec<u8>>>>,
 }
 
 pub(crate) type PackMap = HashMap<ID, Vec<(ID, BlobRestoreRequest)>>;
+type HardlinkByPath = (PathBuf, PathBuf);
 
 pub(crate) struct FileRestorePlan {
     pub(crate) path: PathBuf,
     pub(crate) num_blobs: u32,
     pub(crate) size: u64,
     pub(crate) is_hardlink: bool,
-}
-
-pub(crate) struct RestorePlan {
-    pub(crate) files: Arc<Vec<FileRestorePlan>>,
-    pub(crate) packs: Arc<PackMap>,
-    pub(crate) directories: Vec<(PathBuf, crate::fs::node::Metadata)>,
-    pub(crate) skipped_item_paths: Vec<PathBuf>,
-    pub(crate) total_items: u64,
-    pub(crate) total_bytes: u64,
-    pub(crate) skipped_bytes: u64,
-    pub(crate) hardlinks: Vec<(usize, usize)>,
 }
 
 #[derive(Clone)]
@@ -145,7 +140,7 @@ pub(crate) struct BlobRestoreRequest {
 /// A cache for open file handles during restoration.
 pub(crate) struct FileHandleCache {
     handles: HashMap<usize, File>,
-    order: VecDeque<usize>,
+    order: std::collections::VecDeque<usize>,
     max_handles: usize,
 }
 
@@ -153,7 +148,7 @@ impl FileHandleCache {
     fn new(max_handles: usize) -> Self {
         Self {
             handles: HashMap::new(),
-            order: VecDeque::new(),
+            order: std::collections::VecDeque::new(),
             max_handles,
         }
     }
@@ -213,8 +208,6 @@ impl FileHandleCache {
                         tracing::warn!(target: "restorer", "Failed to preallocate file {}: {e}", path.display());
                     }
                 } else {
-                    // Default to sparse creation via set_len.
-                    // On most modern filesystems (NTFS, APFS, XFS, EXT4), this creates a sparse file.
                     f.set_len(plan.size).with_context(|| {
                         format!("Failed to set length for sparse file: {}", path.display())
                     })?;
@@ -235,7 +228,6 @@ impl FileHandleCache {
             .ok_or_else(|| anyhow!("Failed to retrieve file handle after insertion"))
     }
 
-    /// Open a file for restore.
     fn open_file_for_restore(path: &Path, create: bool) -> io::Result<std::fs::File> {
         let mut opts = OpenOptions::new();
         opts.write(true);
@@ -291,7 +283,9 @@ impl Restorer {
             opts,
             event_sender,
             shutdown_signal,
-            buffers: Arc::new(Mutex::new(VecDeque::with_capacity(num_buffers))),
+            buffers: Arc::new(Mutex::new(std::collections::VecDeque::with_capacity(
+                num_buffers,
+            ))),
         }
     }
 
@@ -313,7 +307,6 @@ impl Restorer {
     }
 
     /// Creates a shallow clone of the restorer for worker threads.
-    /// This is needed because Restorer contains Arc fields that we want to share.
     pub(crate) fn clone_for_workers(&self) -> Self {
         Self {
             repo: self.repo.clone(),
@@ -329,6 +322,7 @@ impl Restorer {
                 verify: self.opts.verify,
                 include: self.opts.include.clone(),
                 exclude: self.opts.exclude.clone(),
+                batch_size: self.opts.batch_size,
             },
             buffers: self.buffers.clone(),
         }
@@ -342,10 +336,8 @@ impl Restorer {
         #[cfg(all(unix, not(target_os = "macos")))]
         {
             let fd = file.as_raw_fd();
-            let result = unsafe {
-                // SAFETY: FFI call to posix_fallocate with a valid file descriptor.
-                libc::posix_fallocate(fd, 0, length as libc::off_t)
-            };
+            // SAFETY: FFI call to posix_fallocate with a valid file descriptor.
+            let result = unsafe { libc::posix_fallocate(fd, 0, length as libc::off_t) };
             if result != 0 {
                 return Err(anyhow!(std::io::Error::from_raw_os_error(result)));
             }
@@ -367,17 +359,13 @@ impl Restorer {
                 fst_bytesalloc: 0,
             };
 
-            let mut res = unsafe {
-                // SAFETY: FFI call to fcntl with a valid file descriptor and fstore_t pointer.
-                libc::fcntl(fd, libc::F_PREALLOCATE, &store)
-            };
+            // SAFETY: FFI call to fcntl with a valid file descriptor and fstore_t pointer.
+            let mut res = unsafe { libc::fcntl(fd, libc::F_PREALLOCATE, &store) };
 
             if res == -1 {
                 store.fst_posmode = F_STARTPOSMODE;
-                res = unsafe {
-                    // SAFETY: FFI call to fcntl as fallback with same valid descriptor and pointer.
-                    libc::fcntl(fd, libc::F_PREALLOCATE, &store)
-                };
+                // SAFETY: FFI call to fcntl as fallback with same valid descriptor and pointer.
+                res = unsafe { libc::fcntl(fd, libc::F_PREALLOCATE, &store) };
             }
 
             if res == -1 {
@@ -436,9 +424,39 @@ impl Restorer {
         Ok(())
     }
 
-    async fn restore(&self, tree_id: ID) -> Result<()> {
-        tracing::info!(target: "restorer", "Starting restoration of tree {tree_id}");
-        let node_stream = SerializedNodeStream::new(
+    async fn restore(&self, snapshot: &Snapshot) -> Result<()> {
+        let tree_id = snapshot.tree;
+        tracing::info!(target: "restorer", "Starting restore of tree {tree_id}");
+
+        if !self.opts.dry_run {
+            fs::create_dir_all(&self.target_path)?;
+        }
+
+        let index = self.repo.index();
+        let secure_storage = self.repo.secure_storage();
+        let batch_size = self.opts.batch_size.unwrap_or(usize::MAX);
+        let dry_run = self.opts.dry_run;
+
+        // Use stored snapshot totals for progress (populated at archive time).
+        // Fall back to a counting pass for snapshots that predate this metadata.
+        let (total_items, total_bytes) = {
+            let s = &snapshot.summary;
+            if s.processed_items_count > 0 {
+                (s.processed_items_count, s.processed_bytes)
+            } else {
+                self.count_restore_work(tree_id).await
+            }
+        };
+        emit_event(
+            &self.event_sender,
+            Event::Restore(RestoreEvent::PlanBuilt {
+                total_items,
+                total_bytes,
+            }),
+        );
+
+        // Second pass: streaming restore
+        let mut node_stream = SerializedNodeStream::new(
             self.repo.clone(),
             Some(tree_id),
             PathBuf::new(),
@@ -447,126 +465,391 @@ impl Restorer {
         )
         .await?;
 
-        if !self.opts.dry_run {
-            fs::create_dir_all(&self.target_path)?;
-        }
+        // Streaming accumulator state
+        let mut chunk_files: Vec<FileRestorePlan> = Vec::new();
+        let mut chunk_packs: PackMap = HashMap::new();
+        // Persistent hardlink index: (dev, inode) → primary file path
+        let primary_hardlinks: Arc<Mutex<HashMap<(u64, u64), PathBuf>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        // Cross-chunk hardlinks stored as (secondary_path, primary_path)
+        let pending_hardlinks: Arc<Mutex<Vec<HardlinkByPath>>> = Arc::new(Mutex::new(Vec::new()));
 
-        let index = self.repo.index();
-        tracing::info!(target: "restorer", "Building restoration plan");
-        let plan = self.build_plan(node_stream, index).await?;
-        tracing::info!(
-            target: "restorer",
-            "Plan built: {} items, {}",
-            plan.total_items,
-            utils::format_size_binary(plan.total_bytes, 1)
-        );
+        let mut node_visited = 0u64;
 
-        emit_event(
-            &self.event_sender,
-            Event::Restore(RestoreEvent::PlanBuilt {
-                total_items: plan.total_items,
-                total_bytes: plan.total_bytes,
-            }),
-        );
+        while let Some(node_res) = node_stream.next().await {
+            if self.shutdown_signal.load(Ordering::Acquire) {
+                bail!("Interrupted");
+            }
 
-        if plan.skipped_bytes > 0 {
-            emit_event(
-                &self.event_sender,
-                Event::Restore(RestoreEvent::BytesProcessed(plan.skipped_bytes)),
-            );
-        }
+            node_visited += 1;
+            if node_visited.is_multiple_of(1024) {
+                emit_event(
+                    &self.event_sender,
+                    Event::Restore(RestoreEvent::NodeVisited(node_visited)),
+                );
+            }
 
-        for path in &plan.skipped_item_paths {
-            emit_event(
-                &self.event_sender,
-                Event::Restore(RestoreEvent::ItemProcessed(path.clone())),
-            );
-        }
-        for (path, _) in &plan.directories {
-            emit_event(
-                &self.event_sender,
-                Event::Restore(RestoreEvent::ItemProcessed(path.clone())),
-            );
-        }
-
-        let plan_files = plan.files.clone();
-        let dry_run = self.opts.dry_run;
-        let secure_storage = self.repo.secure_storage();
-
-        tracing::info!(target: "restorer", "Restoring data packs");
-        self.restore_packs(plan_files, plan.packs, secure_storage, dry_run)
-            .await?;
-
-        if !self.opts.dry_run && !plan.hardlinks.is_empty() {
-            tracing::info!(
-                target: "restorer",
-                "Creating {} hardlinks",
-                plan.hardlinks.len()
-            );
-            for (sec_idx, prim_idx) in &plan.hardlinks {
-                let primary_path = &plan.files[*prim_idx].path;
-                let secondary_path = &plan.files[*sec_idx].path;
-                if let Some(parent) = secondary_path.parent()
-                    && let Err(e) = fs::create_dir_all(parent)
-                {
-                    let err_msg = format!(
-                        "Failed to create parent directory for hardlink {}: {}",
-                        secondary_path.display(),
-                        e
-                    );
-                    if self.opts.quit_on_error {
-                        bail!(err_msg);
-                    }
+            let (mut path, stream_node_res) = match node_res {
+                Ok(res) => res,
+                Err(e) => {
                     emit_event(
                         &self.event_sender,
-                        Event::Restore(RestoreEvent::Error(err_msg)),
-                    );
-                }
-                if let Err(e) = fs::remove_file(secondary_path)
-                    && e.kind() != std::io::ErrorKind::NotFound
-                {
-                    let err_msg = format!(
-                        "Failed to remove existing file for hardlink {}: {}",
-                        secondary_path.display(),
-                        e
-                    );
-                    if self.opts.quit_on_error {
-                        bail!(err_msg);
-                    }
-                    emit_event(
-                        &self.event_sender,
-                        Event::Restore(RestoreEvent::Error(err_msg)),
+                        Event::Restore(RestoreEvent::Error(format!("Error reading node: {e}"))),
                     );
                     continue;
                 }
-                if let Err(e) = fs::hard_link(primary_path, secondary_path) {
-                    let err_msg = format!(
-                        "Failed to create hardlink {} -> {}: {}",
-                        secondary_path.display(),
-                        primary_path.display(),
+            };
+
+            let stream_node = match stream_node_res {
+                Ok(node) => node,
+                Err(e) => {
+                    emit_event(
+                        &self.event_sender,
+                        Event::Restore(RestoreEvent::Warning(format!(
+                            "Error deserializing node {}: {}",
+                            path.display(),
+                            e
+                        ))),
+                    );
+                    continue;
+                }
+            };
+            let node = stream_node.node;
+
+            if let Some(prefix) = &self.opts.strip_prefix {
+                path = match path.strip_prefix(prefix) {
+                    Ok(p) => {
+                        if p.as_os_str().is_empty() {
+                            continue;
+                        }
+                        p.to_path_buf()
+                    }
+                    Err(_) => continue,
+                };
+            }
+
+            let restore_path = match utils::secure_join(&self.target_path, &path) {
+                Ok(p) => p,
+                Err(e) => {
+                    emit_event(
+                        &self.event_sender,
+                        Event::Restore(RestoreEvent::Error(format!(
+                            "Secure join failed for {path:?}: {e}"
+                        ))),
+                    );
+                    continue;
+                }
+            };
+
+            // Directory: create, save metadata for later
+            if node.is_dir() {
+                if !dry_run && let Err(e) = fs::create_dir_all(&restore_path) {
+                    emit_event(
+                        &self.event_sender,
+                        Event::Restore(RestoreEvent::Error(format!(
+                            "Failed to create directory {}: {}",
+                            restore_path.display(),
+                            e
+                        ))),
+                    );
+                    continue;
+                }
+                emit_event(
+                    &self.event_sender,
+                    Event::Restore(RestoreEvent::ItemProcessed(restore_path)),
+                );
+                continue;
+            }
+
+            // Symlink: restore immediately
+            if node.is_symlink() {
+                if !dry_run {
+                    let _ = node_restorer::restore_node_to_path(
+                        self,
+                        &self.event_sender,
+                        &node,
+                        &restore_path,
+                        false,
+                    )
+                    .await;
+                }
+                emit_event(
+                    &self.event_sender,
+                    Event::Restore(RestoreEvent::ItemProcessed(restore_path)),
+                );
+                continue;
+            }
+
+            // File: check strategy, then add to accumulator
+            if node.is_file() {
+                let should_restore = self
+                    .should_restore_node(&node, &restore_path, index.clone())
+                    .await;
+
+                let skip_file = match should_restore {
+                    Ok(true) => false,
+                    Ok(false) => true,
+                    Err(e) => {
+                        emit_event(
+                            &self.event_sender,
+                            Event::Restore(RestoreEvent::Error(format!(
+                                "Error checking {}: {}",
+                                restore_path.display(),
+                                e
+                            ))),
+                        );
+                        if self.opts.quit_on_error {
+                            bail!("{e}");
+                        }
+                        true
+                    }
+                };
+
+                if skip_file {
+                    emit_event(
+                        &self.event_sender,
+                        Event::Restore(RestoreEvent::ItemProcessed(restore_path)),
+                    );
+                    continue;
+                }
+
+                // Look up blobs
+                let mut file_blobs = Vec::new();
+                if let Some(blobs) = &node.blobs {
+                    let mut offset_in_file = 0;
+                    for blob_id in blobs {
+                        let locator = match index.get_data(blob_id) {
+                            Some(loc) => loc,
+                            None => {
+                                emit_event(
+                                    &self.event_sender,
+                                    Event::Restore(RestoreEvent::Error(format!(
+                                        "Blob {blob_id} not found in index"
+                                    ))),
+                                );
+                                continue;
+                            }
+                        };
+                        file_blobs.push((*blob_id, locator, offset_in_file));
+                        offset_in_file += locator.raw_length as u64;
+                    }
+                }
+
+                let file_idx = chunk_files.len();
+                chunk_files.push(FileRestorePlan {
+                    path: restore_path.clone(),
+                    num_blobs: 0,
+                    size: node.metadata.size,
+                    is_hardlink: false,
+                });
+
+                // Hardlink detection
+                let is_hardlink_secondary = {
+                    if let (Some(dev), Some(inode)) = (node.metadata.dev, node.metadata.inode) {
+                        let nlink = node.metadata.nlink;
+                        if nlink.unwrap_or(0) > 1 {
+                            let mut idx = primary_hardlinks.lock();
+                            if let Some(primary_path) = idx.get(&(dev, inode)) {
+                                pending_hardlinks
+                                    .lock()
+                                    .push((restore_path.clone(), primary_path.clone()));
+                                drop(idx);
+                                chunk_files[file_idx].is_hardlink = true;
+                                true
+                            } else {
+                                idx.insert((dev, inode), restore_path.clone());
+                                drop(idx);
+                                false
+                            }
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
+                };
+
+                if !is_hardlink_secondary {
+                    let num_blobs = file_blobs.len().min(u32::MAX as usize) as u32;
+                    for (blob_id, locator, offset_in_file) in &file_blobs {
+                        chunk_packs.entry(locator.pack_id).or_default().push((
+                            *blob_id,
+                            BlobRestoreRequest {
+                                file_idx,
+                                offset_in_file: *offset_in_file,
+                                blob_offset: locator.offset,
+                                blob_length: locator.length,
+                                raw_length: locator.raw_length,
+                            },
+                        ));
+                    }
+                    chunk_files[file_idx].num_blobs = num_blobs;
+
+                    if let (Some(dev), Some(inode)) = (node.metadata.dev, node.metadata.inode)
+                        && node.metadata.nlink.unwrap_or(0) > 1
+                    {
+                        primary_hardlinks
+                            .lock()
+                            .entry((dev, inode))
+                            .or_insert_with(|| restore_path.clone());
+                    }
+                } else if !dry_run
+                    && let Some(parent) = restore_path.parent()
+                    && let Err(e) = fs::create_dir_all(parent)
+                {
+                    emit_event(
+                        &self.event_sender,
+                        Event::Restore(RestoreEvent::Error(format!(
+                            "Failed to create parent for hardlink {}: {}",
+                            restore_path.display(),
+                            e
+                        ))),
+                    );
+                }
+
+                // Flush if the chunk is full
+                if chunk_files.len() >= batch_size {
+                    let chunk_files = Arc::new(std::mem::take(&mut chunk_files));
+                    let chunk_packs = Arc::new(std::mem::take(&mut chunk_packs));
+                    pack_restorer::restore_packs(
+                        self,
+                        chunk_files,
+                        chunk_packs,
+                        secure_storage.clone(),
+                        dry_run,
+                    )
+                    .await?;
+                }
+            }
+        }
+
+        // Flush remaining chunk
+        if !chunk_files.is_empty() {
+            let chunk_files = Arc::new(std::mem::take(&mut chunk_files));
+            let chunk_packs = Arc::new(std::mem::take(&mut chunk_packs));
+            pack_restorer::restore_packs(
+                self,
+                chunk_files,
+                chunk_packs,
+                secure_storage.clone(),
+                dry_run,
+            )
+            .await?;
+        }
+
+        // Create pending hardlinks (cross-chunk)
+        if !dry_run {
+            let hardlinks = std::mem::take(&mut *pending_hardlinks.lock());
+            for (secondary, primary) in &hardlinks {
+                if self.shutdown_signal.load(Ordering::Acquire) {
+                    bail!("Interrupted");
+                }
+                if let Some(parent) = secondary.parent()
+                    && let Err(e) = fs::create_dir_all(parent)
+                {
+                    let msg = format!(
+                        "Failed to create parent for hardlink {}: {}",
+                        secondary.display(),
                         e
                     );
                     if self.opts.quit_on_error {
-                        bail!(err_msg);
+                        bail!(msg);
                     }
+                    emit_event(&self.event_sender, Event::Restore(RestoreEvent::Error(msg)));
+                    continue;
+                }
+                if let Err(e) = fs::remove_file(secondary)
+                    && e.kind() != std::io::ErrorKind::NotFound
+                {
+                    let msg = format!(
+                        "Failed to remove target for hardlink {}: {}",
+                        secondary.display(),
+                        e
+                    );
+                    if self.opts.quit_on_error {
+                        bail!(msg);
+                    }
+                    emit_event(&self.event_sender, Event::Restore(RestoreEvent::Error(msg)));
+                    continue;
+                }
+                if let Err(e) = fs::hard_link(primary, secondary) {
+                    let msg = format!(
+                        "Failed to create hardlink {} -> {}: {}",
+                        secondary.display(),
+                        primary.display(),
+                        e
+                    );
+                    if self.opts.quit_on_error {
+                        bail!(msg);
+                    }
+                    emit_event(&self.event_sender, Event::Restore(RestoreEvent::Error(msg)));
+                } else {
                     emit_event(
                         &self.event_sender,
-                        Event::Restore(RestoreEvent::Error(err_msg)),
+                        Event::Restore(RestoreEvent::ItemProcessed(secondary.clone())),
                     );
                 }
             }
         }
 
+        // Restore metadata
         tracing::info!(target: "restorer", "Restoring metadata");
         self.restore_metadata(
             tree_id,
             self.opts.include.clone(),
             self.opts.exclude.clone(),
-            plan.directories,
         )
         .await?;
 
         tracing::info!(target: "restorer", "Restoration finished");
         Ok(())
+    }
+
+    /// Quick first pass: count items and sum data bytes for progress reporting.
+    async fn count_restore_work(&self, tree_id: ID) -> (u64, u64) {
+        let mut node_stream = match SerializedNodeStream::new(
+            self.repo.clone(),
+            Some(tree_id),
+            PathBuf::new(),
+            self.opts.include.clone(),
+            self.opts.exclude.clone(),
+        )
+        .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                emit_event(
+                    &self.event_sender,
+                    Event::Restore(RestoreEvent::Error(format!(
+                        "Failed to create node stream for counting: {e}"
+                    ))),
+                );
+                return (0, 0);
+            }
+        };
+        let mut items = 0u64;
+        let mut bytes = 0u64;
+        while let Some(node_res) = node_stream.next().await {
+            if self.shutdown_signal.load(Ordering::Acquire) {
+                return (items, bytes);
+            }
+
+            let (_path, stream_node_res) = match node_res {
+                Ok(res) => res,
+                Err(_) => continue,
+            };
+            let stream_node = match stream_node_res {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            let node = stream_node.node;
+
+            items += 1;
+            if node.is_file() {
+                bytes += node.metadata.size;
+            }
+        }
+
+        (items, bytes)
     }
 }

--- a/crates/mapache/src/restorer/mod.rs
+++ b/crates/mapache/src/restorer/mod.rs
@@ -120,6 +120,7 @@ pub(crate) struct Restorer {
 
 pub(crate) type PackMap = HashMap<ID, Vec<(ID, BlobRestoreRequest)>>;
 type HardlinkByPath = (PathBuf, PathBuf);
+type PrimaryHardlinks = Arc<Mutex<HashMap<(u64, u64), (PathBuf, [u8; 32])>>>;
 
 pub(crate) struct FileRestorePlan {
     pub(crate) path: PathBuf,
@@ -469,8 +470,7 @@ impl Restorer {
         let mut chunk_files: Vec<FileRestorePlan> = Vec::new();
         let mut chunk_packs: PackMap = HashMap::new();
         // Persistent hardlink index: (dev, inode) → primary file path
-        let primary_hardlinks: Arc<Mutex<HashMap<(u64, u64), PathBuf>>> =
-            Arc::new(Mutex::new(HashMap::new()));
+        let primary_hardlinks: PrimaryHardlinks = Arc::new(Mutex::new(HashMap::new()));
         // Cross-chunk hardlinks stored as (secondary_path, primary_path)
         let pending_hardlinks: Arc<Mutex<Vec<HardlinkByPath>>> = Arc::new(Mutex::new(Vec::new()));
 
@@ -643,21 +643,35 @@ impl Restorer {
                     is_hardlink: false,
                 });
 
-                // Hardlink detection
+                // Hardlink detection with content verification
                 let is_hardlink_secondary = {
                     if let (Some(dev), Some(inode)) = (node.metadata.dev, node.metadata.inode) {
                         let nlink = node.metadata.nlink;
                         if nlink.unwrap_or(0) > 1 {
+                            let node_blobs = node.blobs.as_deref().unwrap_or(&[]);
+                            let fingerprint = compute_blob_fingerprint(node_blobs);
                             let mut idx = primary_hardlinks.lock();
-                            if let Some(primary_path) = idx.get(&(dev, inode)) {
-                                pending_hardlinks
-                                    .lock()
-                                    .push((restore_path.clone(), primary_path.clone()));
-                                drop(idx);
-                                chunk_files[file_idx].is_hardlink = true;
-                                true
+                            if let Some((primary_path, primary_fp)) = idx.get(&(dev, inode)) {
+                                if *primary_fp == fingerprint {
+                                    pending_hardlinks
+                                        .lock()
+                                        .push((restore_path.clone(), primary_path.clone()));
+                                    drop(idx);
+                                    chunk_files[file_idx].is_hardlink = true;
+                                    true
+                                } else {
+                                    drop(idx);
+                                    emit_event(
+                                        &self.event_sender,
+                                        Event::Restore(RestoreEvent::Warning(format!(
+                                            "Hardlink content mismatch for {}: blob fingerprint differs from primary, restoring as separate file",
+                                            restore_path.display()
+                                        ))),
+                                    );
+                                    false
+                                }
                             } else {
-                                idx.insert((dev, inode), restore_path.clone());
+                                idx.insert((dev, inode), (restore_path.clone(), fingerprint));
                                 drop(idx);
                                 false
                             }
@@ -688,10 +702,12 @@ impl Restorer {
                     if let (Some(dev), Some(inode)) = (node.metadata.dev, node.metadata.inode)
                         && node.metadata.nlink.unwrap_or(0) > 1
                     {
+                        let node_blobs = node.blobs.as_deref().unwrap_or(&[]);
+                        let fingerprint = compute_blob_fingerprint(node_blobs);
                         primary_hardlinks
                             .lock()
                             .entry((dev, inode))
-                            .or_insert_with(|| restore_path.clone());
+                            .or_insert_with(|| (restore_path.clone(), fingerprint));
                     }
                 } else if !dry_run
                     && let Some(parent) = restore_path.parent()
@@ -782,7 +798,31 @@ impl Restorer {
                     if self.opts.quit_on_error {
                         bail!(msg);
                     }
-                    emit_event(&self.event_sender, Event::Restore(RestoreEvent::Error(msg)));
+                    emit_event(
+                        &self.event_sender,
+                        Event::Restore(RestoreEvent::Warning(format!(
+                            "Hardlink failed, falling back to copy {} -> {}",
+                            primary.display(),
+                            secondary.display(),
+                        ))),
+                    );
+                    if let Err(copy_err) = fs::copy(primary, secondary) {
+                        let msg = format!(
+                            "Failed to copy {} -> {}: {}",
+                            primary.display(),
+                            secondary.display(),
+                            copy_err
+                        );
+                        if self.opts.quit_on_error {
+                            bail!(msg);
+                        }
+                        emit_event(&self.event_sender, Event::Restore(RestoreEvent::Error(msg)));
+                    } else {
+                        emit_event(
+                            &self.event_sender,
+                            Event::Restore(RestoreEvent::ItemProcessed(secondary.clone())),
+                        );
+                    }
                 } else {
                     emit_event(
                         &self.event_sender,
@@ -805,7 +845,6 @@ impl Restorer {
         Ok(())
     }
 
-    /// Quick first pass: count items and sum data bytes for progress reporting.
     async fn count_restore_work(&self, tree_id: ID) -> (u64, u64) {
         let mut node_stream = match SerializedNodeStream::new(
             self.repo.clone(),
@@ -852,4 +891,13 @@ impl Restorer {
 
         (items, bytes)
     }
+}
+
+/// Computes a content fingerprint for hardlink verification using blake3 over blob IDs.
+fn compute_blob_fingerprint(blobs: &[ID]) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    for blob_id in blobs {
+        hasher.update(&blob_id.0);
+    }
+    hasher.finalize().into()
 }

--- a/crates/mapache/src/restorer/node_restorer.rs
+++ b/crates/mapache/src/restorer/node_restorer.rs
@@ -288,6 +288,12 @@ pub fn restore_times(
 
 /// Attempts to restore all metadata (times, permissions, ownership, xattrs, flags) for a node.
 /// This is a best-effort operation and will log warnings on failure.
+///
+/// The order is important:
+/// 1. chown — must come first because chown clears setuid/setgid and security.capability
+/// 2. xattrs — applied while the inode is still owner-writable (before a potentially read-only final mode)
+/// 3. chmod — after xattrs, final mode
+/// 4. mtime — last, because chown/chmod/setxattr bump ctime, not mtime
 pub(crate) fn try_restore_node_metadata(
     metadata: &Metadata,
     is_symlink: bool,
@@ -299,7 +305,42 @@ pub(crate) fn try_restore_node_metadata(
         return;
     }
 
-    // Set file times
+    // Unix-specific metadata (ownership, permissions, xattrs)
+    #[cfg(unix)]
+    {
+        // 1. Set owner (uid) and group (gid) — must come first
+        // Restoring uid and gid is very likely to fail unless the user is root.
+        if metadata.owner_uid.is_some() || metadata.owner_gid.is_some() {
+            let _ = std::os::unix::fs::chown(dst_path, metadata.owner_uid, metadata.owner_gid);
+        }
+
+        // 2. Restore extended attributes — before chmod because xattr access may be restricted by mode
+        try_restore_xattrs(metadata, dst_path, event_sender);
+    }
+
+    // Restore Linux flags (before chmod, as flags can interact with permission bits)
+    #[cfg(target_os = "linux")]
+    try_restore_linux_flags(metadata, false, dst_path, event_sender);
+
+    // Restore Windows attributes
+    #[cfg(windows)]
+    try_restore_windows_attributes(metadata, dst_path, event_sender);
+
+    // 3. Set file permissions (mode)
+    #[cfg(unix)]
+    if let Some(mode) = metadata.mode {
+        let permissions = Permissions::from_mode(mode);
+        if std::fs::set_permissions(dst_path, permissions).is_err() {
+            emit_event(
+                event_sender,
+                Event::Restore(RestoreEvent::Warning(format!(
+                    "Could not set permissions (mode: {mode:o})."
+                ))),
+            );
+        }
+    }
+
+    // 4. Set file times — last, because chown/chmod/setxattr bump ctime, not mtime
     if let Err(e) = restore_times(
         dst_path,
         metadata.accessed_time.as_ref(),
@@ -315,45 +356,6 @@ pub(crate) fn try_restore_node_metadata(
             ))),
         );
     }
-
-    // Unix-specific metadata (mode, uid, gid)
-    #[cfg(unix)]
-    {
-        // Set file permissions (mode)
-        if !is_symlink && let Some(mode) = metadata.mode {
-            let permissions = Permissions::from_mode(mode);
-            if std::fs::set_permissions(dst_path, permissions).is_err() {
-                emit_event(
-                    event_sender,
-                    Event::Restore(RestoreEvent::Warning(format!(
-                        "Could not set permissions (mode: {mode:o})."
-                    ))),
-                );
-            }
-        }
-
-        if !is_symlink {
-            // Set owner (uid) and group (gid)
-            let uid = metadata.owner_uid;
-            let gid = metadata.owner_gid;
-
-            // Restoring uid and gid is very likely to fail unless the user is root.
-            if uid.is_some() || gid.is_some() {
-                let _ = std::os::unix::fs::chown(dst_path, uid, gid);
-            }
-        }
-
-        // Restore extended attributes
-        try_restore_xattrs(metadata, dst_path, event_sender);
-    }
-
-    // Restore Linux flags
-    #[cfg(target_os = "linux")]
-    try_restore_linux_flags(metadata, is_symlink, dst_path, event_sender);
-
-    // Restore Windows attributes
-    #[cfg(windows)]
-    try_restore_windows_attributes(metadata, dst_path, event_sender);
 }
 
 /// Restores extended attributes (xattrs) for a node.
@@ -453,28 +455,14 @@ fn try_restore_windows_attributes(
 }
 
 /// Restores metadata for a symlink without following it.
+///
+/// Order: lchown → xattrs → mtime (lchown must come first because it clears
+/// security.capability; xattrs before mtime because mtime should be last).
 #[cfg(unix)]
 fn try_restore_symlink_metadata(metadata: &Metadata, dst_path: &Path, event_sender: &EventSender) {
     use std::os::unix::ffi::OsStrExt;
 
-    // Set file times using set_symlink_file_times
-    if let Err(e) = restore_times(
-        dst_path,
-        metadata.accessed_time.as_ref(),
-        metadata.modified_time.as_ref(),
-        true,
-    ) {
-        emit_event(
-            event_sender,
-            Event::Restore(RestoreEvent::Warning(format!(
-                "Could not set file times for symlink {}: {}",
-                dst_path.display(),
-                e
-            ))),
-        );
-    }
-
-    // Set owner (uid) and group (gid) using lchown to avoid following the link.
+    // 1. Set owner (uid) and group (gid) using lchown to avoid following the link.
     let uid = metadata.owner_uid.unwrap_or(u32::MAX); // -1 in libc
     let gid = metadata.owner_gid.unwrap_or(u32::MAX); // -1 in libc
 
@@ -510,14 +498,10 @@ fn try_restore_symlink_metadata(metadata: &Metadata, dst_path: &Path, event_send
         }
     }
 
-    // Restore extended attributes (xattr crate's set handles symlinks correctly if not following)
+    // 2. Restore extended attributes (xattr crate's set handles symlinks correctly if not following)
     try_restore_xattrs(metadata, dst_path, event_sender);
-}
 
-/// Restores metadata for a symlink on Windows.
-#[cfg(windows)]
-fn try_restore_symlink_metadata(metadata: &Metadata, dst_path: &Path, event_sender: &EventSender) {
-    // Set file times for symlink on Windows
+    // 3. Set file times using set_symlink_file_times — last
     if let Err(e) = restore_times(
         dst_path,
         metadata.accessed_time.as_ref(),
@@ -533,9 +517,30 @@ fn try_restore_symlink_metadata(metadata: &Metadata, dst_path: &Path, event_send
             ))),
         );
     }
+}
 
-    // Restore Windows attributes for the symlink itself
+/// Restores metadata for a symlink on Windows.
+#[cfg(windows)]
+fn try_restore_symlink_metadata(metadata: &Metadata, dst_path: &Path, event_sender: &EventSender) {
+    // Restore Windows attributes for the symlink itself — before mtime
     try_restore_windows_attributes(metadata, dst_path, event_sender);
+
+    // Set file times for symlink — last
+    if let Err(e) = restore_times(
+        dst_path,
+        metadata.accessed_time.as_ref(),
+        metadata.modified_time.as_ref(),
+        true,
+    ) {
+        emit_event(
+            event_sender,
+            Event::Restore(RestoreEvent::Warning(format!(
+                "Could not set file times for symlink {}: {}",
+                dst_path.display(),
+                e
+            ))),
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/mapache/src/restorer/node_restorer.rs
+++ b/crates/mapache/src/restorer/node_restorer.rs
@@ -356,6 +356,20 @@ pub(crate) fn try_restore_node_metadata(
             ))),
         );
     }
+
+    // 5. fsync metadata changes to disk
+    _ = std::fs::File::open(dst_path)
+        .and_then(|file| file.sync_all())
+        .map_err(|e| {
+            emit_event(
+                event_sender,
+                Event::Restore(RestoreEvent::Warning(format!(
+                    "Could not fsync {}: {}",
+                    dst_path.display(),
+                    e
+                ))),
+            );
+        });
 }
 
 /// Restores extended attributes (xattrs) for a node.

--- a/crates/mapache/src/restorer/pack_restorer.rs
+++ b/crates/mapache/src/restorer/pack_restorer.rs
@@ -33,314 +33,315 @@ struct RestoreContext {
     quit_on_error: bool,
 }
 
-impl Restorer {
-    pub(crate) async fn restore_packs(
-        &self,
-        files: Arc<Vec<FileRestorePlan>>,
-        packs: Arc<PackMap>,
-        secure_storage: Arc<SecureStorage>,
-        dry_run: bool,
-    ) -> Result<()> {
-        if dry_run {
-            for blob_requests in packs.values() {
-                for (_, request) in blob_requests.iter() {
-                    emit_event(
-                        &self.event_sender,
-                        Event::Restore(RestoreEvent::BytesProcessed(request.raw_length as u64)),
-                    );
-                }
-            }
-            for file in files.iter() {
+/// Process a chunk of files: download pack segments, decode blobs, write to disk.
+pub(crate) async fn restore_packs(
+    restorer: &Restorer,
+    files: Arc<Vec<FileRestorePlan>>,
+    packs: Arc<PackMap>,
+    secure_storage: Arc<SecureStorage>,
+    dry_run: bool,
+) -> Result<()> {
+    if dry_run {
+        for blob_requests in packs.values() {
+            for (_, request) in blob_requests.iter() {
                 emit_event(
-                    &self.event_sender,
-                    Event::Restore(RestoreEvent::ItemProcessed(file.path.clone())),
-                );
-            }
-            return Ok(());
-        }
-
-        let remaining = Arc::new(
-            files
-                .iter()
-                .map(|f| std::sync::atomic::AtomicU32::new(f.num_blobs))
-                .collect::<Vec<_>>(),
-        );
-
-        let initialized = Arc::new(
-            (0..files.len())
-                .map(|_| std::sync::atomic::AtomicBool::new(false))
-                .collect::<Vec<_>>(),
-        );
-
-        let d = defaults::runtime();
-        let handle_cache = Arc::new(ShardedFileHandleCache::new(d.restore_max_open_files));
-
-        for (idx, file) in files.iter().enumerate() {
-            if file.num_blobs == 0 && !file.is_hardlink {
-                if !file.path.exists() || file.size == 0 {
-                    let mut cache_guard = handle_cache.get_shard(idx).lock();
-                    cache_guard.get_handle(idx, &file.path, file, &initialized[idx], self)?;
-                }
-                emit_event(
-                    &self.event_sender,
-                    Event::Restore(RestoreEvent::ItemProcessed(file.path.clone())),
+                    &restorer.event_sender,
+                    Event::Restore(RestoreEvent::BytesProcessed(request.raw_length as u64)),
                 );
             }
         }
+        for file in files.iter() {
+            emit_event(
+                &restorer.event_sender,
+                Event::Restore(RestoreEvent::ItemProcessed(file.path.clone())),
+            );
+        }
+        return Ok(());
+    }
 
-        let restorer_arc = Arc::new(self.clone_for_workers());
-        let ctx = Arc::new(RestoreContext {
-            handle_cache,
-            files,
-            remaining,
-            initialized,
-            restorer: restorer_arc,
-            event_sender: self.event_sender.clone(),
-            quit_on_error: self.opts.quit_on_error,
-        });
+    let remaining = Arc::new(
+        files
+            .iter()
+            .map(|f| std::sync::atomic::AtomicU32::new(f.num_blobs))
+            .collect::<Vec<_>>(),
+    );
 
-        let packs_map = Arc::try_unwrap(packs).unwrap_or_else(|arc| (*arc).clone());
+    let initialized = Arc::new(
+        (0..files.len())
+            .map(|_| std::sync::atomic::AtomicBool::new(false))
+            .collect::<Vec<_>>(),
+    );
 
-        let mut download_stream = futures::stream::iter(packs_map)
-            .flat_map(|(pack_id, blob_requests)| {
-                let mut blob_to_targets: HashMap<ID, Vec<BlobRestoreRequest>> = HashMap::new();
-                for (blob_id, req) in blob_requests {
-                    blob_to_targets.entry(blob_id).or_default().push(req);
+    let defaults = defaults::runtime();
+    let handle_cache = Arc::new(ShardedFileHandleCache::new(defaults.restore_max_open_files));
+
+    for (idx, file) in files.iter().enumerate() {
+        if file.num_blobs == 0 && !file.is_hardlink {
+            if !file.path.exists() || file.size == 0 {
+                let mut cache_guard = handle_cache.get_shard(idx).lock();
+                cache_guard.get_handle(idx, &file.path, file, &initialized[idx], restorer)?;
+            }
+            emit_event(
+                &restorer.event_sender,
+                Event::Restore(RestoreEvent::ItemProcessed(file.path.clone())),
+            );
+        }
+    }
+
+    let restorer_arc = Arc::new(restorer.clone_for_workers());
+    let ctx = Arc::new(RestoreContext {
+        handle_cache,
+        files,
+        remaining,
+        initialized,
+        restorer: restorer_arc,
+        event_sender: restorer.event_sender.clone(),
+        quit_on_error: restorer.opts.quit_on_error,
+    });
+
+    let packs_map = Arc::try_unwrap(packs).unwrap_or_else(|arc| (*arc).clone());
+
+    let mut download_stream = futures::stream::iter(packs_map)
+        .flat_map(|(pack_id, blob_requests)| {
+            let mut blob_to_targets: HashMap<ID, Vec<BlobRestoreRequest>> = HashMap::new();
+            for (blob_id, req) in blob_requests {
+                blob_to_targets.entry(blob_id).or_default().push(req);
+            }
+
+            let blobs_vec: Vec<(ID, BlobLocator, Vec<BlobRestoreRequest>)> = blob_to_targets
+                .into_iter()
+                .map(|(id, targets)| {
+                    let t0 = &targets[0];
+                    let locator = BlobLocator {
+                        pack_id,
+                        offset: t0.blob_offset,
+                        length: t0.blob_length,
+                        raw_length: t0.raw_length,
+                        blob_type: BlobType::Data,
+                    };
+                    (id, locator, targets)
+                })
+                .collect();
+
+            futures::stream::iter(loader::segment_blobs(pack_id, blobs_vec))
+        })
+        .map(|segment| {
+            let repo = restorer.repo.clone();
+            let secure_storage = secure_storage.clone();
+            let ctx = ctx.clone();
+            let shutdown_signal = restorer.shutdown_signal.clone();
+            let defaults = defaults.clone();
+
+            async move {
+                if shutdown_signal.load(Ordering::Acquire) {
+                    bail!("Interrupted");
                 }
 
-                let blobs_vec: Vec<(ID, BlobLocator, Vec<BlobRestoreRequest>)> = blob_to_targets
-                    .into_iter()
-                    .map(|(id, targets)| {
-                        let t0 = &targets[0];
-                        let locator = BlobLocator {
-                            pack_id,
-                            offset: t0.blob_offset,
-                            length: t0.blob_length,
-                            raw_length: t0.raw_length,
-                            blob_type: BlobType::Data,
-                        };
-                        (id, locator, targets)
-                    })
-                    .collect();
+                let path = repo.get_path(ContentIdType::Pack, &segment.pack_id);
+                let is_tree = segment
+                    .blobs
+                    .iter()
+                    .all(|(_, loc, _)| loc.blob_type == BlobType::Tree);
 
-                futures::stream::iter(loader::segment_blobs(pack_id, blobs_vec))
-            })
-            .map(|segment| {
-                let repo = self.repo.clone();
-                let secure_storage = secure_storage.clone();
-                let ctx = ctx.clone();
-                let shutdown_signal = self.shutdown_signal.clone();
-                let d = d.clone();
+                let segment_data = repo
+                    .backend()
+                    .read(
+                        &crate::backend::Handle::new_with_hint(&path, ContentIdType::Pack, is_tree),
+                        segment.min_offset as isize,
+                        segment.source_len(),
+                    )
+                    .await
+                    .with_context(|| format!("Failed to read pack {}", segment.pack_id))?;
 
-                async move {
+                tracing::debug!(target: "restorer", "Segment from pack {} downloaded ({} bytes)",
+                    segment.pack_id.to_short_hex(8), segment_data.len());
+
+                let data_arc = Arc::new(segment_data);
+                let mut blobs = segment.blobs;
+
+                while !blobs.is_empty() {
                     if shutdown_signal.load(Ordering::Acquire) {
                         bail!("Interrupted");
                     }
 
-                    let path = repo.get_path(ContentIdType::Pack, &segment.pack_id);
-                    let is_tree = segment
-                        .blobs
-                        .iter()
-                        .all(|(_, loc, _)| loc.blob_type == BlobType::Tree);
-
-                    let segment_data = repo
-                        .backend()
-                        .read(
-                            &crate::backend::Handle::new_with_hint(&path, ContentIdType::Pack, is_tree),
-                            segment.min_offset as isize,
-                            segment.source_len(),
-                        )
-                        .await
-                        .with_context(|| format!("Failed to read pack {}", segment.pack_id))?;
-
-                    tracing::debug!(target: "restorer", "Segment from pack {} downloaded ({} bytes)",
-                        segment.pack_id.to_short_hex(8), segment_data.len());
-
-                    let data_arc = Arc::new(segment_data);
-                    let mut blobs = segment.blobs;
-
-                    while !blobs.is_empty() {
-                        if shutdown_signal.load(Ordering::Acquire) {
-                            bail!("Interrupted");
+                    let mut batch = Vec::new();
+                    let mut batch_raw_size = 0;
+                    while let Some(entry) = blobs.pop() {
+                        batch_raw_size += entry.1.raw_length as u64;
+                        batch.push(entry);
+                        if batch_raw_size >= defaults.restore_decoded_budget {
+                            break;
                         }
-
-                        let mut batch = Vec::new();
-                        let mut batch_raw_size = 0;
-                        while let Some(entry) = blobs.pop() {
-                            batch_raw_size += entry.1.raw_length as u64;
-                            batch.push(entry);
-                            if batch_raw_size >= d.restore_decoded_budget {
-                                break;
-                            }
-                        }
-
-                        let secure_storage_inner = secure_storage.clone();
-                        let data_arc_inner = data_arc.clone();
-                        let min_offset = segment.min_offset;
-
-                        let decoded_results: Vec<Result<DecodedBlob>> = spawn_blocking(move || {
-                            batch
-                                .into_par_iter()
-                                .map(|(blob_id, locator, targets)| {
-                                    let blob_offset = locator.offset as u64;
-                                    if blob_offset < min_offset {
-                                        anyhow::bail!("Blob offset {} is before segment start {}", blob_offset, min_offset);
-                                    }
-                                    let start = (blob_offset - min_offset) as usize;
-                                    let end = start + locator.length as usize;
-                                    if end > data_arc_inner.len() {
-                                        anyhow::bail!("Blob end {} exceeds segment data length {}", end, data_arc_inner.len());
-                                    }
-                                    let encoded_blob = &data_arc_inner[start..end];
-
-                                    let decoded_data = secure_storage_inner
-                                        .decode(encoded_blob)
-                                        .with_context(|| {
-                                            format!("Failed to decode blob {blob_id}")
-                                        })?;
-
-                                    Ok(DecodedBlob {
-                                        data: decoded_data,
-                                        targets,
-                                    })
-                                })
-                                .collect()
-                        })
-                        .await
-                        .map_err(|e| anyhow!(e))?;
-
-                        let mut file_batches: HashMap<usize, Vec<(Vec<u8>, u64)>> = HashMap::new();
-                        for res in decoded_results {
-                            let decoded = res?;
-                            if decoded.targets.len() == 1 {
-                                let target = &decoded.targets[0];
-                                file_batches
-                                    .entry(target.file_idx)
-                                    .or_default()
-                                    .push((decoded.data, target.offset_in_file));
-                            } else {
-                                for target in &decoded.targets {
-                                    file_batches
-                                        .entry(target.file_idx)
-                                        .or_default()
-                                        .push((decoded.data.clone(), target.offset_in_file));
-                                }
-                            }
-                        }
-
-                        Self::flush_file_batches(
-                            &mut file_batches,
-                            &ctx,
-                            d.restore_blob_concurrency,
-                        )
-                        .await?;
                     }
 
-                    Ok::<(), anyhow::Error>(())
-                }
-            })
-            .buffer_unordered(d.restore_pack_prefetch);
+                    let secure_storage_inner = secure_storage.clone();
+                    let data_arc_inner = data_arc.clone();
+                    let min_offset = segment.min_offset;
 
-        while let Some(res) = download_stream.next().await {
-            if self.shutdown_signal.load(Ordering::Acquire) {
-                bail!("Interrupted");
-            }
-            res?;
-        }
-
-        Ok(())
-    }
-
-    /// Flush accumulated file batches: write each file's blobs in a single
-    /// spawn_blocking, processing files concurrently.
-    async fn flush_file_batches(
-        file_batches: &mut HashMap<usize, Vec<(Vec<u8>, u64)>>,
-        ctx: &Arc<RestoreContext>,
-        concurrency: usize,
-    ) -> Result<()> {
-        let batches = std::mem::take(file_batches);
-
-        let mut batch_stream = futures::stream::iter(batches)
-            .map(|(file_idx, writes)| {
-                let num_blobs = writes.len().min(u32::MAX as usize) as u32;
-                let total_bytes: u64 = writes.iter().map(|(d, _)| d.len() as u64).sum();
-                let ctx = ctx.clone();
-
-                async move {
-                    let file_path = ctx.files[file_idx].path.clone();
-                    let file_path_for_write = file_path.clone();
-                    let ctx_inner = ctx.clone();
-                    let write_result = spawn_blocking(move || -> Result<u64, anyhow::Error> {
-                        let mut cache_guard = ctx_inner.handle_cache.get_shard(file_idx).lock();
-                        let file = cache_guard.get_handle(
-                            file_idx,
-                            &file_path_for_write,
-                            &ctx_inner.files[file_idx],
-                            &ctx_inner.initialized[file_idx],
-                            &ctx_inner.restorer,
-                        )?;
-                        let mut written = 0u64;
-                        for (data, offset) in writes {
-                            let mut data_remaining = data.as_slice();
-                            let mut write_offset = offset;
-                            while !data_remaining.is_empty() {
-                                #[cfg(unix)]
-                                let n = file
-                                    .write_at(data_remaining, write_offset)
-                                    .map_err(|e| anyhow!(e))?;
-                                #[cfg(windows)]
-                                let n = file
-                                    .seek_write(data_remaining, write_offset)
-                                    .map_err(|e| anyhow!(e))?;
-                                if n == 0 {
-                                    anyhow::bail!("Failed to write data: wrote 0 bytes");
+                    let decoded_results: Vec<Result<DecodedBlob>> = spawn_blocking(move || {
+                        batch
+                            .into_par_iter()
+                            .map(|(blob_id, locator, targets)| {
+                                let blob_offset = locator.offset as u64;
+                                if blob_offset < min_offset {
+                                    anyhow::bail!(
+                                        "Blob offset {} is before segment start {}",
+                                        blob_offset,
+                                        min_offset
+                                    );
                                 }
-                                data_remaining = &data_remaining[n..];
-                                write_offset += n as u64;
-                            }
-                            written += data.len() as u64;
-                        }
-                        Ok(written)
+                                let start = (blob_offset - min_offset) as usize;
+                                let end = start + locator.length as usize;
+                                if end > data_arc_inner.len() {
+                                    anyhow::bail!(
+                                        "Blob end {} exceeds segment data length {}",
+                                        end,
+                                        data_arc_inner.len()
+                                    );
+                                }
+                                let encoded_blob = &data_arc_inner[start..end];
+
+                                let decoded_data = secure_storage_inner
+                                    .decode(encoded_blob)
+                                    .with_context(|| format!("Failed to decode blob {blob_id}"))?;
+
+                                Ok(DecodedBlob {
+                                    data: decoded_data,
+                                    targets,
+                                })
+                            })
+                            .collect()
                     })
                     .await
                     .map_err(|e| anyhow!(e))?;
 
-                    match write_result {
-                        Ok(_bytes) => {
-                            emit_event(
-                                &ctx.event_sender,
-                                Event::Restore(RestoreEvent::BytesProcessed(total_bytes)),
-                            );
-                            if ctx.remaining[file_idx].fetch_sub(num_blobs, Ordering::Relaxed)
-                                == num_blobs
-                            {
-                                emit_event(
-                                    &ctx.event_sender,
-                                    Event::Restore(RestoreEvent::ItemProcessed(file_path)),
-                                );
+                    let mut file_batches: HashMap<usize, Vec<(Vec<u8>, u64)>> = HashMap::new();
+                    for res in decoded_results {
+                        let decoded = res?;
+                        if decoded.targets.len() == 1 {
+                            let target = &decoded.targets[0];
+                            file_batches
+                                .entry(target.file_idx)
+                                .or_default()
+                                .push((decoded.data, target.offset_in_file));
+                        } else {
+                            for target in &decoded.targets {
+                                file_batches
+                                    .entry(target.file_idx)
+                                    .or_default()
+                                    .push((decoded.data.clone(), target.offset_in_file));
                             }
-                        }
-                        Err(e) => {
-                            let err_msg = format!("Failed to write to file index {file_idx}: {e}");
-                            if ctx.quit_on_error {
-                                bail!(err_msg);
-                            }
-                            emit_event(
-                                &ctx.event_sender,
-                                Event::Restore(RestoreEvent::Error(err_msg)),
-                            );
                         }
                     }
 
-                    Ok::<(), anyhow::Error>(())
+                    flush_file_batches(&mut file_batches, &ctx, defaults.restore_blob_concurrency)
+                        .await?;
                 }
-            })
-            .buffer_unordered(concurrency);
 
-        while let Some(res) = batch_stream.next().await {
-            res?;
+                Ok::<(), anyhow::Error>(())
+            }
+        })
+        .buffer_unordered(defaults.restore_pack_prefetch);
+
+    while let Some(res) = download_stream.next().await {
+        if restorer.shutdown_signal.load(Ordering::Acquire) {
+            bail!("Interrupted");
         }
-
-        Ok(())
+        res?;
     }
+
+    Ok(())
+}
+
+/// Flush accumulated file batches: write each file's blobs in a single
+/// spawn_blocking, processing files concurrently.
+async fn flush_file_batches(
+    file_batches: &mut HashMap<usize, Vec<(Vec<u8>, u64)>>,
+    ctx: &Arc<RestoreContext>,
+    concurrency: usize,
+) -> Result<()> {
+    let batches = std::mem::take(file_batches);
+
+    let mut batch_stream = futures::stream::iter(batches)
+        .map(|(file_idx, writes)| {
+            let num_blobs = writes.len().min(u32::MAX as usize) as u32;
+            let total_bytes: u64 = writes.iter().map(|(data, _)| data.len() as u64).sum();
+            let ctx = ctx.clone();
+
+            async move {
+                let file_path = ctx.files[file_idx].path.clone();
+                let file_path_for_write = file_path.clone();
+                let ctx_inner = ctx.clone();
+                let write_result = spawn_blocking(move || -> Result<u64, anyhow::Error> {
+                    let mut cache_guard = ctx_inner.handle_cache.get_shard(file_idx).lock();
+                    let file = cache_guard.get_handle(
+                        file_idx,
+                        &file_path_for_write,
+                        &ctx_inner.files[file_idx],
+                        &ctx_inner.initialized[file_idx],
+                        &ctx_inner.restorer,
+                    )?;
+                    let mut written = 0u64;
+                    for (data, offset) in writes {
+                        let mut data_remaining = data.as_slice();
+                        let mut write_offset = offset;
+                        while !data_remaining.is_empty() {
+                            #[cfg(unix)]
+                            let n = file
+                                .write_at(data_remaining, write_offset)
+                                .map_err(|e| anyhow!(e))?;
+                            #[cfg(windows)]
+                            let n = file
+                                .seek_write(data_remaining, write_offset)
+                                .map_err(|e| anyhow!(e))?;
+                            if n == 0 {
+                                anyhow::bail!("Failed to write data: wrote 0 bytes");
+                            }
+                            data_remaining = &data_remaining[n..];
+                            write_offset += n as u64;
+                        }
+                        written += data.len() as u64;
+                    }
+                    Ok(written)
+                })
+                .await
+                .map_err(|e| anyhow!(e))?;
+
+                match write_result {
+                    Ok(_bytes) => {
+                        emit_event(
+                            &ctx.event_sender,
+                            Event::Restore(RestoreEvent::BytesProcessed(total_bytes)),
+                        );
+                        if ctx.remaining[file_idx].fetch_sub(num_blobs, Ordering::Relaxed)
+                            == num_blobs
+                        {
+                            emit_event(
+                                &ctx.event_sender,
+                                Event::Restore(RestoreEvent::ItemProcessed(file_path)),
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        let err_msg = format!("Failed to write to file index {file_idx}: {e}");
+                        if ctx.quit_on_error {
+                            bail!(err_msg);
+                        }
+                        emit_event(
+                            &ctx.event_sender,
+                            Event::Restore(RestoreEvent::Error(err_msg)),
+                        );
+                    }
+                }
+
+                Ok::<(), anyhow::Error>(())
+            }
+        })
+        .buffer_unordered(concurrency);
+
+    while let Some(res) = batch_stream.next().await {
+        res?;
+    }
+
+    Ok(())
 }

--- a/crates/mapache/src/restorer/planner.rs
+++ b/crates/mapache/src/restorer/planner.rs
@@ -1,8 +1,7 @@
 use std::{
-    collections::HashMap,
     fs::{self, File},
     path::Path,
-    sync::{Arc, atomic::Ordering},
+    sync::Arc,
 };
 
 #[cfg(unix)]
@@ -11,300 +10,19 @@ use std::os::unix::fs::FileExt;
 use std::os::windows::fs::FileExt;
 
 use anyhow::{Context, Result, anyhow, bail};
-use futures::StreamExt;
-use parking_lot::Mutex;
 use tokio::task::spawn_blocking;
 
 use crate::{
-    common::{ID, defaults, hash},
-    fs::{self as repo_fs, node::Node, tree::SerializedNodeStream},
+    common::hash,
+    fs::{self as repo_fs, node::Node},
     repository::index::MasterIndex,
-    restorer::{
-        BlobRestoreRequest, FileRestorePlan, RestorePlan, Restorer, Strategy, node_restorer,
-    },
-    ui::events::{Event, RestoreEvent, emit_event},
-    utils::{self, size},
+    restorer::{Restorer, Strategy},
+    utils::size,
 };
 
 impl Restorer {
-    /// Builds a restoration plan by walking the snapshot tree and determining
-    /// which nodes need to be restored.
-    pub(crate) async fn build_plan(
-        &self,
-        node_stream: SerializedNodeStream,
-        index: Arc<MasterIndex>,
-    ) -> Result<RestorePlan> {
-        let files = Arc::new(Mutex::new(Vec::new()));
-        let directories = Arc::new(Mutex::new(Vec::new()));
-        let skipped_item_paths = Arc::new(Mutex::new(Vec::new()));
-        let packs = Arc::new(dashmap::DashMap::<ID, Vec<(ID, BlobRestoreRequest)>>::new());
-        let node_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let total_items = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let total_bytes = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let skipped_bytes = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let hardlink_index = Arc::new(parking_lot::Mutex::new(HashMap::<(u64, u64), usize>::new()));
-        let hardlinks = Arc::new(parking_lot::Mutex::new(Vec::<(usize, usize)>::new()));
-
-        emit_event(&self.event_sender, Event::Restore(RestoreEvent::Planning));
-
-        let d = defaults::runtime();
-        let num_workers = d.restore_blob_concurrency;
-
-        node_stream
-            .for_each_concurrent(num_workers, |node_res| {
-                let index = index.clone();
-                let files = files.clone();
-                let directories = directories.clone();
-                let skipped_item_paths = skipped_item_paths.clone();
-                let packs = packs.clone();
-                let node_count = node_count.clone();
-                let total_items = total_items.clone();
-                let total_bytes = total_bytes.clone();
-                let skipped_bytes = skipped_bytes.clone();
-                let event_sender = self.event_sender.clone();
-                let shutdown_signal = self.shutdown_signal.clone();
-                let hardlink_index = hardlink_index.clone();
-                let hardlinks = hardlinks.clone();
-
-                async move {
-                    if shutdown_signal.load(Ordering::Acquire) {
-                        return;
-                    }
-
-                    let visited = node_count.fetch_add(1, Ordering::Relaxed) + 1;
-                    emit_event(&event_sender, Event::Restore(RestoreEvent::NodeVisited(visited)));
-
-                    let (mut path, stream_node_res) = match node_res {
-                        Ok(res) => res,
-                        Err(e) => {
-                            emit_event(&event_sender, Event::Restore(RestoreEvent::Error(format!("Error during planning: {e}"))));
-                            return;
-                        }
-                    };
-
-                    let stream_node = match stream_node_res {
-                        Ok(node) => node,
-                        Err(e) => {
-                            emit_event(&event_sender, Event::Restore(RestoreEvent::Error(format!(
-                                "Error reading node {}: {}",
-                                path.display(),
-                                e
-                            ))));
-                            return;
-                        }
-                    };
-                    let node = stream_node.node;
-
-                    if let Some(prefix) = &self.opts.strip_prefix {
-                        path = match path.strip_prefix(prefix) {
-                            Ok(stripped_path) => {
-                                if stripped_path.as_os_str().is_empty() {
-                                    return;
-                                }
-                                stripped_path.to_path_buf()
-                            }
-                            Err(_) => return,
-                        };
-                    }
-
-                    total_items.fetch_add(1, Ordering::Relaxed);
-                    let mut size_to_add = 0u64;
-                    if node.is_file() {
-                        size_to_add = node.metadata.size;
-                        total_bytes.fetch_add(size_to_add, Ordering::Relaxed);
-                    }
-
-                    let restore_path = match utils::secure_join(&self.target_path, &path) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            emit_event(&event_sender, Event::Restore(RestoreEvent::Error(format!("Secure join failed for {path:?}: {e}"))));
-                            return;
-                        }
-                    };
-
-                    match self
-                        .should_restore_node(&node, &restore_path, index.clone())
-                        .await
-                    {
-                        Ok(true) => {}
-                        Ok(false) => {
-                            if node.is_file() {
-                                skipped_bytes.fetch_add(size_to_add, Ordering::Relaxed);
-                            }
-                            skipped_item_paths.lock().push(restore_path);
-                            return;
-                        }
-                        Err(e) => {
-                            emit_event(&event_sender, Event::Restore(RestoreEvent::Error(format!(
-                                "Error checking {}: {}",
-                                path.display(),
-                                e
-                            ))));
-                            return;
-                        }
-                    }
-
-                    if node.is_dir() {
-                        if !self.opts.dry_run
-                            && let Err(e) = fs::create_dir_all(&restore_path)
-                        {
-                            emit_event(&event_sender, Event::Restore(RestoreEvent::Error(format!(
-                                "Failed to create directory {}: {}",
-                                restore_path.display(),
-                                e
-                            ))));
-                            return;
-                        }
-                        directories.lock().push((restore_path.clone(), node.metadata));
-                        return;
-                    }
-
-                    if node.is_file() {
-                        let mut file_blobs = Vec::new();
-                        if let Some(blobs) = &node.blobs {
-                            let mut offset_in_file = 0;
-                            for blob_id in blobs {
-                                let locator = match index.get_data(blob_id) {
-                                    Some(loc) => loc,
-                                    None => {
-                                        let err_msg = format!("Blob {blob_id} not found in index");
-                                        emit_event(&event_sender, Event::Restore(RestoreEvent::Error(err_msg)));
-                                        return;
-                                    }
-                                };
-                                file_blobs.push((*blob_id, locator, offset_in_file));
-                                offset_in_file += locator.raw_length as u64;
-                            }
-                        }
-
-                        let file_idx = {
-                            let mut files_lock = files.lock();
-                            let idx = files_lock.len();
-                            files_lock.push(FileRestorePlan {
-                                path: restore_path.clone(),
-                                num_blobs: 0,
-                                size: node.metadata.size,
-                                is_hardlink: false,
-                            });
-                            idx
-                        };
-
-                        let is_hardlink_secondary = {
-                            if let (Some(dev), Some(inode)) =
-                                (node.metadata.dev, node.metadata.inode)
-                            {
-                                let nlink = node.metadata.nlink;
-                                if nlink.unwrap_or(0) > 1 {
-                                    let mut idx = hardlink_index.lock();
-                                    if let Some(&primary_idx) = idx.get(&(dev, inode)) {
-                                        hardlinks.lock().push((file_idx, primary_idx));
-                                        files.lock()[file_idx].is_hardlink = true;
-                                        true
-                                    } else {
-                                        idx.insert((dev, inode), file_idx);
-                                        false
-                                    }
-                                } else {
-                                    false
-                                }
-                            } else {
-                                false
-                            }
-                        };
-
-                        if is_hardlink_secondary {
-                            if !self.opts.dry_run
-                                && let Some(parent) = restore_path.parent()
-                                && let Err(e) = fs::create_dir_all(parent) {
-                                    emit_event(&event_sender, Event::Restore(RestoreEvent::Error(format!(
-                                        "Failed to create parent directory for secondary hardlink {}: {}",
-                                        restore_path.display(),
-                                        e
-                                    ))));
-                            }
-                        } else {
-                            let num_blobs = file_blobs.len().min(u32::MAX as usize) as u32;
-                            for (blob_id, locator, offset_in_file) in file_blobs {
-                                packs.entry(locator.pack_id).or_default().push((
-                                    blob_id,
-                                    BlobRestoreRequest {
-                                        file_idx,
-                                        offset_in_file,
-                                        blob_offset: locator.offset,
-                                        blob_length: locator.length,
-                                        raw_length: locator.raw_length,
-                                    },
-                                ));
-                            }
-
-                            files.lock()[file_idx].num_blobs = num_blobs;
-                        }
-                    } else if node.is_symlink() {
-                        // Symlinks are restored immediately during planning.
-                        if !self.opts.dry_run
-                            && let Err(e) = node_restorer::restore_node_to_path(
-                                self,
-                                &event_sender,
-                                &node,
-                                &restore_path,
-                                false,
-                            )
-                            .await
-                        {
-                            emit_event(&event_sender, Event::Restore(RestoreEvent::Error(e.to_string())));
-                        }
-                        // We must record symlinks in the plan to report them as processed items later.
-                        // However, we don't want them in `files` because `restore_packs` would treat them as files.
-                        // Let's reuse skipped_item_paths for now, as they only need to be reported as processed.
-                        skipped_item_paths.lock().push(restore_path);
-                    }
-                }
-            })
-            .await;
-
-        let final_visited = node_count.load(Ordering::Relaxed);
-        emit_event(
-            &self.event_sender,
-            Event::Restore(RestoreEvent::NodeVisited(final_visited)),
-        );
-
-        let files = Arc::into_inner(files)
-            .context("Internal error: multiple Arc references to files remained after planning")?
-            .into_inner();
-        let directories = Arc::into_inner(directories)
-            .context(
-                "Internal error: multiple Arc references to directories remained after planning",
-            )?
-            .into_inner();
-        let skipped_item_paths = Arc::into_inner(skipped_item_paths)
-            .context(
-                "Internal error: multiple Arc references to skipped_item_paths remained after planning",
-            )?
-            .into_inner();
-        let packs_map = Arc::into_inner(packs)
-            .context("Internal error: multiple Arc references to packs remained after planning")?
-            .into_iter()
-            .collect();
-        let hardlinks = Arc::into_inner(hardlinks)
-            .context(
-                "Internal error: multiple Arc references to hardlinks remained after planning",
-            )?
-            .into_inner();
-
-        Ok(RestorePlan {
-            files: Arc::new(files),
-            packs: Arc::new(packs_map),
-            directories,
-            skipped_item_paths,
-            total_items: total_items.load(Ordering::Relaxed),
-            total_bytes: total_bytes.load(Ordering::Relaxed),
-            skipped_bytes: skipped_bytes.load(Ordering::Relaxed),
-            hardlinks,
-        })
-    }
-
     /// Checks if a node should be restored based on the current restoration strategy.
-    async fn should_restore_node(
+    pub(crate) async fn should_restore_node(
         &self,
         node: &Node,
         restore_path: &Path,
@@ -507,6 +225,7 @@ mod tests {
                 verify,
                 include: None,
                 exclude: None,
+                batch_size: None,
             },
             buffers: Arc::new(Mutex::new(VecDeque::new())),
         };

--- a/crates/mapache/src/ui/cli/restore.rs
+++ b/crates/mapache/src/ui/cli/restore.rs
@@ -47,8 +47,10 @@ impl CliRestoreState {
         *stage = msg;
     }
 
-    fn set_visited_nodes(&self, count: u64) {
-        self.processed_items_count.store(count, Ordering::Relaxed);
+    fn set_visited_nodes(&self, _count: u64) {
+        // Intentionally no-op: NodeVisited events were overwriting the
+        // processed-items counter when interleaved with ItemProcessed events
+        // from batched restore_packs flushes.
     }
 
     fn resize_workload(&self, num_expected_items: u64, num_expected_bytes: u64) {
@@ -230,11 +232,8 @@ pub(crate) fn make_event_sender(
     let sender: EventSender = Arc::new(move |event: Event| {
         let Event::Restore(ev) = event else { return };
         match ev {
-            RestoreEvent::Planning => {
-                state.set_message("Planning...".to_string());
-            }
-            RestoreEvent::NodeVisited(count) => {
-                state.set_visited_nodes(count);
+            RestoreEvent::NodeVisited(_count) => {
+                state.set_visited_nodes(_count);
             }
             RestoreEvent::PlanBuilt {
                 total_items: t,

--- a/crates/mapache/src/ui/events.rs
+++ b/crates/mapache/src/ui/events.rs
@@ -68,8 +68,6 @@ pub enum BackupEvent {
 
 #[derive(Debug, Clone)]
 pub enum RestoreEvent {
-    /// Planning phase started.
-    Planning,
     /// A node was visited during planning.
     NodeVisited(u64),
     /// Plan is complete; totals are known.

--- a/crates/mapache/src/ui/json/restore.rs
+++ b/crates/mapache/src/ui/json/restore.rs
@@ -123,15 +123,6 @@ pub(crate) fn make_event_sender(
     let sender: EventSender = Arc::new(move |event: Event| {
         let Event::Restore(ev) = event else { return };
         match ev {
-            RestoreEvent::Planning => {
-                {
-                    let mut stage = state.current_stage.lock();
-                    *stage = "Planning...".to_string();
-                }
-                if state.should_emit_update() {
-                    state.emit_status_update();
-                }
-            }
             RestoreEvent::NodeVisited(count) => {
                 state.visited_nodes.store(count, Ordering::Relaxed);
                 if state.should_emit_update() {

--- a/crates/mapache/src/ui/tui/screens/restore/mod.rs
+++ b/crates/mapache/src/ui/tui/screens/restore/mod.rs
@@ -90,6 +90,7 @@ impl RestoreScreen {
             verify: false,
             include: self.config.get_include(),
             exclude: self.config.get_exclude(),
+            batch_size: None,
         };
 
         let tx = self.tx.clone();

--- a/crates/mapache/src/ui/tui/screens/restore/progress.rs
+++ b/crates/mapache/src/ui/tui/screens/restore/progress.rs
@@ -7,9 +7,6 @@ use crate::ui::tui::widgets::{TaskProgressState, TaskProgressWidget};
 
 pub fn handle_event(state: &mut TaskProgressState, event: RestoreEvent) {
     match event {
-        RestoreEvent::Planning => {
-            state.set_message("Planning...".to_string());
-        }
         RestoreEvent::NodeVisited(_) => {}
         RestoreEvent::PlanBuilt {
             total_items,

--- a/crates/mapache/tests/integration_tests/mod.rs
+++ b/crates/mapache/tests/integration_tests/mod.rs
@@ -512,6 +512,7 @@ impl RestoreBuilder {
                 quit_on_error: Some(true),
                 delete: Some(false),
                 no_preserve_root: Some(false),
+                batch_size: None,
             },
         }
     }

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -211,6 +211,7 @@ and subject to garbage collection.
 ### Snapshots
 
 A snapshot is a point-in-time record of your files. It contains:
+
 - The root tree ID (linking to all file/directory metadata)
 - Timestamp, hostname, username
 - Paths, tags, description
@@ -222,6 +223,7 @@ newer ones (shared blobs are reference-counted by the index).
 ### Chunking
 
 Mapache uses FastCDC (Content-Defined Chunking) with:
+
 - Minimum chunk: 512 KiB
 - Average chunk: 1 MiB
 - Maximum chunk: 8 MiB
@@ -290,6 +292,7 @@ skip-if-unchanged = true
 [restore]
 strategy = "newer"
 sparse = true
+batch-size = 100000        # Limit memory by restricting files per batch (optional)
 
 [forget]
 keep-daily = 7
@@ -314,6 +317,7 @@ CLI flags override config file values. Config file values supplement CLI lists
 ### Authentication
 
 Authentication can be provided via:
+
 1. Interactive prompt (default) — prompts for username and password
 2. `--auth-file <PATH>` — file with username on the first line and password on
    the second line
@@ -667,6 +671,7 @@ and `--parent`.
 ### Snapshot Output
 
 After a successful snapshot, mapache displays:
+
 - Changes since parent (new/changed/deleted/unchanged files and dirs)
 - Data and metadata sizes (raw vs compressed)
 - The new snapshot ID
@@ -700,6 +705,7 @@ be a snapshot ID prefix or `latest` (default).
 | `--quit-on-error` | Exit immediately on the first restore error |
 | `--sparse` | Create sparse files instead of preallocating |
 | `--verify` | Force content verification (hash check) even if mtime matches |
+| `--batch-size <N>` | Max files per batch. Limits peak memory. Default: no limit (all files at once) |
 | `--dry-run` | Simulate restoration |
 
 ### Conflict Strategies
@@ -848,6 +854,7 @@ mapache stats --full -r <URL>   # Parse pack footers (expensive)
 ```
 
 Shows:
+
 - **Packs**: count, total size, optional footer analysis (blob count, encoded
   vs raw sizes, dangling blobs)
 - **Index**: count, size, indexed blobs, raw/encoded sizes
@@ -965,6 +972,7 @@ mapache clean --dry-run -r <URL>      # Simulate
 ```
 
 The garbage collector:
+
 1. Scans all snapshots to determine which blobs are still referenced.
 2. Identifies:
    - **Unused packs** — packs where no blobs are referenced (removed).
@@ -995,11 +1003,13 @@ mapache verify --with-cache                # Use local cache
 ```
 
 #### Logical Verification (default)
+
 - Checks that every snapshot references known tree blobs.
 - Checks that every indexed blob points to an existing pack file.
 - Verifies snapshot tree traversal integrity.
 
 #### Physical Verification (`--read-packs`)
+
 - Reads, decrypts, and hashes every blob in every pack (or a sample).
 - Detects bit-rot (pack file hash mismatch) and individual blob corruption.
 - Reports corrupt blobs and the files/snapshots they affect.
@@ -1231,6 +1241,7 @@ mapache tui -r <URL>
 ```
 
 Launches an interactive terminal user interface with screens for:
+
 - **Dashboard** — overview of the repository with version info and key stats
 - **File explorer** — browse snapshot contents with inline detail panel
 - **Snapshot detail** — inspect individual snapshots
@@ -1342,6 +1353,7 @@ These options are available on most commands (exceptions: `bundle`, `cache`,
 ## 21. Full Command Reference
 
 ### `mapache init`
+
 Initialize a new backup repository.
 
 ```
@@ -1349,6 +1361,7 @@ mapache init -r <URL>
 ```
 
 ### `mapache snapshot`
+
 Create a new backup snapshot.
 
 ```
@@ -1370,6 +1383,7 @@ mapache snapshot [PATHS...] -r <URL>
 ```
 
 ### `mapache restore`
+
 Restore a snapshot to a target path.
 
 ```
@@ -1386,10 +1400,12 @@ mapache restore [SNAPSHOT] --target <PATH> -r <URL>
   --quit-on-error         Exit immediately on restore error
   --sparse                Create sparse files
   --verify                Force content verification
+  --batch-size <N>        Max files per batch (limits memory; default: no limit)
   --dry-run               Simulate restoration
 ```
 
 ### `mapache forget`
+
 Remove snapshots and apply retention policies.
 
 ```
@@ -1412,6 +1428,7 @@ mapache forget [SNAPSHOT_IDS...] -r <URL>
 ```
 
 ### `mapache log`
+
 Show snapshots in the repository.
 
 ```
@@ -1423,6 +1440,7 @@ mapache log [SNAPSHOT_ID] -r <URL>
 ```
 
 ### `mapache ls`
+
 List nodes/files in a snapshot.
 
 ```
@@ -1434,6 +1452,7 @@ mapache ls [SNAPSHOT] -r <URL>
 ```
 
 ### `mapache find`
+
 Find files and directories in the repository.
 
 ```
@@ -1445,6 +1464,7 @@ mapache find <TARGET> -r <URL>
 Exits with a non-zero code on error.
 
 ### `mapache diff`
+
 Show differences between snapshots.
 
 ```
@@ -1452,6 +1472,7 @@ mapache diff <SOURCE_ID> <TARGET_ID> -r <URL>
 ```
 
 ### `mapache dump`
+
 Print the contents of a file from a snapshot to stdout.
 
 ```
@@ -1460,6 +1481,7 @@ mapache dump [SNAPSHOT] -r <URL>
 ```
 
 ### `mapache stats`
+
 Show repository statistics.
 
 ```
@@ -1468,6 +1490,7 @@ mapache stats -r <URL>
 ```
 
 ### `mapache clean`
+
 Run garbage collection.
 
 ```
@@ -1478,6 +1501,7 @@ mapache clean -r <URL>
 ```
 
 ### `mapache verify`
+
 Verify repository integrity.
 
 ```
@@ -1490,6 +1514,7 @@ mapache verify -r <URL>
 ```
 
 ### `mapache key`
+
 Manage repository key files.
 
 ```
@@ -1501,6 +1526,7 @@ mapache key export <KEY_ID> -r <URL> [-o <PATH>]
 ```
 
 ### `mapache bundle`
+
 Create, extract, or mount `.mapache` bundle files.
 
 ```
@@ -1522,6 +1548,7 @@ mapache bundle -m <INPUT.mapache> <MOUNTPOINT> [OPTIONS]
 ```
 
 ### `mapache mount`
+
 Mount repository or bundle as FUSE filesystem (Unix only).
 
 ```
@@ -1536,6 +1563,7 @@ mapache mount <MOUNTPOINT> -r <URL>
 Exits with a non-zero code on error.
 
 ### `mapache cat`
+
 Print repository objects.
 
 ```
@@ -1545,6 +1573,7 @@ mapache cat <type>:<ID> -r <URL>
 ```
 
 ### `mapache amend`
+
 Modify an existing snapshot.
 
 ```
@@ -1560,6 +1589,7 @@ mapache amend [SNAPSHOT] -r <URL>
 ```
 
 ### `mapache recall`
+
 Recover a dropped (forgotten) snapshot.
 
 ```
@@ -1567,6 +1597,7 @@ mapache recall <SNAPSHOT_ID> -r <URL>
 ```
 
 ### `mapache rebuild-index`
+
 Rebuild the index by scanning all packs.
 
 ```
@@ -1575,6 +1606,7 @@ mapache rebuild-index -r <URL>
 ```
 
 ### `mapache rechunk`
+
 Rechunk all snapshots with current parameters.
 
 ```
@@ -1582,6 +1614,7 @@ mapache rechunk -r <URL>
 ```
 
 ### `mapache copy`
+
 Transfer snapshots between repositories.
 
 ```
@@ -1596,6 +1629,7 @@ mapache copy --from <URL> -r <URL>
 ```
 
 ### `mapache sync`
+
 Synchronize a repository to another backend.
 
 ```
@@ -1607,6 +1641,7 @@ mapache sync --target <URL> -r <URL>
 ```
 
 ### `mapache unlock`
+
 Remove stale locks.
 
 ```
@@ -1615,6 +1650,7 @@ mapache unlock -r <URL>
 ```
 
 ### `mapache cache`
+
 Manage local cache directories.
 
 ```
@@ -1624,6 +1660,7 @@ mapache cache
 ```
 
 ### `mapache completion`
+
 Generate shell completion scripts.
 
 ```
@@ -1633,6 +1670,7 @@ mapache completion --shell <SHELL> --path <DIR>
 ```
 
 ### `mapache config`
+
 Manage repository configuration.
 
 ```
@@ -1641,6 +1679,7 @@ mapache config template [--output <PATH>]
 ```
 
 ### `mapache tui`
+
 Launch terminal user interface (requires `tui` feature).
 
 ```


### PR DESCRIPTION
Set of changes to improve the restorer.

1. Restore metadata in a more correct order.
2. Allow batching files for restoration. Instead of restoring all nodes at once, --batch-size allows selecting the number of nodes that will be restored in each batch, reducing the amount of memory used at a given time.
3. Verify hardlink content and fall back to copy on failure.
4. `fsync` metadata after restore