### PR TITLE
feat: pass hooks as command options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ### Added
 
-- **`hooks`**: Added pre/post hook support for `snapshot`, `restore`,  `forget`,
+- **`hooks`**: Added pre/post hook support for `snapshot`, `restore`, `forget`,
   `clean`, and `verify` commands. Hooks are configured in the TOML config file
   and receive `MAPACHE_COMMAND`, `MAPACHE_REPOSITORY`, and `MAPACHE_RESULT`
   environment variables. Optional timeout per hook. Skipped on `--dry-run`.
+  Supports `--pre-hook` and `--post-hook` CLI flags to override the
+  TOML-configured hooks for a single invocation. Only the hooks for the active
+  command are loaded into memory.
 
 ### Changed
 

--- a/crates/mapache/src/commands/cmd_clean.rs
+++ b/crates/mapache/src/commands/cmd_clean.rs
@@ -5,13 +5,12 @@ use serde::Serialize;
 
 use crate::{
     backend::new_backend_with_prompt,
-    commands::{GlobalArgs, ToExitCode, cleanup::CleanupHandler, with_repository_lock},
+    commands::{GlobalArgs, HookArgs, ToExitCode, cleanup::CleanupHandler, with_repository_lock},
     common::{defaults::DEFAULT_GC_TOLERANCE, error::MapacheError, hooks},
     repository::{gc, lock::LockHandle, repo::Repository},
     ui::{
         self,
-        cli::color::Colorize,
-        cli::gc as cli_gc,
+        cli::{color::Colorize, gc as cli_gc},
         events::{Event, GcEvent},
     },
     utils::{self},
@@ -65,6 +64,9 @@ pub struct CmdArgs {
     /// making changes to the repository.
     #[clap(long, default_value_t = false)]
     pub dry_run: bool,
+
+    #[clap(flatten)]
+    pub hook_args: HookArgs,
 }
 
 pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), CleanError> {
@@ -84,7 +86,13 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), CleanEr
         |repo, _, lock_handle| async move {
             if !args.dry_run {
                 // Run pre-hook: abort command if it fails
-                hooks::run_pre(hooks::clean(), "clean", &global_args.repo).await?;
+                hooks::run_pre(
+                    hooks::command_hooks(),
+                    "clean",
+                    &global_args.repo,
+                    args.hook_args.pre_hook.as_deref(),
+                )
+                .await?;
             }
 
             run_with_repo(global_args.json, args, repo, lock_handle).await
@@ -98,7 +106,14 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), CleanEr
     };
     if !args.dry_run {
         // Run post-hook: warning on failure, always continues
-        hooks::run_post(hooks::clean(), "clean", &global_args.repo, &result_str).await;
+        hooks::run_post(
+            hooks::command_hooks(),
+            "clean",
+            &global_args.repo,
+            &result_str,
+            args.hook_args.post_hook.as_deref(),
+        )
+        .await;
     }
 
     repo_result.map_err(|e| CleanError::RepoOpenFail(e.to_string()))

--- a/crates/mapache/src/commands/cmd_forget.rs
+++ b/crates/mapache/src/commands/cmd_forget.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     backend::new_backend_with_prompt,
     commands::{
-        self, GlobalArgs, Merge, ToExitCode, cleanup::CleanupHandler, merge_opt, parse_tags,
-        with_repository_lock,
+        self, GlobalArgs, HookArgs, Merge, ToExitCode, cleanup::CleanupHandler, merge_opt,
+        parse_tags, with_repository_lock,
     },
     common::{ContentIdType, ID, defaults::DEFAULT_GC_TOLERANCE, error::MapacheError, hooks},
     repository::{
@@ -136,6 +136,9 @@ pub struct CmdArgs {
     /// pack file before repacking.
     #[clap(short, long)]
     pub tolerance: Option<f32>,
+
+    #[clap(flatten)]
+    pub hook_args: HookArgs,
 }
 
 impl CmdArgs {
@@ -157,6 +160,7 @@ impl CmdArgs {
             dry_run: false,
             run_gc: false,
             tolerance: Some(0.0),
+            hook_args: HookArgs::default(),
         }
     }
 }
@@ -269,7 +273,13 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), ForgetE
 
             if !dry_run {
                 // Run pre-hook: abort command if it fails
-                hooks::run_pre(hooks::forget(), "forget", &global_args.repo).await?;
+                hooks::run_pre(
+                    hooks::command_hooks(),
+                    "forget",
+                    &global_args.repo,
+                    args.hook_args.pre_hook.as_deref(),
+                )
+                .await?;
             }
 
             forget_phase(repo.clone(), args, json_output, &cleanup_handler).await?;
