### PR TITLE
fix(config): reject restore-blob-concurrency = 0

### DIFF
--- a/crates/mapache/src/common/config.rs
+++ b/crates/mapache/src/common/config.rs
@@ -264,14 +264,17 @@ pub fn load_config(path: &PathBuf) -> Result<MapacheConfig> {
         ))
     })?;
 
-    if config
-        .runtime
-        .as_ref()
-        .is_some_and(|runtime| runtime.restore_pack_prefetch == Some(0))
-    {
-        return Err(MapacheError::Config(
-            "runtime.restore_pack_prefetch must be greater than 0".into(),
-        ));
+    if let Some(runtime) = &config.runtime {
+        if runtime.restore_pack_prefetch == Some(0) {
+            return Err(MapacheError::Config(
+                "runtime.restore_pack_prefetch must be greater than 0".into(),
+            ));
+        }
+        if runtime.restore_blob_concurrency == Some(0) {
+            return Err(MapacheError::Config(
+                "runtime.restore_blob_concurrency must be greater than 0".into(),
+            ));
+        }
     }
 
     Ok(config)
@@ -382,6 +385,26 @@ mod tests {
         match err {
             MapacheError::Config(msg) => assert!(
                 msg.contains("restore_pack_prefetch must be greater than 0"),
+                "unexpected message: {msg}"
+            ),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn restore_blob_concurrency_zero_is_rejected() {
+        let dir = std::env::temp_dir().join(format!(
+            "mapache-blob-concurrency-zero-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("mapache.toml");
+        std::fs::write(&path, "[runtime]\nrestore-blob-concurrency = 0\n").unwrap();
+        let err = load_config(&path).expect_err("concurrency 0 must be rejected");
+        let _ = std::fs::remove_dir_all(&dir);
+        match err {
+            MapacheError::Config(msg) => assert!(
+                msg.contains("restore_blob_concurrency must be greater than 0"),
                 "unexpected message: {msg}"
             ),
             other => panic!("unexpected error: {other:?}"),


### PR DESCRIPTION
`runtime.restore_blob_concurrency = 0` feeds `buffer_unordered(0)` in the pack restorer and hangs the restore.

Reject zero at config load with a clear config error.