### PR TITLE
feat(restore): incremental restore with --verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ### Changed
 
+- **Incremental restore with `--verify`**: When `--verify` is used, the restorer
+  now checks each blob individually against the local file content. Only blobs
+  whose content has changed are downloaded and written; unchanged blobs are
+  skipped, preserving existing bytes on disk. This significantly speeds up
+  repeated restores of large files where only a fraction of the content changed.
 - **Restorer**: Ordered metadata restoration as chown, xattrs, chmod, mtime;
   batched file restoration with a streaming pass;verify hardlink content and
   fall back to copy on failure.

--- a/crates/mapache/src/restorer/mod.rs
+++ b/crates/mapache/src/restorer/mod.rs
@@ -10,6 +10,8 @@ mod pack_restorer;
 mod planner;
 mod sync;
 
+pub(crate) use planner::RestorePlan;
+
 pub use sync::{SyncOpts, delete_nodes};
 
 #[cfg(not(unix))]
@@ -35,7 +37,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     common::{ID, defaults},
-    fs::tree::SerializedNodeStream,
+    fs::{node::Node, tree::SerializedNodeStream},
     repository::{repo::Repository, snapshot::Snapshot},
     ui::events::{Event, EventSender, RestoreEvent, emit_event},
     utils,
@@ -127,6 +129,9 @@ pub(crate) struct FileRestorePlan {
     pub(crate) num_blobs: u32,
     pub(crate) size: u64,
     pub(crate) is_hardlink: bool,
+    /// When true, the file was opened without truncation and only changed blobs
+    /// were written. Used by the incremental restorer (--verify).
+    pub(crate) is_selective: bool,
 }
 
 #[derive(Clone)]
@@ -205,27 +210,38 @@ impl FileHandleCache {
                 })?;
             }
 