@@ -287,6 +297,7 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), ForgetE
                     tolerance: args.tolerance.unwrap_or(DEFAULT_GC_TOLERANCE * 100.0),
                     dry_run,
                     no_repack: false,
+                    hook_args: HookArgs::default(),
                 };
                 commands::cmd_clean::run_with_repo(json_output, &gc_args, repo, lock_handle)
                     .await
@@ -304,7 +315,14 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), ForgetE
     };
     if !dry_run {
         // Run post-hook: warning on failure, always continues
-        hooks::run_post(hooks::forget(), "forget", &global_args.repo, &result_str).await;
+        hooks::run_post(
+            hooks::command_hooks(),
+            "forget",
+            &global_args.repo,
+            &result_str,
+            args.hook_args.post_hook.as_deref(),
+        )
+        .await;
     }
 
     repo_result

--- a/crates/mapache/src/commands/cmd_restore.rs
+++ b/crates/mapache/src/commands/cmd_restore.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     backend::new_backend_with_prompt,
     commands::{
-        GlobalArgs, Merge, ToExitCode, UseSnapshot, cleanup::CleanupHandler, find_use_snapshot,
-        merge_opt, with_repository_lock,
+        GlobalArgs, HookArgs, Merge, ToExitCode, UseSnapshot, cleanup::CleanupHandler,
+        find_use_snapshot, merge_opt, with_repository_lock,
     },
     common::{defaults::SHORT_SNAPSHOT_ID_LEN, error::MapacheError, hooks},
     fs::{
@@ -170,6 +170,9 @@ pub struct CmdArgs {
     /// Dry run
     #[clap(long)]
     pub dry_run: bool,
+
+    #[clap(flatten)]
+    pub hook_args: HookArgs,
 }
 
 impl CmdArgs {
@@ -190,6 +193,7 @@ impl CmdArgs {
             quit_on_error: Some(false),
             sparse: Some(false),
             verify: Some(true),
+            hook_args: HookArgs::default(),
         }
     }
 }
@@ -307,7 +311,13 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), Restore
 
             if !dry_run {
                 // Run pre-hook: abort command if it fails
-                hooks::run_pre(hooks::restore(), "restore", &global_args.repo).await?;
+                hooks::run_pre(
+                    hooks::command_hooks(),
+                    "restore",
+                    &global_args.repo,
+                    args.hook_args.pre_hook.as_deref(),
+                )
+                .await?;
             }
 
             run_with_repo(
@@ -332,7 +342,14 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), Restore
     };
     if !dry_run {
         // Run post-hook: warning on failure, always continues
-        hooks::run_post(hooks::restore(), "restore", &global_args.repo, &result_str).await;
+        hooks::run_post(
+            hooks::command_hooks(),
+            "restore",
+            &global_args.repo,
+            &result_str,
+            args.hook_args.post_hook.as_deref(),
+        )
+        .await;
     }
 
     repo_result

--- a/crates/mapache/src/commands/cmd_snapshot.rs
+++ b/crates/mapache/src/commands/cmd_snapshot.rs
@@ -14,8 +14,8 @@ use crate::{
     archiver::{self, SnapshotOptions, progress::SnapshotProcessSummary},
     backend::{StorageHint, new_backend_with_prompt},
     commands::{
-        EMPTY_TAG_MARK, GlobalArgs, Merge, ToExitCode, UseSnapshot, cleanup::CleanupHandler,
-        find_use_snapshot, merge_opt, parse_tags, with_repository_lock,
+        EMPTY_TAG_MARK, GlobalArgs, HookArgs, Merge, ToExitCode, UseSnapshot,
+        cleanup::CleanupHandler, find_use_snapshot, merge_opt, parse_tags, with_repository_lock,
     },
     common::{
         self, ContentIdType, ID, config,
@@ -155,6 +155,9 @@ pub struct CmdArgs {
     /// Requires --auth-file or MAPACHE_USERNAME/MAPACHE_PASSWORD env vars.
     #[clap(long, conflicts_with_all = &["paths", "exclude", "exclude_file", "parent", "as_root"])]
     pub stdin: bool,
+
+    #[clap(flatten)]
+    pub hook_args: HookArgs,
 }
 
 impl CmdArgs {
@@ -175,6 +178,7 @@ impl CmdArgs {
             dry_run: false,
             with_atime: Some(false),
             stdin: false,
+            hook_args: HookArgs::default(),
         }
     }
 }
@@ -353,7 +357,13 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), Snapsho
 
             if !dry_run {
                 // Run pre-hook: abort command if it fails
-                hooks::run_pre(hooks::snapshot(), "snapshot", &global_args.repo).await?;
+                hooks::run_pre(
+                    hooks::command_hooks(),
+                    "snapshot",
+                    &global_args.repo,
+                    args.hook_args.pre_hook.as_deref(),
+                )
+                .await?;
             }
 
             let result = run_with_repo(
@@ -427,10 +437,11 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), Snapsho
     if !dry_run {
         // Run post-hook: warning on failure, always continues
         hooks::run_post(
-            hooks::snapshot(),
+            hooks::command_hooks(),
             "snapshot",
             &global_args.repo,
             &result_str,
+            args.hook_args.post_hook.as_deref(),
         )
         .await;
     }

