### PR TITLE
fix(snapshot): reject --packers 0 at parse time

### DIFF
--- a/crates/mapache/src/commands/cmd_snapshot.rs
+++ b/crates/mapache/src/commands/cmd_snapshot.rs
@@ -138,8 +138,8 @@ pub struct CmdArgs {
     #[clap(long = "readers")]
     pub num_readers: Option<usize>,
 
-    /// Number of writer threads.
-    #[clap(long = "packers")]
+    /// Number of writer threads. Must be greater than 0.
+    #[clap(long = "packers", value_parser = parse_packers)]
     pub num_packers: Option<usize>,
 
     /// Dry run
@@ -825,4 +825,44 @@ fn show_cli_summary(completion: &SnapshotCompletion, dry_run: bool) {
             .to_string(),
     ]);
     ui::cli::log!("{}", data_table.render());
+}
+
+fn parse_packers(s: &str) -> Result<usize, String> {
+    let n = s
+        .parse::<usize>()
+        .map_err(|_| format!("'{s}' is not a valid number"))?;
+    if n == 0 {
+        return Err("packers must be greater than 0".to_string());
+    }
+    Ok(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser, Debug)]
+    #[command(no_binary_name = true)]
+    struct SnapshotArgsParse {
+        #[command(flatten)]
+        args: CmdArgs,
+    }
+
+    #[test]
+    fn packers_rejects_zero() {
+        let err = SnapshotArgsParse::try_parse_from(["--packers", "0"])
+            .expect_err("--packers 0 must be rejected");
+        assert!(
+            err.to_string().contains("greater than 0"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn packers_accepts_positive() {
+        let parsed =
+            SnapshotArgsParse::try_parse_from(["--packers", "8"]).expect("--packers 8 must parse");
+        assert_eq!(parsed.args.num_packers, Some(8));
+    }
 }


### PR DESCRIPTION
`--packers 0` starts the pack saver with an empty worker pool and a rendezvous channel that fails during final flush.

Reject `0` in the clap value parser so that path cannot be configured.