### PR TITLE
Replace tokio-stream with local ReceiverStream wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,7 +2110,6 @@ dependencies = [
  "thiserror 2.0.19",
  "tikv-jemallocator",
  "tokio",
- "tokio-stream",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/crates/mapache/Cargo.toml
+++ b/crates/mapache/Cargo.toml
@@ -52,7 +52,6 @@ tokio = { version = "1.53", features = [
   "signal",
   "process",
 ] }
-tokio-stream = "0.1"
 toml = "1.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/crates/mapache/src/archiver/mod.rs
+++ b/crates/mapache/src/archiver/mod.rs
@@ -19,12 +19,10 @@ use std::{
     time::SystemTime,
 };
 
-use crate::common::error;
 use chrono::Local;
 use futures::StreamExt;
 use parking_lot::Mutex;
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
 
 use crate::{
     archiver::{
@@ -32,7 +30,12 @@ use crate::{
         progress::SnapshotProgress,
         tree_serializer::TreeSerializer,
     },
-    common::{self, error::Result, global::MAPACHE_VERSION_INFO, traits::BlobSaver},
+    common::{
+        self,
+        error::{self, Result},
+        global::MAPACHE_VERSION_INFO,
+        traits::BlobSaver,
+    },
     fs::{
         filter::PathFilter,
         node::{Metadata, Node, NodeType},
@@ -43,7 +46,7 @@ use crate::{
         snapshot::{Snapshot, SnapshotPair, SnapshotSummary},
     },
     ui::events::{BackupEvent, Event, EventSender, emit_event},
-    utils,
+    utils::{self, stream::ReceiverStream},
 };
 
 /// Options for creating a new snapshot.

--- a/crates/mapache/src/bundle/reader.rs
+++ b/crates/mapache/src/bundle/reader.rs
@@ -6,7 +6,6 @@ use std::{
     sync::Arc,
 };
 
-use crate::common::error::{MapacheError, Result};
 use argon2::ParamsBuilder;
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -17,7 +16,11 @@ use crate::{
         BUNDLE_HEADER_SIZE, BUNDLE_KEY_LEN, BUNDLE_MAGIC_END, BUNDLE_MAGIC_START,
         BUNDLE_TRAILER_SIZE_LEN, BundleHeader, BundleIndex, BundleTrailer,
     },
-    common::{ID, traits::BlobLoader},
+    common::{
+        ID,
+        error::{MapacheError, Result},
+        traits::BlobLoader,
+    },
     fs::{
         node::Metadata,
         tree::{NodeDiff, Tree},
@@ -28,6 +31,7 @@ use crate::{
         self,
         events::{BackupEvent, Event, EventSender, RestoreEvent},
     },
+    utils::stream::ReceiverStream,
 };
 
 pub struct BundleReader {
@@ -261,7 +265,7 @@ where
     let meta_sender = make_meta_sender();
 
     let process_future = async {
-        let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+        let stream = ReceiverStream::new(rx);
         stream
             .for_each_concurrent(workers, |(path, node)| {
                 let loader = loader.clone();

--- a/crates/mapache/src/common/id.rs
+++ b/crates/mapache/src/common/id.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::common::error::{MapacheError, Result};
+use crate::{
+    common::error::{MapacheError, Result},
+    utils,
+};
 
 pub const ID_LENGTH: usize = 32;
 pub type Hash256 = [u8; ID_LENGTH];
@@ -26,12 +29,12 @@ impl ID {
 
     /// Converts the ID to a hex String.
     pub fn to_hex(&self) -> String {
-        crate::utils::bytes_to_hex(&self.0)
+        utils::bytes_to_hex(&self.0)
     }
 
     /// Convert to hex String with `len` bytes
     pub fn to_short_hex(&self, len: usize) -> String {
-        crate::utils::bytes_to_hex(&self.0[..len])
+        utils::bytes_to_hex(&self.0[..len])
     }
 
     /// Helper function to convert a hex char into a byte.

--- a/crates/mapache/src/utils/mod.rs
+++ b/crates/mapache/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub mod base64;
 pub mod binary;
 pub mod collections;
 pub mod rate_estimator;
+pub(crate) mod stream;
 
 use std::{
     path::{Path, PathBuf},

--- a/crates/mapache/src/utils/stream.rs
+++ b/crates/mapache/src/utils/stream.rs
@@ -1,0 +1,25 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::Stream;
+use tokio::sync::mpsc;
+
+pub(crate) struct ReceiverStream<T> {
+    rx: mpsc::Receiver<T>,
+}
+
+impl<T> ReceiverStream<T> {
+    pub(crate) fn new(rx: mpsc::Receiver<T>) -> Self {
+        Self { rx }
+    }
+}
+
+impl<T> Stream for ReceiverStream<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx)
+    }
+}

--- a/crates/mapache/tests/integration_tests/mod.rs
+++ b/crates/mapache/tests/integration_tests/mod.rs
@@ -5,6 +5,9 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use tempfile::tempdir;
+use zeroize::Zeroizing;
+
 use mapache::{
     backend::{StorageBackend, localfs::LocalFS, read_backend_dir},
     commands::{
@@ -15,8 +18,6 @@ use mapache::{
     common::{defaults::DEFAULT_PACK_SIZE_MIB, global::set_global_opts_with_args},
     repository::repo::{Auth, Repository},
 };
-use tempfile::tempdir;
-use zeroize::Zeroizing;
 
 use crate::{
     TEST_QUIET,


### PR DESCRIPTION
Replace the external tokio-stream dependency with a small, low-risk implementation.