--- a/crates/mapache/src/commands/cmd_verify.rs
+++ b/crates/mapache/src/commands/cmd_verify.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 
 use crate::{
     backend::new_backend_with_prompt,
-    commands::{GlobalArgs, ToExitCode, cleanup::CleanupHandler, with_repository_lock},
+    commands::{GlobalArgs, HookArgs, ToExitCode, cleanup::CleanupHandler, with_repository_lock},
     common::{
         ID, defaults::UI_RATE_ESTIMATOR_WINDOW, error::MapacheError, global::GlobalOpts, hooks,
     },
@@ -91,6 +91,9 @@ pub struct CmdArgs {
     /// Verify only a random percentage of packs (e.g. 10.5%)
     #[clap(long, value_parser = parse_sample_percentage)]
     pub sample: Option<f64>,
+
+    #[clap(flatten)]
+    pub hook_args: HookArgs,
 }
 
 fn parse_sample_percentage(s: &str) -> Result<f64, String> {
@@ -177,7 +180,13 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), VerifyE
         global_args.retry_lock_duration,
         global_args.no_lock,
         |repo, secure_storage, lock_handle| async move {
-            hooks::run_pre(hooks::verify(), "verify", &global_args.repo).await?;
+            hooks::run_pre(
+                hooks::command_hooks(),
+                "verify",
+                &global_args.repo,
+                args.hook_args.pre_hook.as_deref(),
+            )
+            .await?;
 
             run_with_repo(repo, secure_storage, lock_handle, args, json_out).await
         },
@@ -188,7 +197,14 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), VerifyE
         Ok(_) => "success".to_string(),
         Err(e) => format!("{e}"),
     };
