### PR TITLE
feat(bundle): add --as-root option to bundle mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
 - **`bundle --import`**: Import a `.mapache` bundle file as a new snapshot
   into the repository. Already-present blobs are skipped automatically
   (cross-repo deduplication). Requires `-r` / `--repo`.
+- **`bundle --as-root`**: Use a single directory as the bundle root in bundle
+  mode. The directory's children become the top-level items in the bundle,
+  matching the behavior of `snapshot --as-root`.
 
 ### Changed
 

--- a/crates/mapache/src/commands/cmd_bundle.rs
+++ b/crates/mapache/src/commands/cmd_bundle.rs
@@ -47,6 +47,7 @@ use crate::{
     },
     utils::{self, collections::IdSet, format_size_binary, rate_estimator::RateEstimator},
 };
+
 #[cfg(all(feature = "mount", unix))]
 use crate::{
     fs::path_exists,
@@ -115,6 +116,10 @@ pub struct CmdArgs {
     #[arg(short = 'e', long)]
     pub exclude: Vec<PathBuf>,
 
+    /// Use a single directory path as the bundle root (bundle mode only)
+    #[clap(long = "as-root", value_parser, action = clap::ArgAction::Set, num_args = 0..=1, default_missing_value = "true")]
+    pub as_root: Option<bool>,
+
     /// Number of parallel readers. Must be greater than 0.
     #[clap(long, default_value_t = DEFAULT_SNAPSHOT_READERS, value_parser = parse_readers)]
     pub readers: usize,
@@ -155,6 +160,7 @@ impl Default for CmdArgs {
             input: vec![],
             output: None,
             exclude: vec![],
+            as_root: None,
             readers: DEFAULT_SNAPSHOT_READERS,
             create: false,
             allow_other: false,
@@ -176,6 +182,7 @@ impl Default for CmdArgs {
             input: vec![],
             output: None,
             exclude: vec![],
+            as_root: None,
             readers: DEFAULT_SNAPSHOT_READERS,
             internal_password: None,
         }
@@ -183,6 +190,12 @@ impl Default for CmdArgs {
 }
 
 pub async fn run(global: &crate::commands::GlobalArgs, args: &CmdArgs) -> Result<(), BundleError> {
+    if args.as_root.is_some() && !args.bundle {
+        return Err(BundleError::Config(
+            "--as-root can only be used with bundle mode".to_string(),
+        ));
+    }
+
     if args.export_snapshot.is_some() {
         run_export_snapshot(global, args).await
     } else if args.import {
@@ -257,6 +270,27 @@ async fn run_create(global: &GlobalArgs, args: &CmdArgs) -> Result<(), BundleErr
             }
         })
         .collect();
+
+    // If --as-root is set, expand a single directory into its children
+    if args.as_root.unwrap_or(false) {
+        if absolute_source_paths.len() != 1 {
+            return Err(BundleError::Config(
+                "bundle mode --as-root requires exactly one input path".to_string(),
+            ));
+        }
+        let root = &absolute_source_paths[0];
+        if !root.is_dir() {
+            return Err(BundleError::Config(
+                "bundle mode --as-root input must be a directory".to_string(),
+            ));
+        }
+        let mut dir = tokio::fs::read_dir(root).await?;
+        let mut children = Vec::new();
+        while let Some(entry) = dir.next_entry().await? {
+            children.push(entry.path());
+        }
+        absolute_source_paths = children;
+    }
 
     let snapshot_root_path = if absolute_source_paths.len() == 1 {
         let p = &absolute_source_paths[0];

--- a/crates/mapache/tests/integration_tests/mod.rs
+++ b/crates/mapache/tests/integration_tests/mod.rs
@@ -683,6 +683,11 @@ impl BundleBuilder {
         self
     }
 
+    pub fn root(mut self, as_root: bool) -> Self {
+        self.args.as_root = Some(as_root);
+        self
+    }
+
     pub fn export_snapshot(mut self, snapshot: mapache::commands::UseSnapshot) -> Self {
         self.args.export_snapshot = Some(snapshot);
         self

--- a/crates/mapache/tests/integration_tests/test_cmd_bundle.rs
+++ b/crates/mapache/tests/integration_tests/test_cmd_bundle.rs
@@ -249,3 +249,49 @@ async fn test_import_dedup() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_bundle_with_as_root() -> Result<()> {
+    let mut ctx = TestContext::new().await?;
+    let dataset = Dataset::new().with_structure(INTEGRATION_TEST_DATA);
+    let synthetic = SyntheticData::new(dataset);
+    let backup_data_path = ctx.setup_backup_data(&synthetic)?;
+
+    let bundle_path = ctx._tmp_dir.path().join("as_root_bundle.mapache");
+    let extract_path = ctx._tmp_dir.path().join("extracted_as_root");
+
+    ctx.bundle_builder()
+        .bundle(true)
+        .input(vec![backup_data_path.join("0")])
+        .output(bundle_path.clone())
+        .password("test_password".to_string())
+        .root(true)
+        .run(&ctx.global.clone())
+        .await?;
+
+    assert!(bundle_path.exists());
+
+    ctx.bundle_builder()
+        .extract(true)
+        .input(vec![bundle_path.clone()])
+        .output(extract_path.clone())
+        .password("test_password".to_string())
+        .run(&ctx.global.clone())
+        .await?;
+
+    // With --as-root, the bundle root is the children of "0",
+    // so extract_path should contain file0.txt, 00/, 01/ etc. directly.
+    assert!(extract_path.join("file0.txt").exists());
+    assert!(extract_path.join("00").exists());
+    assert!(extract_path.join("00/file00.txt").exists());
+    assert!(extract_path.join("01").exists());
+    assert!(extract_path.join("01/file01a.txt").exists());
+    assert!(extract_path.join("01/file01b.txt").exists());
+
+    // Verify file contents match originals
+    let original = backup_data_path.join("0/file0.txt");
+    let extracted = extract_path.join("file0.txt");
+    assert_eq!(std::fs::read(&extracted)?, std::fs::read(&original)?);
+
+    Ok(())
+}

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -1181,6 +1181,9 @@ mapache bundle -a ~/project -o project.mapache -e "*.log" -e "tmp/"
 
 # Custom compression
 mapache bundle -a ~/Documents -o docs.mapache --compression best
+
+# Use a directory as the bundle root (its children become top-level items)
+mapache bundle -a ~/Photos -o photos.mapache --as-root
 ```
 
 ### Extract a Bundle
@@ -1234,6 +1237,7 @@ Bundle-specific options:
 | `--export-snapshot <ID>` | Export mode: export snapshot to a bundle (requires `-r`) |
 | `-i, --import` | Import mode: import bundle as snapshot (requires `-r`) |
 | `-e, --exclude <GLOB>` | Glob patterns to exclude (bundle mode only) |
+| `--as-root` | Use a single directory as the bundle root (bundle mode only) |
 | `--readers <N>` | Parallel readers (default: 4) |
 | `-c, --create` | Create mountpoint if it does not exist (mount mode) |
 | `--allow-other` | Allow other users to access the mount |
@@ -1644,6 +1648,7 @@ mapache bundle -m <INPUT.mapache> <MOUNTPOINT> [OPTIONS]
   -m, --mount             Mount mode (FUSE, Unix only)
   -o, --output <PATH>     Bundle file (-a, --export-snapshot) or destination (-x)
   -e, --exclude <GLOB>    Exclude globs (bundle mode)
+  --as-root               Use a single directory as the bundle root (bundle mode)
   --readers <N>           Parallel readers (default: 4)
   -c, --create            Create mountpoint (mount mode)
   --allow-other           Allow other users (mount mode)

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -1174,16 +1174,16 @@ transferred to other systems.
 
 ```bash
 # Create a bundle from files/directories
-mapache bundle -a PATH [PATH...] -o bundle.mapache
+mapache bundle -b PATH [PATH...] -o bundle.mapache
 
 # With exclusions
-mapache bundle -a ~/project -o project.mapache -e "*.log" -e "tmp/"
+mapache bundle -b ~/project -o project.mapache -e "*.log" -e "tmp/"
 
 # Custom compression
-mapache bundle -a ~/Documents -o docs.mapache --compression best
+mapache bundle -b ~/Documents -o docs.mapache --compression best
 
 # Use a directory as the bundle root (its children become top-level items)
-mapache bundle -a ~/Photos -o photos.mapache --as-root
+mapache bundle -b ~/Photos -o photos.mapache --as-root
 ```
 
 ### Extract a Bundle
@@ -1635,7 +1635,7 @@ mapache key export <KEY_ID> -r <URL> [-o <PATH>]
 Create, extract, import, export, or mount `.mapache` bundle files.
 
 ```
-mapache bundle -a <INPUT...> -o <OUTPUT.mapache> [OPTIONS]
+mapache bundle -b <INPUT...> -o <OUTPUT.mapache> [OPTIONS]
 mapache bundle -x <INPUT.mapache> [-o <DIR>] [OPTIONS]
 mapache bundle --export-snapshot <SNAPSHOT> -o <OUTPUT.mapache> -r <URL>
 mapache bundle -i <INPUT.mapache...> -r <URL>


### PR DESCRIPTION
- Allow creating bundles with --as-root, as in the snapshot command. This option is only allowed in --bundle mode and rejected in the other modes.
- Fixed bundle mode flag in cmd_bundle. Previously incorrect `-a`. Now `-b`.