-            let mut f = Self::open_file_for_restore(path, true).map_err(|e| {
-                MapacheError::Internal(format!(
-                    "failed to create/truncate file: {}: {e}",
-                    path.display()
-                ))
-            })?;
+            let f = if plan.is_selective {
+                // Selective restore: open without truncating so unchanged bytes are preserved.
+                Self::open_file_for_restore(path, false).map_err(|e| {
+                    MapacheError::Internal(format!(
+                        "failed to open file for selective restore: {}: {e}",
+                        path.display()
+                    ))
+                })?
+            } else {
+                let mut f = Self::open_file_for_restore(path, true).map_err(|e| {
+                    MapacheError::Internal(format!(
+                        "failed to create/truncate file: {}: {e}",
+                        path.display()
+                    ))
+                })?;
 
-            if plan.size > 0 {
-                if restorer.opts.preallocate {
-                    if let Err(e) = restorer.preallocate_file(&mut f, plan.size) {
-                        tracing::warn!(target: "restorer", "Failed to preallocate file {}: {e}", path.display());
+                if plan.size > 0 {
+                    if restorer.opts.preallocate {
+                        if let Err(e) = restorer.preallocate_file(&mut f, plan.size) {
+                            tracing::warn!(target: "restorer", "Failed to preallocate file {}: {e}", path.display());
+                        }
+                    } else {
+                        f.set_len(plan.size).map_err(|e| {
+                            MapacheError::Internal(format!(
+                                "failed to set length for sparse file: {}: {e}",
+                                path.display()
+                            ))
+                        })?;
                     }
-                } else {
-                    f.set_len(plan.size).map_err(|e| {
-                        MapacheError::Internal(format!(
-                            "failed to set length for sparse file: {}: {e}",
-                            path.display()
-                        ))
-                    })?;
                 }
-            }
+                f
+            };
 
             initialized.store(true, std::sync::atomic::Ordering::Release);
             f
@@ -604,13 +620,132 @@ impl Restorer {
 
             // File: check strategy, then add to accumulator
             if node.is_file() {
-                let should_restore = self
+                let restore_plan = self
                     .should_restore_node(&node, &restore_path, index.clone())
                     .await;
 
-                let skip_file = match should_restore {
-                    Ok(true) => false,
-                    Ok(false) => true,
+                match restore_plan {
+                    Ok(RestorePlan::Skip) => {
+                        if dry_run {
+                            emit_event(
+                                &self.event_sender,
+                                Event::Restore(RestoreEvent::ItemProcessed(restore_path)),
+                            );
+                        }
+                        continue;
+                    }
+                    Ok(RestorePlan::SelectiveRestore { changed_blobs }) => {
+                        // Look up all blobs to compute offsets, but only add changed ones to pack map
+                        let mut file_blobs = Vec::new();
+                        if let Some(blobs) = &node.blobs {
+                            let mut offset_in_file = 0u64;
+                            for blob_id in blobs {
+                                match index.get_data(blob_id) {
+                                    Some(locator) => {
+                                        file_blobs.push((*blob_id, locator, offset_in_file));
+                                        offset_in_file += locator.raw_length as u64;
+                                    }
+                                    None => {
+                                        emit_event(
+                                            &self.event_sender,
+                                            Event::Restore(RestoreEvent::Error(format!(
+                                                "Blob {blob_id} not found in index"
+                                            ))),
+                                        );
+                                    }
+                                };
+                            }
+                        }
+
+                        // Emit BlobsSkipped event for incremental restore progress
+                        let total_blob_count = node.blobs.as_ref().map_or(0, |b| b.len());
+                        let skipped_count =
+                            (total_blob_count as u32).saturating_sub(changed_blobs.len() as u32);
+                        if skipped_count > 0 {
+                            let total_bytes: u64 = file_blobs
+                                .iter()
+                                .map(|(_, loc, _)| loc.raw_length as u64)
+                                .sum();
+                            let changed_bytes: u64 = changed_blobs
+                                .iter()
+                                .filter_map(|&idx| file_blobs.get(idx))
+                                .map(|(_, loc, _)| loc.raw_length as u64)
+                                .sum();
+                            emit_event(
+                                &self.event_sender,
+                                Event::Restore(RestoreEvent::BlobsSkipped {
+                                    count: skipped_count as u64,
+                                    bytes: total_bytes - changed_bytes,
+                                }),
+                            );
+                        }
+
+                        let file_idx = chunk_files.len();
+                        chunk_files.push(FileRestorePlan {
+                            path: restore_path.clone(),
+                            num_blobs: changed_blobs.len() as u32,
+                            size: node.metadata.size,
+                            is_hardlink: false,
+                            is_selective: true,
+                        });
+
+                        // Hardlink detection
+                        let is_hardlink_secondary = detect_hardlink(
+                            &node,
+                            &restore_path,
+                            &primary_hardlinks,
+                            &pending_hardlinks,
+                        );
+
+                        if is_hardlink_secondary {
+                            chunk_files[file_idx].is_hardlink = true;
+                        } else {
+                            for &blob_idx in &changed_blobs {
+                                if let Some((blob_id, locator, offset_in_file)) =
+                                    file_blobs.get(blob_idx)
+                                {
+                                    chunk_packs.entry(locator.pack_id).or_default().push((
+                                        *blob_id,
+                                        BlobRestoreRequest {
+                                            file_idx,
+                                            offset_in_file: *offset_in_file,
+                                            blob_offset: locator.offset,
+                                            blob_length: locator.length,
+                                            raw_length: locator.raw_length,
+                                        },
+                                    ));
+                                }
+                            }
+
+                            if let (Some(dev), Some(inode)) =
+                                (node.metadata.dev, node.metadata.inode)
+                                && node.metadata.nlink.unwrap_or(0) > 1
+                            {
+                                let node_blobs = node.blobs.as_deref().unwrap_or(&[]);
+                                let fingerprint = compute_blob_fingerprint(node_blobs);
+                                primary_hardlinks
+                                    .lock()
+                                    .entry((dev, inode))
+                                    .or_insert_with(|| (restore_path.clone(), fingerprint));
+                            }
+                        }
+
+                        // Flush if the chunk is full
+                        if chunk_files.len() >= batch_size {
+                            let chunk_files = Arc::new(std::mem::take(&mut chunk_files));
+                            let chunk_packs = Arc::new(std::mem::take(&mut chunk_packs));
+                            pack_restorer::restore_packs(
+                                self,
+                                chunk_files,
+                                chunk_packs,
+                                secure_storage.clone(),
+                                dry_run,
+                            )
+                            .await?;
+                        }
+                        continue;
+                    }
+                    Ok(RestorePlan::FullRestore) => { /* fall through to full restore below */ }
                     Err(e) => {
                         emit_event(
                             &self.event_sender,
@@ -623,21 +758,11 @@ impl Restorer {
                         if self.opts.quit_on_error {
                             return Err(MapacheError::Internal(format!("{e}")));
                         }
-                        true
+                        continue;
                     }
-                };
-
-                if skip_file {
-                    if dry_run {
-                        emit_event(
-                            &self.event_sender,
-                            Event::Restore(RestoreEvent::ItemProcessed(restore_path)),
-                        );
-                    }
-                    continue;
                 }
 
-                // Look up blobs
+                // Full restore: look up all blobs
                 let mut file_blobs = Vec::new();
                 if let Some(blobs) = &node.blobs {
                     let mut offset_in_file = 0;
@@ -665,49 +790,29 @@ impl Restorer {
                     num_blobs: 0,
                     size: node.metadata.size,
                     is_hardlink: false,
+                    is_selective: false,
                 });
 
                 // Hardlink detection with content verification
-                let is_hardlink_secondary = {
-                    if let (Some(dev), Some(inode)) = (node.metadata.dev, node.metadata.inode) {
-                        let nlink = node.metadata.nlink;
-                        if nlink.unwrap_or(0) > 1 {
-                            let node_blobs = node.blobs.as_deref().unwrap_or(&[]);
-                            let fingerprint = compute_blob_fingerprint(node_blobs);
-                            let mut idx = primary_hardlinks.lock();
-                            if let Some((primary_path, primary_fp)) = idx.get(&(dev, inode)) {
-                                if *primary_fp == fingerprint {
-                                    pending_hardlinks
-                                        .lock()
-                                        .push((restore_path.clone(), primary_path.clone()));
-                                    drop(idx);
-                                    chunk_files[file_idx].is_hardlink = true;
-                                    true
-                                } else {
-                                    drop(idx);
-                                    emit_event(
-                                        &self.event_sender,
-                                        Event::Restore(RestoreEvent::Warning(format!(
-                                            "Hardlink content mismatch for {}: blob fingerprint differs from primary, restoring as separate file",
-                                            restore_path.display()
-                                        ))),
-                                    );
-                                    false
-                                }
-                            } else {
-                                idx.insert((dev, inode), (restore_path.clone(), fingerprint));
-                                drop(idx);
-                                false
-                            }
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    }
-                };
+                let is_hardlink_secondary =
+                    detect_hardlink(&node, &restore_path, &primary_hardlinks, &pending_hardlinks);
 
-                if !is_hardlink_secondary {
+                if is_hardlink_secondary {
+                    chunk_files[file_idx].is_hardlink = true;
+                    if !dry_run
+                        && let Some(parent) = restore_path.parent()
+                        && let Err(e) = fs::create_dir_all(parent)
+                    {
+                        emit_event(
+                            &self.event_sender,
+                            Event::Restore(RestoreEvent::Error(format!(
+                                "Failed to create parent for hardlink {}: {}",
+                                restore_path.display(),
+                                e
+                            ))),
+                        );
+                    }
+                } else {
                     let num_blobs = file_blobs.len().min(u32::MAX as usize) as u32;
                     for (blob_id, locator, offset_in_file) in &file_blobs {
                         chunk_packs.entry(locator.pack_id).or_default().push((
@@ -722,29 +827,6 @@ impl Restorer {
                         ));
                     }
                     chunk_files[file_idx].num_blobs = num_blobs;
-
-                    if let (Some(dev), Some(inode)) = (node.metadata.dev, node.metadata.inode)
-                        && node.metadata.nlink.unwrap_or(0) > 1
-                    {
-                        let node_blobs = node.blobs.as_deref().unwrap_or(&[]);
-                        let fingerprint = compute_blob_fingerprint(node_blobs);
-                        primary_hardlinks
-                            .lock()
-                            .entry((dev, inode))
-                            .or_insert_with(|| (restore_path.clone(), fingerprint));
-                    }
-                } else if !dry_run
-                    && let Some(parent) = restore_path.parent()
-                    && let Err(e) = fs::create_dir_all(parent)
-                {
-                    emit_event(
-                        &self.event_sender,
-                        Event::Restore(RestoreEvent::Error(format!(
-                            "Failed to create parent for hardlink {}: {}",
-                            restore_path.display(),
-                            e
-                        ))),
-                    );
                 }
 
                 // Flush if the chunk is full
@@ -914,4 +996,39 @@ fn compute_blob_fingerprint(blobs: &[ID]) -> [u8; 32] {
         hasher.update(&blob_id.0);
     }
     hasher.finalize().into()
+}
+
+/// Detects whether a file node is a hardlink secondary (already seen primary).
+/// Returns `true` if this is a secondary and registers the pending hardlink.
+fn detect_hardlink(
+    node: &Node,
+    restore_path: &Path,
+    primary_hardlinks: &PrimaryHardlinks,
+    pending_hardlinks: &Arc<Mutex<Vec<HardlinkByPath>>>,
+) -> bool {
+    if let (Some(dev), Some(inode)) = (node.metadata.dev, node.metadata.inode) {
+        let nlink = node.metadata.nlink;
+        if nlink.unwrap_or(0) > 1 {
+            let node_blobs = node.blobs.as_deref().unwrap_or(&[]);
+            let fingerprint = compute_blob_fingerprint(node_blobs);
+            let mut idx = primary_hardlinks.lock();
+            if let Some((primary_path, primary_fp)) = idx.get(&(dev, inode)) {
+                if *primary_fp == fingerprint {
+                    pending_hardlinks
+                        .lock()
+                        .push((restore_path.to_path_buf(), primary_path.clone()));
+                    drop(idx);
+                    return true;
+                } else {
+                    drop(idx);
+                    return false;
+                }
+            } else {
+                idx.insert((dev, inode), (restore_path.to_path_buf(), fingerprint));
+                drop(idx);
+                return false;
+            }
+        }
+    }
+    false
 }

--- a/crates/mapache/src/restorer/pack_restorer.rs
+++ b/crates/mapache/src/restorer/pack_restorer.rs
@@ -76,7 +76,9 @@ pub(crate) async fn restore_packs(
     let handle_cache = Arc::new(ShardedFileHandleCache::new(defaults.restore_max_open_files));
 
     for (idx, file) in files.iter().enumerate() {
-        if file.num_blobs == 0 && !file.is_hardlink && !file.path.exists() || file.size == 0 {
+        if !file.is_selective
+            && (file.num_blobs == 0 && !file.is_hardlink && !file.path.exists() || file.size == 0)
+        {
             let mut cache_guard = handle_cache.get_shard(idx).lock();
             cache_guard.get_handle(idx, &file.path, file, &initialized[idx], restorer)?;
         }

--- a/crates/mapache/src/restorer/planner.rs
+++ b/crates/mapache/src/restorer/planner.rs
@@ -20,16 +20,29 @@ use crate::{
     utils::size,
 };
 
+/// Describes the restore decision for a single node.
+#[derive(Debug, Clone)]
+pub(crate) enum RestorePlan {
+    /// The node should not be restored (already matches or strategy says skip).
+    Skip,
+    /// The node must be fully restored (all blobs).
+    FullRestore,
+    /// Only the listed blob indices differ from local content and need download.
+    /// All other blobs already match the local file.
+    SelectiveRestore { changed_blobs: Vec<usize> },
+}
+
 impl Restorer {
-    /// Checks if a node should be restored based on the current restoration strategy.
+    /// Decides how a node should be restored based on the current strategy and
+    /// (when `verify` is enabled) per-blob content matching.
     pub(crate) async fn should_restore_node(
         &self,
         node: &Node,
         restore_path: &Path,
         index: Arc<MasterIndex>,
-    ) -> Result<bool> {
+    ) -> Result<RestorePlan> {
         if !repo_fs::path_exists(restore_path).await {
-            return Ok(true);
+            return Ok(RestorePlan::FullRestore);
         }
 
         if node.is_file()
@@ -44,28 +57,30 @@ impl Restorer {
                     .times_match(local_mtime, node.metadata.modified_time);
 
                 if mtime_matches && !self.opts.verify {
-                    return Ok(false);
+                    return Ok(RestorePlan::Skip);
                 }
 
-                let content_matches = match self
-                    .verify_file_content(node, restore_path, index)
-                    .await
-                {
-                    Ok(matches) => matches,
+                match self.verify_file_content(node, restore_path, index).await {
+                    Ok(changed) if changed.is_empty() => return Ok(RestorePlan::Skip),
+                    Ok(changed) => {
+                        let total = node.blobs.as_ref().map_or(0, |b| b.len());
+                        if changed.len() >= total {
+                            return Ok(RestorePlan::FullRestore);
+                        }
+                        return Ok(RestorePlan::SelectiveRestore {
+                            changed_blobs: changed,
+                        });
+                    }
                     Err(e) => {
                         tracing::warn!(target: "restorer", "Could not verify file {:?}: {e}", restore_path);
-                        false
                     }
-                };
-                if content_matches {
-                    return Ok(false);
                 }
             }
         }
 
         match self.opts.strategy {
-            Strategy::Overwrite => Ok(true),
-            Strategy::Skip => Ok(false),
+            Strategy::Overwrite => Ok(RestorePlan::FullRestore),
+            Strategy::Skip => Ok(RestorePlan::Skip),
             Strategy::Newer => {
                 let local_metadata = fs::symlink_metadata(restore_path).map_err(|e| {
                     MapacheError::Internal(format!(
@@ -84,21 +99,21 @@ impl Restorer {
 
                     let local_size = local_metadata.len();
                     if local_mtime < repo_mtime {
-                        return Ok(true);
+                        return Ok(RestorePlan::FullRestore);
                     }
 
                     if local_mtime == repo_mtime && local_size != node.metadata.size {
-                        return Ok(true);
+                        return Ok(RestorePlan::FullRestore);
                     }
 
-                    return Ok(false);
+                    return Ok(RestorePlan::Skip);
                 }
 
-                Ok(true)
+                Ok(RestorePlan::FullRestore)
             }
             Strategy::Fail => {
                 if node.is_dir() {
-                    return Ok(true);
+                    return Ok(RestorePlan::FullRestore);
                 }
                 Err(MapacheError::Internal(format!(
                     "target {} exists already",
@@ -109,29 +124,33 @@ impl Restorer {
     }
 
     /// Verifies that the content of a local file matches the blobs in the repository.
+    /// Returns the list of blob indices whose content does NOT match the local file
+    /// (i.e. blobs that need to be re-downloaded and written).
+    /// An empty vector means the entire file content is identical.
     async fn verify_file_content(
         &self,
         node: &Node,
         local_path: &Path,
         index: Arc<MasterIndex>,
-    ) -> Result<bool> {
+    ) -> Result<Vec<usize>> {
         let blobs = match &node.blobs {
             Some(b) => b.clone(),
-            None => return Ok(true),
+            None => return Ok(Vec::new()),
         };
 
         let local_path = local_path.to_path_buf();
         spawn_blocking(move || {
             let file = File::open(&local_path)?;
             let mut offset = 0;
+            let mut changed = Vec::new();
 
             const VERIFY_BUFFER_SIZE: usize = size::MiB as usize;
             let mut buffer = vec![0u8; VERIFY_BUFFER_SIZE];
 
-            for blob_id in blobs {
+            for (idx, blob_id) in blobs.iter().enumerate() {
                 let locator = index
-                    .get_data(&blob_id)
-                    .ok_or(MapacheError::NotInIndex(blob_id))?;
+                    .get_data(blob_id)
+                    .ok_or(MapacheError::NotInIndex(*blob_id))?;
 
                 let mut hasher = hash::Hasher::new();
                 let mut remaining = locator.raw_length as u64;
@@ -168,12 +187,12 @@ impl Restorer {
                 }
 
                 let actual_id = hasher.finalize();
-                if actual_id != blob_id {
-                    return Ok(false);
+                if actual_id != *blob_id {
+                    changed.push(idx);
                 }
                 offset += locator.raw_length as u64;
             }
-            Ok(true)
+            Ok(changed)
         })
         .await
         .map_err(|e| MapacheError::Internal(format!("background task failed: {e}")))?
@@ -200,6 +219,8 @@ mod tests {
     use crate::repository::repo::{Auth, Repository};
     use crate::restorer::{RestoreOptions, Restorer, Strategy};
     use crate::ui::events::noop_sender;
+
+    use super::RestorePlan;
 
     fn auth() -> Auth {
         Auth {
@@ -271,9 +292,12 @@ mod tests {
             let path = PathBuf::from("/does/not/exist");
             let index = Arc::new(MasterIndex::new());
             assert!(
-                restorer
-                    .should_restore_node(&file_node(100), &path, index)
-                    .await?,
+                matches!(
+                    restorer
+                        .should_restore_node(&file_node(100), &path, index)
+                        .await?,
+                    RestorePlan::FullRestore
+                ),
                 "strategy {strategy:?} should restore missing paths"
             );
         }
@@ -286,11 +310,12 @@ mod tests {
         let path = tmp.path().join("existing.txt");
         std::fs::write(&path, "data")?;
         let index = Arc::new(MasterIndex::new());
-        assert!(
+        assert!(matches!(
             restorer
                 .should_restore_node(&file_node(999), &path, index)
-                .await?
-        );
+                .await?,
+            RestorePlan::FullRestore
+        ));
         Ok(())
     }
 
@@ -300,11 +325,12 @@ mod tests {
         let path = tmp.path().join("existing.txt");
         std::fs::write(&path, "data")?;
         let index = Arc::new(MasterIndex::new());
-        assert!(
-            !restorer
+        assert!(matches!(
+            restorer
                 .should_restore_node(&file_node(999), &path, index)
-                .await?
-        );
+                .await?,
+            RestorePlan::Skip
+        ));
         Ok(())
     }
 
@@ -329,11 +355,12 @@ mod tests {
         let path = tmp.path().join("existing_dir");
         std::fs::create_dir(&path)?;
         let index = Arc::new(MasterIndex::new());
-        assert!(
+        assert!(matches!(
             restorer
                 .should_restore_node(&dir_node(), &path, index)
-                .await?
-        );
+                .await?,
+            RestorePlan::FullRestore
+        ));
         Ok(())
     }
 
@@ -356,7 +383,10 @@ mod tests {
             ..Default::default()
         };
         let index = Arc::new(MasterIndex::new());
-        assert!(!restorer.should_restore_node(&node, &path, index).await?);
+        assert!(matches!(
+            restorer.should_restore_node(&node, &path, index).await?,
+            RestorePlan::Skip
+        ));
         Ok(())
     }
 }

--- a/crates/mapache/src/ui/cli/restore.rs
+++ b/crates/mapache/src/ui/cli/restore.rs
@@ -238,6 +238,9 @@ pub(crate) fn make_event_sender(
             RestoreEvent::BytesProcessed(bytes) => {
                 state.processed_bytes(bytes);
             }
+            RestoreEvent::BlobsSkipped { count: _, bytes } => {
+                state.processed_bytes(bytes);
+            }
             RestoreEvent::Warning(ref msg) => {
                 state.warning(msg);
             }

--- a/crates/mapache/src/ui/events.rs
+++ b/crates/mapache/src/ui/events.rs
@@ -76,6 +76,8 @@ pub enum RestoreEvent {
     ItemProcessed(PathBuf),
     /// A number of bytes written.
     BytesProcessed(u64),
+    /// Blobs skipped because they already match local content (incremental restore).
+    BlobsSkipped { count: u64, bytes: u64 },
     /// Non-fatal warning.
     Warning(String),
     /// Recoverable error.

--- a/crates/mapache/src/ui/json/restore.rs
+++ b/crates/mapache/src/ui/json/restore.rs
@@ -152,6 +152,16 @@ pub(crate) fn make_event_sender(
                     state.emit_status_update();
                 }
             }
+            RestoreEvent::BlobsSkipped { count, bytes } => {
+                #[derive(Serialize)]
+                struct BlobsSkippedMsg {
+                    count: u64,
+                    bytes: u64,
+                }
+                state
+                    .json_reporter
+                    .emit("blobs_skipped", &BlobsSkippedMsg { count, bytes });
+            }
             RestoreEvent::Warning(ref msg) => {
                 state.warning_counter.fetch_add(1, Ordering::Relaxed);
                 state

--- a/crates/mapache/src/ui/tui/screens/restore/progress.rs
+++ b/crates/mapache/src/ui/tui/screens/restore/progress.rs
@@ -22,6 +22,10 @@ pub fn handle_event(state: &mut TaskProgressState, event: RestoreEvent) {
         RestoreEvent::BytesProcessed(bytes) => {
             state.add_processed_bytes(bytes);
         }
+        RestoreEvent::BlobsSkipped { count: _, bytes } => {
+            // Treat skipped bytes as processed (no download needed).
+            state.add_processed_bytes(bytes);
+        }
         RestoreEvent::Error(err) => {
             state.add_error(err);
         }

--- a/crates/mapache/tests/integration_tests/test_cmd_restore.rs
+++ b/crates/mapache/tests/integration_tests/test_cmd_restore.rs
@@ -913,4 +913,137 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_restore_incremental_skip_unchanged() -> Result<()> {
+        let ctx = TestContext::new().await?;
+        let backup_path = ctx._tmp_dir.path().join("backup");
+        std::fs::create_dir_all(&backup_path)?;
+
+        let file_path = backup_path.join("file.txt");
+        std::fs::write(&file_path, "Original content")?;
+
+        ctx.init_repo().await?;
+
+        // Snapshot
+        ctx.snapshot_builder(vec![file_path.clone()])
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
+
+        // First restore (creates the file)
+        let restore_path = ctx._tmp_dir.path().join("restore");
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .run(&ctx.global)
+            .await?;
+
+        let restored_file = restore_path.join("file.txt");
+        assert_eq!(std::fs::read_to_string(&restored_file)?, "Original content");
+
+        // Second restore with --verify should skip (content unchanged)
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .verify(true)
+            .run(&ctx.global)
+            .await?;
+
+        assert_eq!(std::fs::read_to_string(&restored_file)?, "Original content");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_restore_incremental_partial_change() -> Result<()> {
+        let ctx = TestContext::new().await?;
+        let backup_path = ctx._tmp_dir.path().join("backup");
+        std::fs::create_dir_all(&backup_path)?;
+
+        // Create a large file so it gets split into multiple blobs
+        let file_path = backup_path.join("large.bin");
+        let content_a = vec![0xAA_u8; 512 * 1024]; // 512 KiB
+        std::fs::write(&file_path, &content_a)?;
+
+        ctx.init_repo().await?;
+
+        // Snapshot A
+        ctx.snapshot_builder(vec![file_path.clone()])
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
+
+        // Restore to get the file locally
+        let restore_path = ctx._tmp_dir.path().join("restore");
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .run(&ctx.global)
+            .await?;
+
+        let restored_file = restore_path.join("large.bin");
+        assert_eq!(std::fs::read(&restored_file)?, content_a);
+
+        // Modify only the first 16 bytes of the backup source
+        let mut content_b = content_a.clone();
+        content_b[..16].copy_from_slice(&[0xBB_u8; 16]);
+        std::fs::write(&file_path, &content_b)?;
+
+        // Snapshot B
+        ctx.snapshot_builder(vec![file_path.clone()])
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
+
+        // Restore with --verify should still produce correct content
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .verify(true)
+            .run(&ctx.global)
+            .await?;
+
+        assert_eq!(std::fs::read(&restored_file)?, content_b);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_restore_incremental_new_file() -> Result<()> {
+        let ctx = TestContext::new().await?;
+        let backup_path = ctx._tmp_dir.path().join("backup");
+        std::fs::create_dir_all(&backup_path)?;
+
+        let file_path = backup_path.join("new_file.txt");
+        std::fs::write(&file_path, "brand new content")?;
+
+        ctx.init_repo().await?;
+
+        ctx.snapshot_builder(vec![file_path.clone()])
+            .no_scan(true)
+            .num_readers(1)
+            .num_packers(1)
+            .run(&ctx.global)
+            .await?;
+
+        // Restore to a fresh target (file doesn't exist locally)
+        let restore_path = ctx._tmp_dir.path().join("restore_fresh");
+        ctx.restore_builder(restore_path.clone())
+            .strategy(Strategy::Overwrite)
+            .verify(true)
+            .run(&ctx.global)
+            .await?;
+
+        let restored_file = restore_path.join("new_file.txt");
+        assert!(restored_file.exists());
+        assert_eq!(
+            std::fs::read_to_string(&restored_file)?,
+            "brand new content"
+        );
+
+        Ok(())
+    }
 }

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -254,7 +254,7 @@ Argon2id to produce wrapping keys that encrypt the master key.
 
 Mapache can read settings from a TOML configuration file specified via
 `--with-config <PATH>`. The file supports `[global]`, `[snapshot]`, `[restore]`,
-`[forget]`, and `[runtime]` sections.
+`[forget]`, `[runtime]`, and `[hooks]` sections.
 
 Generate the canonical template with:
 
@@ -309,6 +309,12 @@ blobs-per-index-file = 65535
 index-flush-timeout-secs = 600
 s3-multipart-threshold = 134217728
 s3-multipart-part-size = 134217728
+
+[hooks.snapshot.pre]
+command = "echo 'Starting snapshot'"
+
+[hooks.snapshot.post]
+command = "echo 'Snapshot finished: $MAPACHE_RESULT'"
 ```
 
 CLI flags override config file values. Config file values supplement CLI lists
@@ -704,7 +710,7 @@ be a snapshot ID prefix or `latest` (default).
 | `--no-preserve-root` | Allow `--delete` to remove root-level items |
 | `--quit-on-error` | Exit immediately on the first restore error |
 | `--sparse` | Create sparse files instead of preallocating |
-| `--verify` | Force content verification (hash check) even if mtime matches |
+| `--verify` | Verify content by hashing each blob and skip unchanged data (incremental restore) |
 | `--batch-size <N>` | Max files per batch. Limits peak memory. Default: no limit (all files at once) |
 | `--dry-run` | Simulate restoration |
 
@@ -759,6 +765,12 @@ on some filesystems but may cause fragmentation.
 By default, mapache skips content verification for files whose modification
 time matches the snapshot (optimization). Use `--verify` to force reading and
 hashing every restored file.
+
+When `--verify` is active, the restorer performs **incremental restore**: each
+blob is individually compared against the local file content. Only blobs whose
+hash differs from the on-disk data are downloaded and written; unchanged blobs
+are skipped. This significantly speeds up repeated restores of large files
+where only a small fraction of the content changed.
 
 ### Dry Run
 
@@ -1312,6 +1324,8 @@ These options are available on most commands (exceptions: `bundle`, `cache`,
 | `--limit-upload <SPEED>` | Upload bandwidth limit (e.g., `10MB/s`, `500KB/s`, `1G`) |
 | `--limit-download <SPEED>` | Download bandwidth limit (e.g., `10MB/s`, `500KB/s`, `1G`) |
 | `--json` | Output results in JSON format (supported by most commands) |
+| `--pre-hook <CMD>` | Shell command to run before the main command (overrides TOML config) |
+| `--post-hook <CMD>` | Shell command to run after the main command (overrides TOML config) |
 
 ### Compression Levels
 
@@ -1380,6 +1394,8 @@ mapache snapshot [PATHS...] -r <URL>
   --dry-run               Simulate without making changes
   --stdin                 Read data from stdin as file /stdin
   --with-atime            Store file access times
+  --pre-hook <CMD>        Shell command to run before snapshot (overrides config)
+  --post-hook <CMD>       Shell command to run after snapshot (overrides config)
 ```
 
 ### `mapache restore`
@@ -1399,8 +1415,10 @@ mapache restore [SNAPSHOT] --target <PATH> -r <URL>
   --no-preserve-root      Allow --delete at root level
   --quit-on-error         Exit immediately on restore error
   --sparse                Create sparse files
-  --verify                Force content verification
+  --verify                Verify content by hashing each blob (incremental restore)
   --batch-size <N>        Max files per batch (limits memory; default: no limit)
+  --pre-hook <CMD>        Shell command to run before restore (overrides config)
+  --post-hook <CMD>       Shell command to run after restore (overrides config)
   --dry-run               Simulate restoration
 ```
 
@@ -1425,6 +1443,8 @@ mapache forget [SNAPSHOT_IDS...] -r <URL>
   --dry-run               Show what would be removed
   --clean                 Run garbage collector after
   -t, --tolerance <%>     GC garbage tolerance (0–100)
+  --pre-hook <CMD>        Shell command to run before forget (overrides config)
+  --post-hook <CMD>       Shell command to run after forget (overrides config)
 ```
 
 ### `mapache log`
@@ -1498,6 +1518,8 @@ mapache clean -r <URL>
   -t, --tolerance <%>     Garbage tolerance (0–100, default: 0)
   --no-repack             Skip repacking
   --dry-run               Simulate without making changes
+  --pre-hook <CMD>        Shell command to run before clean (overrides config)
+  --post-hook <CMD>       Shell command to run after clean (overrides config)
 ```
 
 ### `mapache verify`
@@ -1511,6 +1533,8 @@ mapache verify -r <URL>
   --with-cache            Use local cache (disabled by default)
   --fail-early            Stop on first error
   --sample <%>            Verify random sample of packs (e.g., 10.5%)
+  --pre-hook <CMD>        Shell command to run before verify (overrides config)
+  --post-hook <CMD>       Shell command to run after verify (overrides config)
 ```
 
 ### `mapache key`


### PR DESCRIPTION
When restoring with --verify, skip writing blobs whose content already matches the local file. This avoids re-downloading unchanged data while keeping the same user-facing behavior.