-    hooks::run_post(hooks::verify(), "verify", &global_args.repo, &result_str).await;
+    hooks::run_post(
+        hooks::command_hooks(),
+        "verify",
+        &global_args.repo,
+        &result_str,
+        args.hook_args.post_hook.as_deref(),
+    )
+    .await;
 
     repo_result.map_err(|e| match e {
         VerifyError::Repo(err) => VerifyError::RepoOpenFail(err.inner()),

--- a/crates/mapache/src/commands/mod.rs
+++ b/crates/mapache/src/commands/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use error::ToExitCode;
 use std::{collections::BTreeSet, env, path::PathBuf, str::FromStr, sync::Arc};
 
 use chrono::Duration;
-use clap::{ArgGroup, CommandFactory, FromArgMatches, Parser, Subcommand};
+use clap::{ArgGroup, Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use serde::{Deserialize, Serialize, Serializer};
 use zeroize::Zeroizing;
 
@@ -249,6 +249,20 @@ impl CliGlobalArgs {
             no_lock: Some(false),
         }
     }
+}
+
+/// CLI flags for overriding hooks. Flattened into each command's CmdArgs.
+#[derive(Args, Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HookArgs {
+    /// Shell command to run before the main command (overrides TOML pre-hook)
+    #[clap(long = "pre-hook")]
+    #[serde(skip)]
+    pub pre_hook: Option<String>,
+
+    /// Shell command to run after the main command (overrides TOML post-hook)
+    #[clap(long = "post-hook")]
+    #[serde(skip)]
+    pub post_hook: Option<String>,
 }
 
 impl Merge for CliGlobalArgs {
@@ -601,8 +615,18 @@ pub async fn parse_and_run() -> i32 {
     // Initialize runtime defaults from config
     init_runtime_defaults(config.runtime.as_ref());
 
-    // Initialize hooks from config
-    hooks::init(config.hooks.clone().unwrap_or_default());
+    // Initialize hooks for the current command only
+    let command_name = match &args.command {
+        Command::Snapshot(_) => Some("snapshot"),
+        Command::Restore(_) => Some("restore"),
+        Command::Forget(_) => Some("forget"),
+        Command::Clean(_) => Some("clean"),
+        Command::Verify(_) => Some("verify"),
+        _ => None,
+    };
+    let cmd_hooks =
+        command_name.and_then(|name| config.hooks.as_ref().and_then(|h| h.get_command(name)));
+    hooks::init(cmd_hooks);
 
     let (global_result, command_result) = match args.command {
         // Commands without repository URL

--- a/crates/mapache/src/common/config.rs
+++ b/crates/mapache/src/common/config.rs
@@ -185,6 +185,17 @@ pub struct HooksConfig {
 }
 
 impl HooksConfig {
+    pub(crate) fn get_command(&self, name: &str) -> Option<CommandHooks> {
+        match name {
+            "snapshot" => self.snapshot.clone(),
+            "restore" => self.restore.clone(),
+            "forget" => self.forget.clone(),
+            "clean" => self.clean.clone(),
+            "verify" => self.verify.clone(),
+            _ => None,
+        }
+    }
+
     pub(crate) fn template() -> Self {
         Self {
             snapshot: Some(CommandHooks {

--- a/crates/mapache/src/common/hooks.rs
+++ b/crates/mapache/src/common/hooks.rs
@@ -5,49 +5,38 @@ use tokio::{process::Command, time::timeout};
 use crate::{
     common::error::{MapacheError, Result},
     common::{
-        config::{CommandHooks, HooksConfig},
+        config::CommandHooks,
         vars::{PASSWORD_ENVVAR, USERNAME_ENVVAR},
     },
 };
 
-static HOOKS: OnceLock<HooksConfig> = OnceLock::new();
+static HOOKS: OnceLock<Option<CommandHooks>> = OnceLock::new();
 
-const DEFAULT_HOOKS: HooksConfig = HooksConfig {
-    snapshot: None,
-    restore: None,
-    forget: None,
-    clean: None,
-    verify: None,
-};
-
-pub(crate) fn init(hooks: HooksConfig) {
+pub(crate) fn init(hooks: Option<CommandHooks>) {
     let _ = HOOKS.set(hooks);
 }
 
-pub(crate) fn config() -> &'static HooksConfig {
-    HOOKS.get().unwrap_or(&DEFAULT_HOOKS)
+pub(crate) fn command_hooks() -> Option<&'static CommandHooks> {
+    HOOKS.get().and_then(|h| h.as_ref())
 }
-
-macro_rules! hook_accessor {
-    ($name:ident) => {
-        pub(crate) fn $name() -> Option<&'static CommandHooks> {
-            config().$name.as_ref()
-        }
-    };
-}
-
-hook_accessor!(snapshot);
-hook_accessor!(restore);
-hook_accessor!(forget);
-hook_accessor!(clean);
-hook_accessor!(verify);
 
 /// Run the pre-hook. Fails (aborts the command) if the hook exits non-zero.
+/// If `cli_hook` is provided and non-empty, it overrides the TOML pre-hook.
 pub(crate) async fn run_pre(
     cmd_hooks: Option<&CommandHooks>,
     command_name: &str,
     repo: &str,
+    cli_hook: Option<&str>,
 ) -> Result<()> {
+    // CLI override takes priority
+    if let Some(cmd) = cli_hook.filter(|s| !s.is_empty()) {
+        if let Err(e) = run_hook(cmd, command_name, repo, None, None).await {
+            tracing::error!(target: "hooks", "pre-hook failed: {e}");
+            return Err(e);
+        }
+        return Ok(());
+    }
+
     let Some(hook) = cmd_hooks.and_then(|h| h.pre.as_ref()) else {
         return Ok(());
     };
@@ -66,12 +55,22 @@ pub(crate) async fn run_pre(
 }
 
 /// Run the post-hook. Warnings are logged on failure.
+/// If `cli_hook` is provided and non-empty, it overrides the TOML post-hook.
 pub(crate) async fn run_post(
     cmd_hooks: Option<&CommandHooks>,
     command_name: &str,
     repo: &str,
     result: &str,
+    cli_hook: Option<&str>,
 ) {
+    // CLI override takes priority
+    if let Some(cmd) = cli_hook.filter(|s| !s.is_empty()) {
+        if let Err(e) = run_hook(cmd, command_name, repo, Some(result), None).await {
+            tracing::warn!(target: "hooks", "post-hook warning: {e}");
+        }
+        return;
+    }
+
     let Some(hook) = cmd_hooks.and_then(|h| h.post.as_ref()) else {
         return;
     };
@@ -246,24 +245,51 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_pre() {
-        assert!(run_pre(None, "cmd", "repo").await.is_ok());
-        assert!(run_pre(Some(&pre_hooks("")), "cmd", "repo").await.is_ok());
+        assert!(run_pre(None, "cmd", "repo", None).await.is_ok());
         assert!(
-            run_pre(Some(&pre_hooks("true")), "cmd", "repo")
+            run_pre(Some(&pre_hooks("")), "cmd", "repo", None)
                 .await
                 .is_ok()
         );
         assert!(
-            run_pre(Some(&pre_hooks("false")), "cmd", "repo")
+            run_pre(Some(&pre_hooks("true")), "cmd", "repo", None)
+                .await
+                .is_ok()
+        );
+        assert!(
+            run_pre(Some(&pre_hooks("false")), "cmd", "repo", None)
                 .await
                 .is_err()
+        );
+        // CLI override takes priority over TOML
+        assert!(
+            run_pre(Some(&pre_hooks("false")), "cmd", "repo", Some("true"))
+                .await
+                .is_ok()
+        );
+        assert!(run_pre(None, "cmd", "repo", Some("false")).await.is_err());
+        // Empty CLI hook falls through to TOML
+        assert!(
+            run_pre(Some(&pre_hooks("true")), "cmd", "repo", Some(""))
+                .await
+                .is_ok()
         );
     }
 
     #[tokio::test]
     async fn test_run_post() {
-        run_post(None, "cmd", "repo", "success").await;
-        run_post(Some(&post_hooks("")), "cmd", "repo", "success").await;
-        run_post(Some(&post_hooks("false")), "cmd", "repo", "success").await;
+        run_post(None, "cmd", "repo", "success", None).await;
+        run_post(Some(&post_hooks("")), "cmd", "repo", "success", None).await;
+        run_post(Some(&post_hooks("false")), "cmd", "repo", "success", None).await;
+        // CLI override takes priority
+        run_post(
+            Some(&post_hooks("false")),
+            "cmd",
+            "repo",
+            "success",
+            Some("true"),
+        )
+        .await;
+        run_post(None, "cmd", "repo", "success", Some("false")).await;
     }
 }

--- a/crates/mapache/tests/integration_tests/mod.rs
+++ b/crates/mapache/tests/integration_tests/mod.rs
@@ -345,6 +345,7 @@ impl VerifyBuilder {
                 with_cache: false,
                 fail_early: false,
                 sample: None,
+                hook_args: Default::default(),
             },
         }
     }
@@ -422,6 +423,7 @@ impl SnapshotBuilder {
                 dry_run: false,
                 with_atime: None,
                 stdin: false,
+                hook_args: Default::default(),
             },
         }
     }
@@ -521,6 +523,7 @@ impl RestoreBuilder {
                 delete: Some(false),
                 no_preserve_root: Some(false),
                 batch_size: None,
+                hook_args: Default::default(),
             },
         }
     }
@@ -713,6 +716,7 @@ impl ForgetBuilder {
                 keep_tags: None,
                 hosts: Vec::new(),
                 keep_min: None,
+                hook_args: Default::default(),
             },
         }
     }
