### PR TITLE
fix(config): reject restore-pack-prefetch = 0

### DIFF
--- a/crates/mapache/src/common/config.rs
+++ b/crates/mapache/src/common/config.rs
@@ -264,12 +264,14 @@ pub fn load_config(path: &PathBuf) -> Result<MapacheConfig> {
         ))
     })?;
 
-    if let Some(runtime) = &config.runtime {
-        if runtime.restore_pack_prefetch == Some(0) {
-            return Err(MapacheError::Config(
-                "runtime.restore_pack_prefetch must be greater than 0".into(),
-            ));
-        }
+    if config
+        .runtime
+        .as_ref()
+        .is_some_and(|runtime| runtime.restore_pack_prefetch == Some(0))
+    {
+        return Err(MapacheError::Config(
+            "runtime.restore_pack_prefetch must be greater than 0".into(),
+        ));
     }
 
     Ok(config)
@@ -370,17 +372,11 @@ mod tests {
 
     #[test]
     fn restore_pack_prefetch_zero_is_rejected() {
-        let dir = std::env::temp_dir().join(format!(
-            "mapache-prefetch-zero-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("mapache-prefetch-zero-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         let path = dir.join("mapache.toml");
-        std::fs::write(
-            &path,
-            "[runtime]\nrestore-pack-prefetch = 0\n",
-        )
-        .unwrap();
+        std::fs::write(&path, "[runtime]\nrestore-pack-prefetch = 0\n").unwrap();
         let err = load_config(&path).expect_err("prefetch 0 must be rejected");
         let _ = std::fs::remove_dir_all(&dir);
         match err {
@@ -391,5 +387,4 @@ mod tests {
             other => panic!("unexpected error: {other:?}"),
         }
     }
-
 }

--- a/crates/mapache/src/common/config.rs
+++ b/crates/mapache/src/common/config.rs
@@ -264,6 +264,14 @@ pub fn load_config(path: &PathBuf) -> Result<MapacheConfig> {
         ))
     })?;
 
+    if let Some(runtime) = &config.runtime {
+        if runtime.restore_pack_prefetch == Some(0) {
+            return Err(MapacheError::Config(
+                "runtime.restore_pack_prefetch must be greater than 0".into(),
+            ));
+        }
+    }
+
     Ok(config)
 }
 
@@ -359,4 +367,29 @@ mod tests {
         assert_eq!(config.runtime.is_some(), parsed.runtime.is_some());
         assert_eq!(config.hooks.is_some(), parsed.hooks.is_some());
     }
+
+    #[test]
+    fn restore_pack_prefetch_zero_is_rejected() {
+        let dir = std::env::temp_dir().join(format!(
+            "mapache-prefetch-zero-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("mapache.toml");
+        std::fs::write(
+            &path,
+            "[runtime]\nrestore-pack-prefetch = 0\n",
+        )
+        .unwrap();
+        let err = load_config(&path).expect_err("prefetch 0 must be rejected");
+        let _ = std::fs::remove_dir_all(&dir);
+        match err {
+            MapacheError::Config(msg) => assert!(
+                msg.contains("restore_pack_prefetch must be greater than 0"),
+                "unexpected message: {msg}"
+            ),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
 }


### PR DESCRIPTION
`runtime.restore_pack_prefetch = 0` feeds `buffer_unordered(0)` in the pack restorer and hangs the restore.

Reject zero at config load with a clear config error.