### PR TITLE
fix(snapshot): reject --readers 0 at parse time

### DIFF
--- a/crates/mapache/src/commands/cmd_snapshot.rs
+++ b/crates/mapache/src/commands/cmd_snapshot.rs
@@ -134,8 +134,8 @@ pub struct CmdArgs {
     #[serde(deserialize_with = "deserialize_use_snapshot_opt")]
     pub parent: Option<UseSnapshot>,
 
-    /// Number of files to process in parallel.
-    #[clap(long = "readers")]
+    /// Number of files to process in parallel. Must be greater than 0.
+    #[clap(long = "readers", value_parser = parse_readers)]
     pub num_readers: Option<usize>,
 
     /// Number of writer threads.
@@ -825,4 +825,44 @@ fn show_cli_summary(completion: &SnapshotCompletion, dry_run: bool) {
             .to_string(),
     ]);
     ui::cli::log!("{}", data_table.render());
+}
+
+fn parse_readers(s: &str) -> Result<usize, String> {
+    let n = s
+        .parse::<usize>()
+        .map_err(|_| format!("'{s}' is not a valid number"))?;
+    if n == 0 {
+        return Err("readers must be greater than 0".to_string());
+    }
+    Ok(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser, Debug)]
+    #[command(no_binary_name = true)]
+    struct SnapshotArgsParse {
+        #[command(flatten)]
+        args: CmdArgs,
+    }
+
+    #[test]
+    fn readers_rejects_zero() {
+        let err = SnapshotArgsParse::try_parse_from(["--readers", "0"])
+            .expect_err("--readers 0 must be rejected");
+        assert!(
+            err.to_string().contains("greater than 0"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn readers_accepts_positive() {
+        let parsed =
+            SnapshotArgsParse::try_parse_from(["--readers", "8"]).expect("--readers 8 must parse");
+        assert_eq!(parsed.args.num_readers, Some(8));
+    }
 }


### PR DESCRIPTION
`--readers 0` builds an `mpsc` channel with capacity 0 and panics.

Reject `0` in the clap value parser so the panic cannot be configured.