@@ -752,6 +756,7 @@ impl CleanBuilder {
                 tolerance: 0.0,
                 dry_run: false,
                 no_repack: false,
+                hook_args: Default::default(),
             },
         }
     }

--- a/crates/mapache/tests/integration_tests/test_cmd_mount.rs
+++ b/crates/mapache/tests/integration_tests/test_cmd_mount.rs
@@ -128,6 +128,7 @@ async fn inner_test_mount(auto_mount: bool) -> Result<()> {
         dry_run: false,
         with_atime: None,
         stdin: false,
+        hook_args: Default::default(),
     };
     commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
         .await
@@ -249,6 +250,7 @@ async fn test_mount_multiple_snapshots() -> Result<()> {
         dry_run: false,
         with_atime: None,
         stdin: false,
+        hook_args: Default::default(),
     };
     commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
         .await
@@ -278,6 +280,7 @@ async fn test_mount_multiple_snapshots() -> Result<()> {
         dry_run: false,
         with_atime: None,
         stdin: false,
+        hook_args: Default::default(),
     };
     commands::cmd_snapshot::run(&ctx.global, &snapshot_args)
         .await


### PR DESCRIPTION
Commands supporting hooks now hace --pre-hook and --post-hook flags. Hooks are loaded lazily instead of statically.