### PR TITLE
Complete zero blob deduplication

### DIFF
--- a/crates/mapache/src/archiver/processor.rs
+++ b/crates/mapache/src/archiver/processor.rs
@@ -28,7 +28,7 @@ use crate::{
 /// Returns `true` if every byte in `data` is zero.
 /// Fast path: O(1) when first byte is non-zero (the common case).
 #[inline]
-fn is_all_zero(data: &[u8]) -> bool {
+pub(crate) fn is_all_zero(data: &[u8]) -> bool {
     data.first().is_some_and(|&b| b == 0) && data.iter().all(|&b| b == 0)
 }
 

--- a/crates/mapache/src/archiver/processor.rs
+++ b/crates/mapache/src/archiver/processor.rs
@@ -25,6 +25,13 @@ use crate::{
     ui::events::{BackupEvent, Event, EventSender, emit_event},
 };
 
+/// Returns `true` if every byte in `data` is zero.
+/// Fast path: O(1) when first byte is non-zero (the common case).
+#[inline]
+fn is_all_zero(data: &[u8]) -> bool {
+    data.first().is_some_and(|&b| b == 0) && data.iter().all(|&b| b == 0)
+}
+
 /// Reusable buffers that persist across processing calls in a pool thread.
 #[derive(Default)]
 pub(crate) struct ReusableBuffers {
@@ -370,8 +377,14 @@ pub(crate) fn chunk_and_store_file<R: Read + Send>(
 
             let chunk_len = chunk_data.len() as u64;
 
+            let blob_type = if is_all_zero(&chunk_data) {
+                BlobType::Zero
+            } else {
+                BlobType::Data
+            };
+
             let id = blob_saver.save_blob(
-                BlobType::Data,
+                blob_type,
                 WriteContents::Borrowed(&chunk_data),
                 SaveID::CalculateID,
             )?;
@@ -422,8 +435,14 @@ fn store_small_file<R: Read>(
     }
 
     // Perform the intensive save_blob directly in the worker thread.
+    let blob_type = if is_all_zero(&buf[..]) {
+        BlobType::Zero
+    } else {
+        BlobType::Data
+    };
+
     let id = blob_saver.save_blob(
-        BlobType::Data,
+        blob_type,
         WriteContents::Borrowed(&buf[..]),
         SaveID::CalculateID,
     )?;

--- a/crates/mapache/src/commands/cmd_migrate.rs
+++ b/crates/mapache/src/commands/cmd_migrate.rs
@@ -336,7 +336,7 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), Migrate
                     return Err(MigrateError::Interrupted);
                 }
 
-                // Zero blobs are now in pack footers as BlobType::Zero with length=0.
+                // Zero blobs are registered in pack footers as BlobType::Zero with length=0.
                 // They go through add_pack like data/tree blobs.
                 // parse_footer already filters out Padding entries.
                 zero_blob_count += descriptors

--- a/crates/mapache/src/commands/cmd_migrate.rs
+++ b/crates/mapache/src/commands/cmd_migrate.rs
@@ -336,21 +336,18 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), Migrate
                     return Err(MigrateError::Interrupted);
                 }
 
-                // Separate zero blobs from pack blobs.
+                // Zero blobs are now in pack footers as BlobType::Zero with length=0.
+                // They go through add_pack like data/tree blobs.
                 let pack_descriptors: Vec<_> = descriptors
                     .iter()
-                    .filter(|d| {
-                        if matches!(d.blob_type, BlobType::Zero) {
-                            new_master_index.add_zero_blob(d.id, d.raw_length);
-                            zero_blob_count += 1;
-                            false
-                        } else {
-                            true
-                        }
-                    })
+                    .filter(|d| !matches!(d.blob_type, BlobType::Padding))
                     .cloned()
                     .collect();
 
+                zero_blob_count += pack_descriptors
+                    .iter()
+                    .filter(|d| matches!(d.blob_type, BlobType::Zero))
+                    .count();
                 blob_count += pack_descriptors.len();
                 new_master_index
                     .add_pack(repo.as_ref(), new_id, pack_descriptors)

--- a/crates/mapache/src/commands/cmd_migrate.rs
+++ b/crates/mapache/src/commands/cmd_migrate.rs
@@ -12,7 +12,7 @@ use indicatif::ProgressBar;
 use crate::{
     backend::new_backend_with_prompt,
     commands::{GlobalArgs, ToExitCode, cleanup::CleanupHandler, with_repository_lock},
-    common::{ContentIdType, ID, error::MapacheError},
+    common::{BlobType, ContentIdType, ID, error::MapacheError},
     repository::{
         index::{IndexMode, MasterIndex},
         migration,
@@ -330,19 +330,40 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), Migrate
             );
 
             let mut blob_count = 0;
+            let mut zero_blob_count = 0;
             for (_old_id, new_id, descriptors) in &pack_map {
                 if cleanup_handler.is_interrupted() {
                     return Err(MigrateError::Interrupted);
                 }
-                blob_count += descriptors.len();
+
+                // Separate zero blobs from pack blobs.
+                let pack_descriptors: Vec<_> = descriptors
+                    .iter()
+                    .filter(|d| {
+                        if matches!(d.blob_type, BlobType::Zero) {
+                            new_master_index.add_zero_blob(d.id, d.raw_length);
+                            zero_blob_count += 1;
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                    .cloned()
+                    .collect();
+
+                blob_count += pack_descriptors.len();
                 new_master_index
-                    .add_pack(repo.as_ref(), new_id, descriptors.clone())
+                    .add_pack(repo.as_ref(), new_id, pack_descriptors)
                     .await?;
                 scan_bar.inc(1);
             }
             scan_bar.finish_and_clear();
 
-            ui::cli::log!("Index covers {} blobs across {} packs", blob_count, pack_map.len());
+            if zero_blob_count > 0 {
+                ui::cli::log!("Index covers {} blobs ({} zero) across {} packs", blob_count, zero_blob_count, pack_map.len());
+            } else {
+                ui::cli::log!("Index covers {} blobs across {} packs", blob_count, pack_map.len());
+            }
 
             let old_index_ids = repo.list_index_ids().await?;
 

--- a/crates/mapache/src/commands/cmd_migrate.rs
+++ b/crates/mapache/src/commands/cmd_migrate.rs
@@ -338,19 +338,14 @@ pub async fn run(global_args: &GlobalArgs, args: &CmdArgs) -> Result<(), Migrate
 
                 // Zero blobs are now in pack footers as BlobType::Zero with length=0.
                 // They go through add_pack like data/tree blobs.
-                let pack_descriptors: Vec<_> = descriptors
-                    .iter()
-                    .filter(|d| !matches!(d.blob_type, BlobType::Padding))
-                    .cloned()
-                    .collect();
-
-                zero_blob_count += pack_descriptors
+                // parse_footer already filters out Padding entries.
+                zero_blob_count += descriptors
                     .iter()
                     .filter(|d| matches!(d.blob_type, BlobType::Zero))
                     .count();
-                blob_count += pack_descriptors.len();
+                blob_count += descriptors.len();
                 new_master_index
-                    .add_pack(repo.as_ref(), new_id, pack_descriptors)
+                    .add_pack(repo.as_ref(), new_id, descriptors.clone())
                     .await?;
                 scan_bar.inc(1);
             }

--- a/crates/mapache/src/repository/index.rs
+++ b/crates/mapache/src/repository/index.rs
@@ -423,8 +423,11 @@ impl Index {
 
         // Backward compat: old index format stored zero blobs in a separate section
         // without pack info. Create synthetic entries (load_blob ignores pack_id for zeros).
+        // Dedup against zero_entries already populated from pack blobs.
+        let existing_zeros: std::collections::HashSet<ID> =
+            zero_entries.iter().map(|(id, _)| *id).collect();
         for zb in index_file.zero_blobs {
-            if !zero_entries.iter().any(|(id, _)| *id == zb.id) {
+            if !existing_zeros.contains(&zb.id) {
                 zero_entries.push((
                     zb.id,
                     BlobLocationInternal {
@@ -496,9 +499,16 @@ impl Index {
                     .and_then(|l| self.resolve_location(l, BlobType::Tree))
             })
             .or_else(|| {
-                self.zero_ids
-                    .get(id)
-                    .and_then(|l| self.resolve_location(l, BlobType::Zero))
+                // Zero blobs don't live in packs — synthesize a locator directly.
+                // resolve_location would fail because pack_array_index is synthetic.
+                self.zero_ids.get(id).map(|l| BlobLocator {
+                    pack_id: ID::default(),
+                    blob_type: BlobType::Zero,
+                    offset: 0,
+                    length: 0,
+                    raw_length: l.raw_length,
+                    compressed: false,
+                })
             })
     }
 
@@ -694,7 +704,8 @@ impl Index {
 
         process_map(&self.data_ids, BlobType::Data);
         process_map(&self.tree_ids, BlobType::Tree);
-        process_map(&self.zero_ids, BlobType::Zero);
+        // Zero blobs don't live in packs (stored in footer with length=0).
+        // Skip them to avoid phantom descriptors from backward-compat synthetic entries.
 
         pack_descriptors
     }
@@ -1339,8 +1350,7 @@ fn default_true() -> bool {
 /// Serialize an `IndexFile` to the binary format.
 pub fn serialize_index_binary(index_file: &IndexFile) -> Vec<u8> {
     let total_blobs: usize = index_file.packs.iter().map(|p| p.blobs.len()).sum();
-    let size =
-        4 + index_file.packs.len() * 36 + total_blobs * 45 + 4 + index_file.zero_blobs.len() * 36;
+    let size = 4 + index_file.packs.len() * 36 + total_blobs * 45 + 4;
     let mut buf = Vec::with_capacity(size);
 
     // Header

--- a/crates/mapache/src/repository/index.rs
+++ b/crates/mapache/src/repository/index.rs
@@ -209,11 +209,17 @@ impl IndexMetadata {
         let pack_ids: Vec<ID> = index.pack_ids.iter().copied().collect();
         let blob_count = index.num_blobs();
 
+        let zero_blobs: Vec<(ID, u32)> = index
+            .zero_ids
+            .iter()
+            .map(|(id, loc)| (*id, loc.raw_length))
+            .collect();
+
         Self {
             file_id,
             bloom_filter,
             pack_ids,
-            zero_blobs: Vec::new(),
+            zero_blobs,
             blob_count,
         }
     }
@@ -688,6 +694,7 @@ impl Index {
 
         process_map(&self.data_ids, BlobType::Data);
         process_map(&self.tree_ids, BlobType::Tree);
+        process_map(&self.zero_ids, BlobType::Zero);
 
         pack_descriptors
     }
@@ -856,7 +863,7 @@ impl MasterIndex {
                     pack_id: ID::default(),
                     blob_type: BlobType::Zero,
                     offset: 0,
-                    length: raw_length,
+                    length: 0,
                     raw_length,
                     compressed: false,
                 });

--- a/crates/mapache/src/repository/index.rs
+++ b/crates/mapache/src/repository/index.rs
@@ -421,7 +421,7 @@ impl Index {
             }
         }
 
-        // Backward compat: old index format stored zero blobs in a separate section
+        // TODO(v1-removal): Backward compat: old index format stored zero blobs in a separate section
         // without pack info. Create synthetic entries (load_blob ignores pack_id for zeros).
         // Dedup against zero_entries already populated from pack blobs.
         let existing_zeros: std::collections::HashSet<ID> =
@@ -1282,6 +1282,7 @@ pub struct IndexFile {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub packs: Vec<IndexFilePack>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    // TODO(v1-removal): Remove zero_blobs field — v2 stores zero blobs in pack footers.
     pub zero_blobs: Vec<IndexFileZeroBlob>,
 }
 
@@ -1309,6 +1310,7 @@ impl IndexFile {
 }
 
 /// A zero blob: ID -> raw_length. No pack data.
+// TODO(v1-removal): Remove IndexFileZeroBlob — v2 stores zero blobs in pack footers.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct IndexFileZeroBlob {
     pub id: ID,
@@ -2207,5 +2209,113 @@ mod tests {
         let ids: Vec<ID> = index.iter_ids().map(|(id, _)| *id).collect();
         assert!(ids.contains(&mock_id("zero_a")));
         assert!(ids.contains(&mock_id("data_1")));
+    }
+
+    #[test]
+    fn test_zero_blob_backward_compat_old_format() {
+        let index_file = IndexFile {
+            packs: Vec::new(),
+            zero_blobs: vec![
+                IndexFileZeroBlob {
+                    id: mock_id("old_zero_1"),
+                    raw_length: 4096,
+                },
+                IndexFileZeroBlob {
+                    id: mock_id("old_zero_2"),
+                    raw_length: 8192,
+                },
+            ],
+        };
+
+        let idx = Index::from_index_file(index_file, mock_id("test"));
+        assert!(idx.contains(&mock_id("old_zero_1")));
+        assert!(idx.contains(&mock_id("old_zero_2")));
+
+        let loc1 = idx.get(&mock_id("old_zero_1")).unwrap();
+        assert_eq!(loc1.blob_type, BlobType::Zero);
+        assert_eq!(loc1.raw_length, 4096);
+        assert_eq!(loc1.length, 0);
+        assert_eq!(loc1.pack_id, ID::default());
+
+        let loc2 = idx.get(&mock_id("old_zero_2")).unwrap();
+        assert_eq!(loc2.blob_type, BlobType::Zero);
+        assert_eq!(loc2.raw_length, 8192);
+    }
+
+    #[test]
+    fn test_zero_blob_metadata_from_index() {
+        let mut index = Index::new();
+        let pack_id = mock_id("pack_meta");
+        let id1 = mock_id("zero_m1");
+        let id2 = mock_id("zero_m2");
+        index.add_pack(
+            &pack_id,
+            vec![
+                PackedBlobDescriptor {
+                    id: id1,
+                    blob_type: BlobType::Zero,
+                    offset: 0,
+                    length: 0,
+                    raw_length: 1024,
+                    compressed: false,
+                },
+                PackedBlobDescriptor {
+                    id: id2,
+                    blob_type: BlobType::Zero,
+                    offset: 0,
+                    length: 0,
+                    raw_length: 2048,
+                    compressed: false,
+                },
+                mock_blob_desc("data_x", BlobType::Data, 0, 512),
+            ],
+        );
+        index.finalize();
+
+        let meta = IndexMetadata::from_index(&index, mock_id("file_meta"));
+        assert_eq!(meta.zero_blobs.len(), 2);
+
+        let (z1_id, z1_len) = meta.zero_blobs.iter().find(|(id, _)| *id == id1).unwrap();
+        assert_eq!(*z1_id, id1);
+        assert_eq!(*z1_len, 1024);
+
+        let (z2_id, z2_len) = meta.zero_blobs.iter().find(|(id, _)| *id == id2).unwrap();
+        assert_eq!(*z2_id, id2);
+        assert_eq!(*z2_len, 2048);
+    }
+
+    #[test]
+    fn test_zero_blob_cold_lookup() {
+        let mi = MasterIndex::new(IndexMode::Lazy);
+
+        let mut index = Index::new();
+        let pack_id = mock_id("pack_cold");
+        let zero_id = mock_id("cold_zero");
+        index.add_pack(
+            &pack_id,
+            vec![PackedBlobDescriptor {
+                id: zero_id,
+                blob_type: BlobType::Zero,
+                offset: 0,
+                length: 0,
+                raw_length: 16384,
+                compressed: false,
+            }],
+        );
+        index.finalize();
+
+        let file_id = mock_id("cold_file");
+        let meta = IndexMetadata::from_index(&index, file_id);
+        mi.add_cold_metadata(meta);
+
+        match mi.get_with_cold(&zero_id) {
+            LookupResult::Found(locator) => {
+                assert_eq!(locator.blob_type, BlobType::Zero);
+                assert_eq!(locator.raw_length, 16384);
+                assert_eq!(locator.length, 0);
+                assert_eq!(locator.pack_id, ID::default());
+            }
+            other => panic!("expected Found for cold zero blob, got {:?}", other),
+        }
     }
 }

--- a/crates/mapache/src/repository/index.rs
+++ b/crates/mapache/src/repository/index.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     str::FromStr,
     sync::{
         Arc,
@@ -201,7 +200,6 @@ pub struct IndexMetadata {
 impl IndexMetadata {
     /// Create IndexMetadata from an existing `Index`.
     pub fn from_index(index: &Index, file_id: ID) -> Self {
-        // Create a combined bloom filter from both data_ids and tree_ids
         let total_blobs = index.num_blobs();
         let mut bloom_filter = BloomFilter::new(total_blobs, 0.01);
         for (id, _) in index.iter_ids() {
@@ -209,19 +207,13 @@ impl IndexMetadata {
         }
 
         let pack_ids: Vec<ID> = index.pack_ids.iter().copied().collect();
-        let mut zero_blobs: Vec<(ID, u32)> = index
-            .zero_ids
-            .iter()
-            .map(|(&id, &raw_length)| (id, raw_length))
-            .collect();
-        zero_blobs.sort_unstable_by_key(|(id, _)| *id);
         let blob_count = index.num_blobs();
 
         Self {
             file_id,
             bloom_filter,
             pack_ids,
-            zero_blobs,
+            zero_blobs: Vec::new(),
             blob_count,
         }
     }
@@ -305,9 +297,9 @@ pub struct Index {
     data_ids: BlobMap,
     tree_ids: BlobMap,
 
-    /// Zero blobs: ID -> raw_length. These blobs have no pack data;
-    /// during restore, `raw_length` bytes of zeros are produced.
-    zero_ids: HashMap<ID, u32>,
+    /// Zero blobs: ID -> BlobLocationInternal. Listed in data pack footers
+    /// with length=0, raw_length=N. During restore, N bytes of zeros are produced.
+    zero_ids: BlobMap,
 
     /// The Pack IDs referenced in this index. Using an `IndexSet` allows us
     /// to store a small `usize` index in `BlobLocationInternal` instead of the full `ID`,
@@ -333,7 +325,7 @@ impl Index {
             file_id: None,
             data_ids: BlobMap::new_mutable(),
             tree_ids: BlobMap::new_mutable(),
-            zero_ids: HashMap::new(),
+            zero_ids: BlobMap::new_mutable(),
             pack_ids: IdIndexSet::new_id_set(),
             status: IndexStatus::Pending,
             create_time: Instant::now(),
@@ -396,6 +388,7 @@ impl Index {
 
         let mut data_entries = Vec::new();
         let mut tree_entries = Vec::new();
+        let mut zero_entries = Vec::new();
 
         for pack in index_file.packs {
             let pack_index = index.pack_ids.insert(pack.id) as u32;
@@ -405,20 +398,35 @@ impl Index {
                     continue;
                 }
 
-                let entries = match blob.blob_type {
-                    BlobType::Data => &mut data_entries,
-                    BlobType::Tree => &mut tree_entries,
-                    _ => continue,
+                let loc = BlobLocationInternal {
+                    pack_array_index: pack_index,
+                    offset: blob.offset,
+                    length: blob.length,
+                    raw_length: blob.raw_length,
+                    compressed: blob.compressed,
                 };
 
-                entries.push((
-                    blob.id,
+                match blob.blob_type {
+                    BlobType::Data => data_entries.push((blob.id, loc)),
+                    BlobType::Tree => tree_entries.push((blob.id, loc)),
+                    BlobType::Zero => zero_entries.push((blob.id, loc)),
+                    _ => {}
+                }
+            }
+        }
+
+        // Backward compat: old index format stored zero blobs in a separate section
+        // without pack info. Create synthetic entries (load_blob ignores pack_id for zeros).
+        for zb in index_file.zero_blobs {
+            if !zero_entries.iter().any(|(id, _)| *id == zb.id) {
+                zero_entries.push((
+                    zb.id,
                     BlobLocationInternal {
-                        pack_array_index: pack_index,
-                        offset: blob.offset,
-                        length: blob.length,
-                        raw_length: blob.raw_length,
-                        compressed: blob.compressed,
+                        pack_array_index: 0,
+                        offset: 0,
+                        length: 0,
+                        raw_length: zb.raw_length,
+                        compressed: false,
                     },
                 ));
             }
@@ -426,6 +434,7 @@ impl Index {
 
         data_entries.sort_unstable_by_key(|(id, _)| *id);
         tree_entries.sort_unstable_by_key(|(id, _)| *id);
+        zero_entries.sort_unstable_by_key(|(id, _)| *id);
 
         let mut data_bf = BloomFilter::new(data_entries.len(), 0.01);
         for (id, _) in &data_entries {
@@ -435,14 +444,14 @@ impl Index {
         for (id, _) in &tree_entries {
             tree_bf.insert(id);
         }
+        let mut zero_bf = BloomFilter::new(zero_entries.len(), 0.01);
+        for (id, _) in &zero_entries {
+            zero_bf.insert(id);
+        }
 
         index.data_ids = BlobMap::Immutable(data_entries, data_bf);
         index.tree_ids = BlobMap::Immutable(tree_entries, tree_bf);
-        index.zero_ids = index_file
-            .zero_blobs
-            .into_iter()
-            .map(|zb| (zb.id, zb.raw_length))
-            .collect();
+        index.zero_ids = BlobMap::Immutable(zero_entries, zero_bf);
 
         index
     }
@@ -450,7 +459,7 @@ impl Index {
     /// Checks if the index contains the given object ID.
     #[inline]
     pub fn contains(&self, id: &ID) -> bool {
-        self.data_ids.contains(id) || self.tree_ids.contains(id) || self.zero_ids.contains_key(id)
+        self.data_ids.contains(id) || self.tree_ids.contains(id) || self.zero_ids.contains(id)
     }
 
     /// Helper to resolve internal location to a public BlobLocator.
@@ -481,14 +490,9 @@ impl Index {
                     .and_then(|l| self.resolve_location(l, BlobType::Tree))
             })
             .or_else(|| {
-                self.zero_ids.get(id).map(|&raw_length| BlobLocator {
-                    pack_id: ID::default(),
-                    blob_type: BlobType::Zero,
-                    offset: 0,
-                    length: raw_length,
-                    raw_length,
-                    compressed: false,
-                })
+                self.zero_ids
+                    .get(id)
+                    .and_then(|l| self.resolve_location(l, BlobType::Zero))
             })
     }
 
@@ -512,6 +516,7 @@ impl Index {
             let map = match blob.blob_type {
                 BlobType::Data => &mut self.data_ids,
                 BlobType::Tree => &mut self.tree_ids,
+                BlobType::Zero => &mut self.zero_ids,
                 _ => continue,
             };
 
@@ -526,11 +531,6 @@ impl Index {
                 },
             );
         }
-    }
-
-    /// Registers a zero blob (no pack data needed).
-    pub fn add_zero_blob(&mut self, id: ID, raw_length: u32) {
-        self.zero_ids.insert(id, raw_length);
     }
 
     /// Saves the index to the repository.
@@ -574,6 +574,7 @@ impl Index {
 
         add_to_entries(&self.data_ids, BlobType::Data);
         add_to_entries(&self.tree_ids, BlobType::Tree);
+        add_to_entries(&self.zero_ids, BlobType::Zero);
 
         // Sort blobs within each pack for deterministic serialization
         for pack in &mut pack_entries {
@@ -586,17 +587,11 @@ impl Index {
         // Sort packs themselves
         pack_entries.sort_unstable_by_key(|p| p.id);
 
-        let zero_entries: Vec<IndexFileZeroBlob> = self
-            .zero_ids
-            .iter()
-            .map(|(&id, &raw_length)| IndexFileZeroBlob { id, raw_length })
-            .collect();
-
         let effective_version = repo_version.unwrap_or(repo.repo_version());
         // TODO(v1-removal): Remove effective_version, always use binary serialization.
         let serialized = IndexFile {
             packs: pack_entries,
-            zero_blobs: zero_entries,
+            zero_blobs: Vec::new(),
         }
         .serialize(effective_version)?;
 
@@ -617,6 +612,7 @@ impl Index {
         // Free memory: convert Mutable (HashMap) to Immutable (sorted Vec)
         self.data_ids.freeze();
         self.tree_ids.freeze();
+        self.zero_ids.freeze();
 
         Ok(size)
     }
@@ -648,18 +644,10 @@ impl Index {
                 result.push((id, locator));
             }
         }
-        for (id, &raw_length) in &self.zero_ids {
-            result.push((
-                id,
-                BlobLocator {
-                    pack_id: ID::default(),
-                    blob_type: BlobType::Zero,
-                    offset: 0,
-                    length: raw_length,
-                    raw_length,
-                    compressed: false,
-                },
-            ));
+        for (id, loc) in self.zero_ids.iter() {
+            if let Some(locator) = self.resolve_location(loc, BlobType::Zero) {
+                result.push((id, locator));
+            }
         }
         result.into_iter()
     }
@@ -815,14 +803,9 @@ impl MasterIndex {
             })
             .or_else(|| {
                 lock.indices.iter().rev().find_map(|idx| {
-                    idx.zero_ids.get(id).map(|&raw_length| BlobLocator {
-                        pack_id: ID::default(),
-                        blob_type: BlobType::Zero,
-                        offset: 0,
-                        length: raw_length,
-                        raw_length,
-                        compressed: false,
-                    })
+                    idx.zero_ids
+                        .get(id)
+                        .and_then(|l| idx.resolve_location(l, BlobType::Zero))
                 })
             })
     }
@@ -1016,31 +999,6 @@ impl MasterIndex {
 
         // Try to insert into pending_blobs. This is sharded so it's low contention.
         self.pending_blobs.insert(id)
-    }
-
-    /// Registers a zero blob directly in the current pending index.
-    pub fn add_zero_blob(&self, id: ID, raw_length: u32) {
-        {
-            let lock = self.inner.read();
-            if lock.indices.iter().rev().any(|idx| idx.contains(&id)) {
-                return;
-            }
-        }
-
-        {
-            let mut lock = self.inner.write();
-            if !lock.indices.iter().any(|idx| idx.is_pending()) {
-                lock.indices.push(Index::new());
-            }
-            let pending = lock
-                .indices
-                .iter_mut()
-                .find(|idx| idx.is_pending())
-                .expect("just created a pending index");
-            pending.add_zero_blob(id, raw_length);
-        }
-
-        self.pending_blobs.remove(&id);
     }
 
     /// Processes a newly created pack of blobs. It removes these blobs from the
@@ -2133,10 +2091,30 @@ mod tests {
     #[test]
     fn test_zero_blob_index_roundtrip() {
         let mut index = Index::new();
+        let pack_id = mock_id("pack_z");
         let id1 = mock_id("zero_1");
         let id2 = mock_id("zero_2");
-        index.add_zero_blob(id1, 4096);
-        index.add_zero_blob(id2, 8192);
+        index.add_pack(
+            &pack_id,
+            vec![
+                PackedBlobDescriptor {
+                    id: id1,
+                    blob_type: BlobType::Zero,
+                    offset: 0,
+                    length: 0,
+                    raw_length: 4096,
+                    compressed: false,
+                },
+                PackedBlobDescriptor {
+                    id: id2,
+                    blob_type: BlobType::Zero,
+                    offset: 0,
+                    length: 0,
+                    raw_length: 8192,
+                    compressed: false,
+                },
+            ],
+        );
 
         assert!(index.contains(&id1));
         assert!(index.contains(&id2));
@@ -2144,8 +2122,7 @@ mod tests {
         let loc1 = index.get(&id1).expect("zero blob 1 should be found");
         assert_eq!(loc1.blob_type, BlobType::Zero);
         assert_eq!(loc1.raw_length, 4096);
-        assert_eq!(loc1.length, 4096);
-        assert_eq!(loc1.offset, 0);
+        assert_eq!(loc1.length, 0);
 
         let loc2 = index.get(&id2).expect("zero blob 2 should be found");
         assert_eq!(loc2.blob_type, BlobType::Zero);
@@ -2155,40 +2132,58 @@ mod tests {
     #[test]
     fn test_zero_blob_persist_roundtrip() {
         let index_file = IndexFile {
-            packs: Vec::new(),
-            zero_blobs: vec![
-                IndexFileZeroBlob {
-                    id: mock_id("zero_1"),
-                    raw_length: 100,
-                },
-                IndexFileZeroBlob {
-                    id: mock_id("zero_2"),
-                    raw_length: 200,
-                },
-            ],
+            packs: vec![IndexFilePack {
+                id: mock_id("pack_z"),
+                blobs: vec![
+                    IndexFileBlob {
+                        id: mock_id("zero_1"),
+                        blob_type: BlobType::Zero,
+                        offset: 0,
+                        length: 0,
+                        raw_length: 100,
+                        compressed: false,
+                    },
+                    IndexFileBlob {
+                        id: mock_id("zero_2"),
+                        blob_type: BlobType::Zero,
+                        offset: 0,
+                        length: 0,
+                        raw_length: 200,
+                        compressed: false,
+                    },
+                ],
+            }],
+            zero_blobs: Vec::new(),
         };
 
         let binary = serialize_index_binary(&index_file);
         let restored = deserialize_index_binary(&binary).unwrap();
-        assert_eq!(restored.zero_blobs.len(), 2);
-        assert_eq!(restored.zero_blobs[0].raw_length, 100);
-        assert_eq!(restored.zero_blobs[1].raw_length, 200);
+        assert_eq!(restored.packs.len(), 1);
+        assert_eq!(restored.packs[0].blobs.len(), 2);
 
         let idx = Index::from_index_file(restored, mock_id("test"));
         let loc = idx.get(&mock_id("zero_1")).unwrap();
         assert_eq!(loc.blob_type, BlobType::Zero);
         assert_eq!(loc.raw_length, 100);
-        assert_eq!(loc.length, 100);
-        assert_eq!(loc.offset, 0);
+        assert_eq!(loc.length, 0);
     }
 
     #[test]
     fn test_zero_blob_in_iter_ids() {
         let mut index = Index::new();
-        index.add_zero_blob(mock_id("zero_a"), 500);
         index.add_pack(
             &mock_id("pack1"),
-            vec![mock_blob_desc("data_1", BlobType::Data, 0, 100)],
+            vec![
+                mock_blob_desc("data_1", BlobType::Data, 0, 100),
+                PackedBlobDescriptor {
+                    id: mock_id("zero_a"),
+                    blob_type: BlobType::Zero,
+                    offset: 0,
+                    length: 0,
+                    raw_length: 500,
+                    compressed: false,
+                },
+            ],
         );
         index.finalize();
 

--- a/crates/mapache/src/repository/migration.rs
+++ b/crates/mapache/src/repository/migration.rs
@@ -92,11 +92,11 @@ pub async fn re_encrypt_pack(
         }
     }
 
-    // Rebuild the footer: only non-zero blobs go in the pack footer.
+    // Rebuild the footer: zero blobs appear as BlobType::Zero with length=0.
     // v1 blobs were always zstd-compressed, so compressed: true.
     let mut footer_descriptors: Vec<_> = descriptors
         .iter()
-        .filter(|d| !matches!(d.blob_type, BlobType::Zero | BlobType::Padding))
+        .filter(|d| !matches!(d.blob_type, BlobType::Padding))
         .cloned()
         .collect();
     let footer_bytes = Packer::generate_footer(&mut footer_descriptors);

--- a/crates/mapache/src/repository/migration.rs
+++ b/crates/mapache/src/repository/migration.rs
@@ -3,6 +3,7 @@
 //! All items in this module are temporary and should be removed when v1 is deprecated.
 // TODO(v1-removal): Remove this entire module.
 
+use crate::archiver::processor::is_all_zero;
 use crate::backend::{Handle, StorageBackend};
 use crate::common::{
     BlobType, ContentIdType, ID,
@@ -71,12 +72,13 @@ pub async fn re_encrypt_pack(
         let blob_encrypted = &pack_data[start..end];
 
         // Decrypt to check for zero content.
+        // Fast path: first byte non-zero (common case) skips the full iter().all() scan.
         let plaintext = match secure_storage.decrypt_inner(blob_encrypted, old_nonce_at_end)? {
             crate::backend::WriteContents::Owned(v) => v,
             crate::backend::WriteContents::Borrowed(b) => b.to_vec(),
         };
 
-        if plaintext.iter().all(|&b| b == 0) {
+        if is_all_zero(&plaintext) {
             // Zero blob: mark but don't include in new pack.
             desc.blob_type = BlobType::Zero;
             desc.offset = 0;

--- a/crates/mapache/src/repository/migration.rs
+++ b/crates/mapache/src/repository/migration.rs
@@ -5,7 +5,7 @@
 
 use crate::backend::{Handle, StorageBackend};
 use crate::common::{
-    ContentIdType, ID,
+    BlobType, ContentIdType, ID,
     error::{MapacheError, Result},
 };
 use crate::repository::packer::{PackedBlobDescriptor, Packer};
@@ -52,25 +52,53 @@ pub async fn re_encrypt_pack(
     let data_section_end = total_len - 4 - encoded_footer_length;
 
     // Parse footer with old nonce position to get descriptors (non-padding only, correct offsets).
-    let descriptors = Packer::parse_footer(secure_storage, &pack_data, old_nonce_at_end, 1)?;
+    let mut descriptors = Packer::parse_footer(secure_storage, &pack_data, old_nonce_at_end, 1)?;
 
     tracing::debug!(target: "migrate", "Pack {}: {} blobs, data_section={} bytes, footer={} bytes",
         old_pack_id.to_short_hex(8), descriptors.len(), data_section_end, encoded_footer_length);
 
     // Re-encrypt each non-padding blob and build the new data section.
+    // Zero blobs are detected and marked with BlobType::Zero (no pack data).
     let mut new_data = Vec::with_capacity(data_section_end);
-    for desc in &descriptors {
+    let mut new_offset = 0u32;
+    for desc in &mut descriptors {
+        if matches!(desc.blob_type, BlobType::Padding) {
+            continue;
+        }
+
         let start = desc.offset as usize;
         let end = start + desc.length as usize;
         let blob_encrypted = &pack_data[start..end];
-        let re_encrypted =
-            secure_storage.re_encrypt(blob_encrypted, old_nonce_at_end, new_nonce_at_end)?;
-        new_data.extend_from_slice(&re_encrypted);
+
+        // Decrypt to check for zero content.
+        let plaintext = match secure_storage.decrypt_inner(blob_encrypted, old_nonce_at_end)? {
+            crate::backend::WriteContents::Owned(v) => v,
+            crate::backend::WriteContents::Borrowed(b) => b.to_vec(),
+        };
+
+        if plaintext.iter().all(|&b| b == 0) {
+            // Zero blob: mark but don't include in new pack.
+            desc.blob_type = BlobType::Zero;
+            desc.offset = 0;
+            desc.length = 0;
+        } else {
+            // Non-zero: re-encrypt with new nonce position.
+            let re_encrypted =
+                secure_storage.re_encrypt(blob_encrypted, old_nonce_at_end, new_nonce_at_end)?;
+            desc.offset = new_offset;
+            desc.length = re_encrypted.len() as u32;
+            new_offset += desc.length;
+            new_data.extend_from_slice(&re_encrypted);
+        }
     }
 
-    // Rebuild the footer: v1 blobs were always zstd-compressed, so every
-    // descriptor carries `compressed: true` and gets the compression bit set.
-    let mut footer_descriptors = descriptors.clone();
+    // Rebuild the footer: only non-zero blobs go in the pack footer.
+    // v1 blobs were always zstd-compressed, so compressed: true.
+    let mut footer_descriptors: Vec<_> = descriptors
+        .iter()
+        .filter(|d| !matches!(d.blob_type, BlobType::Zero | BlobType::Padding))
+        .cloned()
+        .collect();
     let footer_bytes = Packer::generate_footer(&mut footer_descriptors);
     let mut ctx = secure_storage.get_encoding_context()?;
     let new_footer =

--- a/crates/mapache/src/repository/packer.rs
+++ b/crates/mapache/src/repository/packer.rs
@@ -126,10 +126,10 @@ impl Packer {
         self.buffer.len() as u64
     }
 
-    /// Returns true if no data have been added to the packer.
+    /// Returns true if no blobs (including zero-length) have been added to the packer.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.buffer.is_empty()
+        self.descriptors.is_empty()
     }
 
     /// Returns the number of blobs currently staged in the packer.
@@ -186,7 +186,7 @@ impl Packer {
     /// The internal buffer is essentially "stolen" by the result and must be
     /// returned via `recycle_buffer` later.
     fn finalize_and_extract(&mut self) -> Result<Option<PackFinalizationResult>> {
-        if self.buffer.is_empty() {
+        if self.descriptors.is_empty() {
             return Ok(None);
         }
 

--- a/crates/mapache/src/repository/packer.rs
+++ b/crates/mapache/src/repository/packer.rs
@@ -60,6 +60,10 @@ static NEXT_PACKER_ID: AtomicU64 = AtomicU64::new(1);
 
 pub const FOOTER_BLOB_LEN: usize = 41;
 
+/// Maximum descriptors per pack before flushing. Guards against unbounded
+/// accumulation when a pack contains only zero blobs (which don't grow `buffer`).
+const MAX_DESCRIPTORS_PER_PACK: usize = 4096;
+
 /// Describes a single blob's location and size within a packed file.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PackedBlobDescriptor {
@@ -156,7 +160,7 @@ impl Packer {
         let raw_length = u32::try_from(raw_size)
             .map_err(|e| MapacheError::Integrity(format!("blob raw size exceeds u32::MAX: {e}")))?;
 
-        if !encoded_data.is_empty() {
+        if blob_type != BlobType::Zero {
             self.buffer.extend_from_slice(encoded_data);
         }
 
@@ -630,13 +634,15 @@ impl PackSaver {
                     raw_length,
                     compressed,
                 } => {
+                    let max_size = self.max_packer_size;
                     let Some(packer) = self.packer_for(blob_type) else {
                         continue;
                     };
 
                     packer.add_blob(id, blob_type, &data, raw_length, compressed)?;
 
-                    if packer.size() >= self.max_packer_size {
+                    if packer.size() >= max_size || packer.num_objects() >= MAX_DESCRIPTORS_PER_PACK
+                    {
                         self.dispatch_packer(blob_type)?;
                     }
                 }

--- a/crates/mapache/src/repository/packer.rs
+++ b/crates/mapache/src/repository/packer.rs
@@ -156,7 +156,9 @@ impl Packer {
         let raw_length = u32::try_from(raw_size)
             .map_err(|e| MapacheError::Integrity(format!("blob raw size exceeds u32::MAX: {e}")))?;
 
-        self.buffer.extend_from_slice(encoded_data);
+        if !encoded_data.is_empty() {
+            self.buffer.extend_from_slice(encoded_data);
+        }
 
         self.descriptors.push(PackedBlobDescriptor {
             id,
@@ -609,7 +611,7 @@ impl PackSaver {
 
     fn packer_for(&mut self, blob_type: BlobType) -> Option<&mut Packer> {
         match blob_type {
-            BlobType::Data => Some(&mut self.data_packer),
+            BlobType::Data | BlobType::Zero => Some(&mut self.data_packer),
             BlobType::Tree => Some(&mut self.tree_packer),
             _ => None,
         }
@@ -661,7 +663,7 @@ impl PackSaver {
     /// and sends the full one to the workers.
     fn dispatch_packer(&mut self, blob_type: BlobType) -> Result<()> {
         let packer_ref = match blob_type {
-            BlobType::Data => &mut self.data_packer,
+            BlobType::Data | BlobType::Zero => &mut self.data_packer,
             BlobType::Tree => &mut self.tree_packer,
             _ => return Ok(()),
         };
@@ -697,7 +699,7 @@ impl PackSaver {
         blob_type: BlobType,
     ) {
         match blob_type {
-            BlobType::Data => {
+            BlobType::Data | BlobType::Zero => {
                 // For Data packs, the 'raw' and 'encoded' sizes correspond to the blobs themselves.
                 // The 'meta' sizes correspond to the pack footer.
                 repo.stats.raw_bytes.fetch_add(raw_size, Ordering::Relaxed);

--- a/crates/mapache/src/repository/repo.rs
+++ b/crates/mapache/src/repository/repo.rs
@@ -541,7 +541,9 @@ impl Repository {
         // Zero blobs: send to packer with empty encoded data (no bytes in pack data section).
         // They appear in the pack footer as BlobType::Zero with length=0, raw_length=N.
         if blob_type == BlobType::Zero {
-            let raw_length = data.len() as u64;
+            let raw_length = u32::try_from(data.len()).map_err(|e| {
+                MapacheError::Integrity(format!("zero blob raw size exceeds u32::MAX: {e}"))
+            })? as u64;
 
             let tx = {
                 let tx_guard = self.pack_saver_tx.read();

--- a/crates/mapache/src/repository/repo.rs
+++ b/crates/mapache/src/repository/repo.rs
@@ -543,10 +543,32 @@ impl Repository {
             return Ok(id);
         }
 
-        // Zero blobs (v2+): register directly in index without pack data.
-        if blob_type == BlobType::Zero && self.repo_version >= 2 {
-            let raw_length = data.len() as u32;
-            self.master_index.add_zero_blob(id, raw_length);
+        // Zero blobs: send to packer with empty encoded data (no bytes in pack data section).
+        // They appear in the pack footer as BlobType::Zero with length=0, raw_length=N.
+        if blob_type == BlobType::Zero {
+            let raw_length = data.len() as u64;
+
+            let tx = {
+                let tx_guard = self.pack_saver_tx.read();
+                tx_guard
+                    .as_ref()
+                    .ok_or_else(|| {
+                        MapacheError::Repo("packer is stopped or not initialized".to_string())
+                    })?
+                    .clone()
+            };
+
+            tx.send(PackSaverRequest::SaveBlob {
+                id,
+                blob_type,
+                data: Vec::new(),
+                raw_length,
+                compressed: false,
+            })
+            .map_err(|_| MapacheError::Repo("packer channel closed".to_string()))?;
+
+            self.master_index.add_pending_blob(id);
+
             return Ok(id);
         }
 

--- a/crates/mapache/src/repository/repo.rs
+++ b/crates/mapache/src/repository/repo.rs
@@ -496,11 +496,6 @@ impl Repository {
         self.repo_version >= 2
     }
 
-    /// v2: zero-blob dedup (store length only, no pack data).
-    pub fn supports_zero_blobs(&self) -> bool {
-        self.repo_version >= 2
-    }
-
     /// v2: high bit of type byte is a compression marker.
     /// v1: always zstd-compressed, bit is not meaningful.
     pub fn has_compression_marker(&self) -> bool {

--- a/crates/mapache/src/repository/repo.rs
+++ b/crates/mapache/src/repository/repo.rs
@@ -543,7 +543,7 @@ impl Repository {
             return Ok(id);
         }
 
-        // TODO(v1-removal): Zero blobs: register directly in index, no pack data (v2+ only).
+        // Zero blobs (v2+): register directly in index without pack data.
         if blob_type == BlobType::Zero && self.repo_version >= 2 {
             let raw_length = data.len() as u32;
             self.master_index.add_zero_blob(id, raw_length);

--- a/crates/mapache/src/repository/verify.rs
+++ b/crates/mapache/src/repository/verify.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc;
 
 use crate::{
     backend::{Handle, StorageBackend},
-    common::{self, ContentIdType, ID},
+    common::{self, BlobType, ContentIdType, ID},
     fs::tree::Tree,
     repository::{packer::Packer, repo::Repository, storage::SecureStorage},
     utils::{
@@ -391,7 +391,9 @@ pub async fn verify_snapshot_refs(
             for id in referenced_ids {
                 match index.get(id) {
                     Some(blob_locator) => {
-                        if !existing_packs.contains(&blob_locator.pack_id) {
+                        if blob_locator.blob_type != BlobType::Zero
+                            && !existing_packs.contains(&blob_locator.pack_id)
+                        {
                             return Err(MapacheError::Integrity(format!(
                                 "broken reference: Pack {} referenced by blob {} is missing from storage",
                                 blob_locator.pack_id, id

--- a/crates/mapache/src/repository/verify.rs
+++ b/crates/mapache/src/repository/verify.rs
@@ -86,6 +86,12 @@ async fn verify_pack_inline(
             .fold(
                 || (0usize, Vec::new(), 0u64),
                 |(mut v, mut corrupt, mut bytes), desc| {
+                    // Zero blobs have no data in the pack (length=0); skip physical verification.
+                    if matches!(desc.blob_type, BlobType::Zero) {
+                        v += 1;
+                        return (v, corrupt, bytes);
+                    }
+
                     let start = desc.offset as usize;
                     let end = start + desc.length as usize;
 

--- a/crates/mapache/src/restorer/mod.rs
+++ b/crates/mapache/src/restorer/mod.rs
@@ -121,6 +121,8 @@ pub(crate) struct Restorer {
 }
 
 pub(crate) type PackMap = HashMap<ID, Vec<(ID, BlobRestoreRequest)>>;
+/// file_idx -> list of (offset_in_file, raw_length) for zero blobs
+pub(crate) type ZeroBatchMap = HashMap<usize, Vec<(u64, u32)>>;
 type HardlinkByPath = (PathBuf, PathBuf);
 type PrimaryHardlinks = Arc<Mutex<HashMap<(u64, u64), (PathBuf, [u8; 32])>>>;
 

--- a/crates/mapache/src/restorer/mod.rs
+++ b/crates/mapache/src/restorer/mod.rs
@@ -36,7 +36,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    common::{ID, defaults},
+    common::{BlobType, ID, defaults},
     fs::{node::Node, tree::SerializedNodeStream},
     repository::{repo::Repository, snapshot::Snapshot},
     ui::events::{Event, EventSender, RestoreEvent, emit_event},
@@ -142,6 +142,7 @@ pub(crate) struct BlobRestoreRequest {
     pub(crate) blob_length: u32,
     pub(crate) raw_length: u32,
     pub(crate) compressed: bool,
+    pub(crate) blob_type: BlobType,
 }
 
 /// A cache for open file handles during restoration.
@@ -748,6 +749,7 @@ impl Restorer {
                                             blob_length: locator.length,
                                             raw_length: locator.raw_length,
                                             compressed: locator.compressed,
+                                            blob_type: locator.blob_type,
                                         },
                                     ));
                                 }
@@ -860,6 +862,7 @@ impl Restorer {
                                 blob_length: locator.length,
                                 raw_length: locator.raw_length,
                                 compressed: locator.compressed,
+                                blob_type: locator.blob_type,
                             },
                         ));
                     }

--- a/crates/mapache/src/restorer/pack_restorer.rs
+++ b/crates/mapache/src/restorer/pack_restorer.rs
@@ -16,7 +16,9 @@ use crate::{
     ui::events::{Event, EventSender, RestoreEvent, emit_event},
 };
 
-use super::{BlobRestoreRequest, FileRestorePlan, PackMap, Restorer, ShardedFileHandleCache};
+use super::{
+    BlobRestoreRequest, FileRestorePlan, PackMap, Restorer, ShardedFileHandleCache, ZeroBatchMap,
+};
 
 struct DecodedBlob {
     data: Vec<u8>,
@@ -97,18 +99,19 @@ pub(crate) async fn restore_packs(
 
     let packs_map = Arc::try_unwrap(packs).unwrap_or_else(|arc| (*arc).clone());
 
-    // Handle zero blobs separately: they have no pack data, write zeros directly.
-    let mut zero_file_batches: HashMap<usize, Vec<(Vec<u8>, u64)>> = HashMap::new();
-    let mut regular_packs: HashMap<ID, Vec<(ID, BlobRestoreRequest)>> = HashMap::new();
+    // Split blobs into two streams:
+    // - Zero blobs: no pack data to download, just N bytes of zeros to write directly.
+    // - Regular blobs: need to be fetched from pack files on storage.
+    let mut zero_file_batches: ZeroBatchMap = HashMap::new();
+    let mut regular_packs: PackMap = HashMap::new();
 
     for (pack_id, blob_requests) in packs_map {
         for (blob_id, req) in blob_requests {
             if matches!(req.blob_type, BlobType::Zero) {
-                let zeros = vec![0u8; req.raw_length as usize];
                 zero_file_batches
                     .entry(req.file_idx)
                     .or_default()
-                    .push((zeros, req.offset_in_file));
+                    .push((req.offset_in_file, req.raw_length));
             } else {
                 regular_packs
                     .entry(pack_id)
@@ -119,7 +122,7 @@ pub(crate) async fn restore_packs(
     }
 
     if !zero_file_batches.is_empty() {
-        flush_file_batches(
+        flush_zero_batches(
             &mut zero_file_batches,
             &ctx,
             defaults.restore_blob_concurrency,
@@ -350,6 +353,97 @@ async fn flush_file_batches(
                     }
                     Err(e) => {
                         let err_msg = format!("failed to write to file index {file_idx}: {e}");
+                        if ctx.quit_on_error {
+                            return Err(MapacheError::Internal(err_msg));
+                        }
+                        emit_event(
+                            &ctx.event_sender,
+                            Event::Restore(RestoreEvent::Error(err_msg)),
+                        );
+                    }
+                }
+
+                Ok::<(), MapacheError>(())
+            }
+        })
+        .buffer_unordered(concurrency);
+
+    while let Some(res) = batch_stream.next().await {
+        res?;
+    }
+
+    Ok(())
+}
+
+/// Chunk size for writing zeros — avoids allocating the full zero blob in memory.
+const ZERO_WRITE_CHUNK: usize = 64 * 1024;
+
+/// Flush zero blob batches: write zeros directly to files in chunks,
+/// without materializing the full zero content in memory.
+async fn flush_zero_batches(
+    zero_batches: &mut ZeroBatchMap,
+    ctx: &Arc<RestoreContext>,
+    concurrency: usize,
+) -> Result<()> {
+    let batches = std::mem::take(zero_batches);
+
+    let mut batch_stream = futures::stream::iter(batches)
+        .map(|(file_idx, writes)| {
+            let num_blobs = writes.len().min(u32::MAX as usize) as u32;
+            let total_bytes: u64 = writes.iter().map(|&(_, len)| len as u64).sum();
+            let ctx = ctx.clone();
+
+            async move {
+                let file_path = ctx.files[file_idx].path.clone();
+                let file_path_for_write = file_path.clone();
+                let ctx_inner = ctx.clone();
+                let write_result = spawn_blocking(move || -> Result<u64> {
+                    let mut cache_guard = ctx_inner.handle_cache.get_shard(file_idx).lock();
+                    let file = cache_guard.get_handle(
+                        file_idx,
+                        &file_path_for_write,
+                        &ctx_inner.files[file_idx],
+                        &ctx_inner.initialized[file_idx],
+                        &ctx_inner.restorer,
+                    )?;
+                    let zeros = [0u8; ZERO_WRITE_CHUNK];
+                    let mut written = 0u64;
+                    for (offset, length) in writes {
+                        let mut remaining = length as u64;
+                        let mut write_offset = offset;
+                        while remaining > 0 {
+                            let chunk = remaining.min(ZERO_WRITE_CHUNK as u64) as usize;
+                            let slice = &zeros[..chunk];
+                            #[cfg(unix)]
+                            let n = file.write_at(slice, write_offset)?;
+                            #[cfg(windows)]
+                            let n = file.seek_write(slice, write_offset)?;
+                            if n == 0 {
+                                return Err(MapacheError::Internal(
+                                    "failed to write zeros: wrote 0 bytes".to_string(),
+                                ));
+                            }
+                            remaining -= n as u64;
+                            write_offset += n as u64;
+                        }
+                        written += length as u64;
+                    }
+                    Ok(written)
+                })
+                .await
+                .map_err(|e| MapacheError::task_panicked("zero blob restore", e))?;
+
+                match write_result {
+                    Ok(_bytes) => {
+                        emit_event(
+                            &ctx.event_sender,
+                            Event::Restore(RestoreEvent::BytesProcessed(total_bytes)),
+                        );
+                        ctx.remaining[file_idx].fetch_sub(num_blobs, Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        let err_msg =
+                            format!("failed to write zeros to file index {file_idx}: {e}");
                         if ctx.quit_on_error {
                             return Err(MapacheError::Internal(err_msg));
                         }

--- a/crates/mapache/src/restorer/pack_restorer.rs
+++ b/crates/mapache/src/restorer/pack_restorer.rs
@@ -98,21 +98,18 @@ pub(crate) async fn restore_packs(
     let packs_map = Arc::try_unwrap(packs).unwrap_or_else(|arc| (*arc).clone());
 
     // Handle zero blobs separately: they have no pack data, write zeros directly.
-    let zero_pack_id = ID::default();
     let mut zero_file_batches: HashMap<usize, Vec<(Vec<u8>, u64)>> = HashMap::new();
     let mut regular_packs: HashMap<ID, Vec<(ID, BlobRestoreRequest)>> = HashMap::new();
 
     for (pack_id, blob_requests) in packs_map {
-        if pack_id == zero_pack_id {
-            for (_blob_id, req) in blob_requests {
+        for (blob_id, req) in blob_requests {
+            if matches!(req.blob_type, BlobType::Zero) {
                 let zeros = vec![0u8; req.raw_length as usize];
                 zero_file_batches
                     .entry(req.file_idx)
                     .or_default()
                     .push((zeros, req.offset_in_file));
-            }
-        } else {
-            for (blob_id, req) in blob_requests {
+            } else {
                 regular_packs
                     .entry(pack_id)
                     .or_default()

--- a/crates/mapache/src/restorer/pack_restorer.rs
+++ b/crates/mapache/src/restorer/pack_restorer.rs
@@ -97,7 +97,40 @@ pub(crate) async fn restore_packs(
 
     let packs_map = Arc::try_unwrap(packs).unwrap_or_else(|arc| (*arc).clone());
 
-    let mut download_stream = futures::stream::iter(packs_map)
+    // Handle zero blobs separately: they have no pack data, write zeros directly.
+    let zero_pack_id = ID::default();
+    let mut zero_file_batches: HashMap<usize, Vec<(Vec<u8>, u64)>> = HashMap::new();
+    let mut regular_packs: HashMap<ID, Vec<(ID, BlobRestoreRequest)>> = HashMap::new();
+
+    for (pack_id, blob_requests) in packs_map {
+        if pack_id == zero_pack_id {
+            for (_blob_id, req) in blob_requests {
+                let zeros = vec![0u8; req.raw_length as usize];
+                zero_file_batches
+                    .entry(req.file_idx)
+                    .or_default()
+                    .push((zeros, req.offset_in_file));
+            }
+        } else {
+            for (blob_id, req) in blob_requests {
+                regular_packs
+                    .entry(pack_id)
+                    .or_default()
+                    .push((blob_id, req));
+            }
+        }
+    }
+
+    if !zero_file_batches.is_empty() {
+        flush_file_batches(
+            &mut zero_file_batches,
+            &ctx,
+            defaults.restore_blob_concurrency,
+        )
+        .await?;
+    }
+
+    let mut download_stream = futures::stream::iter(regular_packs)
         .flat_map(|(pack_id, blob_requests)| {
             let mut blob_to_targets: HashMap<ID, Vec<BlobRestoreRequest>> = HashMap::new();
             for (blob_id, req) in blob_requests {

--- a/crates/mapache/tests/integration_tests/test_cmd_clean.rs
+++ b/crates/mapache/tests/integration_tests/test_cmd_clean.rs
@@ -155,8 +155,8 @@ mod tests {
         // Create file A (512KiB) and file B (512KiB). Total ~1MiB, should fit in one or two packs.
         let file_a = backup_path.join("file_a.bin");
         let file_b = backup_path.join("file_b.bin");
-        let data_a = vec![0u8; 512 * 1024];
-        let data_b = vec![1u8; 512 * 1024];
+        let data_a = vec![0xAAu8; 512 * 1024];
+        let data_b = vec![0x55u8; 512 * 1024];
         std::fs::write(&file_a, &data_a)?;
         std::fs::write(&file_b, &data_b)?;
 
@@ -246,8 +246,8 @@ mod tests {
         // Create file A (1MiB) and file B (1MiB).
         let file_a = backup_path.join("file_a.bin");
         let file_b = backup_path.join("file_b.bin");
-        let data_a = vec![0u8; 1024 * 1024];
-        let data_b = vec![1u8; 1024 * 1024];
+        let data_a = vec![0xAAu8; 1024 * 1024];
+        let data_b = vec![0x55u8; 1024 * 1024];
         std::fs::write(&file_a, &data_a)?;
         std::fs::write(&file_b, &data_b)?;
 

--- a/crates/mapache/tests/integration_tests/test_cmd_clean.rs
+++ b/crates/mapache/tests/integration_tests/test_cmd_clean.rs
@@ -153,6 +153,7 @@ mod tests {
         std::fs::create_dir(&backup_path)?;
 
         // Create file A (512KiB) and file B (512KiB). Total ~1MiB, should fit in one or two packs.
+        // Use non-zero patterns to avoid triggering zero-blob deduplication.
         let file_a = backup_path.join("file_a.bin");
         let file_b = backup_path.join("file_b.bin");
         let data_a = vec![0xAAu8; 512 * 1024];
@@ -244,6 +245,7 @@ mod tests {
         std::fs::create_dir(&backup_path)?;
 
         // Create file A (1MiB) and file B (1MiB).
+        // Use non-zero patterns to avoid triggering zero-blob deduplication.
         let file_a = backup_path.join("file_a.bin");
         let file_b = backup_path.join("file_b.bin");
         let data_a = vec![0xAAu8; 1024 * 1024];

--- a/crates/mapache/tests/integration_tests/test_cmd_snapshot.rs
+++ b/crates/mapache/tests/integration_tests/test_cmd_snapshot.rs
@@ -5,7 +5,11 @@ mod tests {
 
     use anyhow::{Context, Result};
 
-    use mapache::{commands::UseSnapshot, repository::repo::SNAPSHOTS_DIR, utils};
+    use mapache::{
+        commands::{Compression, UseSnapshot},
+        repository::repo::SNAPSHOTS_DIR,
+        utils,
+    };
 
     use crate::{
         integration_tests::{INTEGRATION_TEST_DATA, TestContext, assert_times_equal},
@@ -715,6 +719,360 @@ mod tests {
             0,
             "index should have been created"
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compression_none_snapshot_restore() -> Result<()> {
+        let mut ctx = TestContext::new().await?;
+        let dataset = Dataset::new().with_structure(INTEGRATION_TEST_DATA);
+        let synthetic = SyntheticData::new(dataset);
+        let backup_data_path = ctx.setup_backup_data(&synthetic)?;
+
+        ctx.init_repo().await?;
+
+        let mut global = ctx.global.clone();
+        global.compression_level = Compression::None;
+
+        ctx.snapshot_builder(vec![
+            backup_data_path.join("file.txt"),
+            backup_data_path.join("0"),
+            backup_data_path.join("1"),
+            backup_data_path.join("2"),
+        ])
+        .run(&global)
+        .await
+        .context("snapshot with --compression none failed")?;
+
+        let restore_path = ctx._tmp_dir.path().join("restore");
+        ctx.restore_builder(restore_path.clone())
+            .run(&global)
+            .await
+            .context("restore after --compression none failed")?;
+
+        let paths = vec![
+            PathBuf::from("file.txt"),
+            PathBuf::from("0/file0.txt"),
+            PathBuf::from("0/00/file00.txt"),
+            PathBuf::from("0/01/file01a.txt"),
+            PathBuf::from("0/01/file01b.txt"),
+            PathBuf::from("1/10/file10.txt"),
+        ];
+
+        for path in &paths {
+            let backup_file = backup_data_path.join(path);
+            let restored_file = restore_path.join(path);
+            assert!(
+                restored_file.exists(),
+                "missing after restore: {}",
+                path.display()
+            );
+            assert_eq!(
+                std::fs::read(&backup_file)?,
+                std::fs::read(&restored_file)?,
+                "content mismatch: {}",
+                path.display()
+            );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compression_none_empty_file() -> Result<()> {
+        let mut ctx = TestContext::new().await?;
+        let dataset = Dataset::new().with_structure(INTEGRATION_TEST_DATA);
+        let synthetic = SyntheticData::new(dataset);
+        let backup_data_path = ctx.setup_backup_data(&synthetic)?;
+
+        ctx.init_repo().await?;
+
+        let mut global = ctx.global.clone();
+        global.compression_level = Compression::None;
+
+        ctx.snapshot_builder(vec![backup_data_path.join("empty.txt")])
+            .run(&global)
+            .await
+            .context("snapshot empty file with --compression none failed")?;
+
+        let restore_path = ctx._tmp_dir.path().join("restore");
+        ctx.restore_builder(restore_path.clone())
+            .run(&global)
+            .await
+            .context("restore empty file with --compression none failed")?;
+
+        let restored = std::fs::read(restore_path.join("empty.txt"))?;
+        assert!(
+            restored.is_empty(),
+            "empty file should remain empty after restore"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compression_none_large_file() -> Result<()> {
+        let ctx = TestContext::new().await?;
+
+        let data_dir = ctx._tmp_dir.path().join("backup");
+        std::fs::create_dir_all(&data_dir)?;
+        let pattern = b"ABCDEFGHIJKLMNOP";
+        let mut content = Vec::with_capacity(pattern.len() * 10_000);
+        for _ in 0..10_000 {
+            content.extend_from_slice(pattern);
+        }
+        std::fs::write(data_dir.join("large.bin"), &content)?;
+
+        ctx.init_repo().await?;
+
+        let mut global = ctx.global.clone();
+        global.compression_level = Compression::None;
+
+        ctx.snapshot_builder(vec![data_dir.join("large.bin")])
+            .run(&global)
+            .await
+            .context("snapshot large file with --compression none failed")?;
+
+        let restore_path = ctx._tmp_dir.path().join("restore");
+        ctx.restore_builder(restore_path.clone())
+            .run(&global)
+            .await
+            .context("restore large file with --compression none failed")?;
+
+        assert_eq!(std::fs::read(restore_path.join("large.bin"))?, content);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compression_none_unicode_paths() -> Result<()> {
+        let mut ctx = TestContext::new().await?;
+        let dataset = Dataset::new().with_structure(INTEGRATION_TEST_DATA);
+        let synthetic = SyntheticData::new(dataset);
+        let backup_data_path = ctx.setup_backup_data(&synthetic)?;
+
+        ctx.init_repo().await?;
+
+        let mut global = ctx.global.clone();
+        global.compression_level = Compression::None;
+
+        ctx.snapshot_builder(vec![
+            backup_data_path.join("🚀"),
+            backup_data_path.join("日本語"),
+        ])
+        .run(&global)
+        .await
+        .context("snapshot unicode paths with --compression none failed")?;
+
+        let restore_path = ctx._tmp_dir.path().join("restore");
+        ctx.restore_builder(restore_path.clone())
+            .run(&global)
+            .await
+            .context("restore unicode paths with --compression none failed")?;
+
+        assert_eq!(
+            std::fs::read(restore_path.join("🚀/mañana.txt"))?,
+            "UTF-8 content: ñáóú\n".as_bytes()
+        );
+        assert_eq!(
+            std::fs::read(restore_path.join("日本語/こんにちは.txt"))?,
+            "こんにちは、世界！\n".as_bytes()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compression_none_multiple_snapshots() -> Result<()> {
+        let mut ctx = TestContext::new().await?;
+        let dataset = Dataset::new().with_structure(INTEGRATION_TEST_DATA);
+        let synthetic = SyntheticData::new(dataset);
+        let backup_data_path = ctx.setup_backup_data(&synthetic)?;
+
+        ctx.init_repo().await?;
+
+        let mut global = ctx.global.clone();
+        global.compression_level = Compression::None;
+
+        ctx.snapshot_builder(vec![backup_data_path.join("file.txt")])
+            .run(&global)
+            .await
+            .context("first snapshot failed")?;
+
+        ctx.snapshot_builder(vec![backup_data_path.join("file.txt")])
+            .run(&global)
+            .await
+            .context("second snapshot failed")?;
+
+        let restore_path = ctx._tmp_dir.path().join("restore");
+        ctx.restore_builder(restore_path.clone())
+            .run(&global)
+            .await
+            .context("restore failed")?;
+
+        assert_eq!(
+            std::fs::read(restore_path.join("file.txt"))?,
+            b"This is a test file.\n"
+        );
+
+        ctx.verify_builder()
+            .read_packs(true)
+            .run(&global)
+            .await
+            .context("verify failed")?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_mixed_compression_across_snapshots() -> Result<()> {
+        let mut ctx = TestContext::new().await?;
+        let dataset = Dataset::new().with_structure(INTEGRATION_TEST_DATA);
+        let synthetic = SyntheticData::new(dataset);
+        let backup_data_path = ctx.setup_backup_data(&synthetic)?;
+
+        ctx.init_repo().await?;
+
+        ctx.snapshot_builder(vec![
+            backup_data_path.join("file.txt"),
+            backup_data_path.join("0"),
+            backup_data_path.join("1"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await
+        .context("snapshot with compression failed")?;
+
+        let restore1 = ctx._tmp_dir.path().join("restore1");
+        ctx.restore_builder(restore1.clone())
+            .run(&ctx.global)
+            .await
+            .context("restore first snapshot failed")?;
+        assert_eq!(
+            std::fs::read(restore1.join("file.txt"))?,
+            b"This is a test file.\n"
+        );
+
+        let mut global_no_comp = ctx.global.clone();
+        global_no_comp.compression_level = Compression::None;
+
+        ctx.snapshot_builder(vec![
+            backup_data_path.join("file.txt"),
+            backup_data_path.join("0"),
+            backup_data_path.join("1"),
+        ])
+        .no_scan(true)
+        .run(&global_no_comp)
+        .await
+        .context("snapshot without compression failed")?;
+
+        let restore2 = ctx._tmp_dir.path().join("restore2");
+        ctx.restore_builder(restore2.clone())
+            .run(&ctx.global)
+            .await
+            .context("restore second snapshot failed")?;
+
+        assert_eq!(
+            std::fs::read(restore2.join("file.txt"))?,
+            b"This is a test file.\n"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_zero_blob_dedup() -> Result<()> {
+        let ctx = TestContext::new().await?;
+
+        let data_dir = ctx._tmp_dir.path().join("backup");
+        std::fs::create_dir_all(&data_dir)?;
+
+        let zeros_small = vec![0u8; 4096];
+        std::fs::write(data_dir.join("zeros_small.bin"), &zeros_small)?;
+
+        let zeros_large = vec![0u8; 65536];
+        std::fs::write(data_dir.join("zeros_large.bin"), &zeros_large)?;
+
+        std::fs::write(data_dir.join("normal.bin"), b"normal content\n")?;
+
+        ctx.init_repo().await?;
+
+        ctx.snapshot_builder(vec![
+            data_dir.join("zeros_small.bin"),
+            data_dir.join("zeros_large.bin"),
+            data_dir.join("normal.bin"),
+        ])
+        .no_scan(true)
+        .run(&ctx.global)
+        .await
+        .context("snapshot with zero blobs failed")?;
+
+        ctx.verify_builder()
+            .read_packs(true)
+            .run(&ctx.global)
+            .await
+            .context("verify failed with zero blobs")?;
+
+        let restore_path = ctx._tmp_dir.path().join("restore");
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await
+            .context("restore with zero blobs failed")?;
+
+        assert_eq!(
+            std::fs::read(restore_path.join("zeros_small.bin"))?,
+            zeros_small
+        );
+        assert_eq!(
+            std::fs::read(restore_path.join("zeros_large.bin"))?,
+            zeros_large
+        );
+        assert_eq!(
+            std::fs::read(restore_path.join("normal.bin"))?,
+            b"normal content\n"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_zero_blob_dedup_across_snapshots() -> Result<()> {
+        let ctx = TestContext::new().await?;
+
+        let data_dir = ctx._tmp_dir.path().join("backup");
+        std::fs::create_dir_all(&data_dir)?;
+
+        let zeros = vec![0u8; 8192];
+        std::fs::write(data_dir.join("zeros.bin"), &zeros)?;
+
+        ctx.init_repo().await?;
+
+        ctx.snapshot_builder(vec![data_dir.join("zeros.bin")])
+            .no_scan(true)
+            .run(&ctx.global)
+            .await
+            .context("first snapshot failed")?;
+
+        ctx.snapshot_builder(vec![data_dir.join("zeros.bin")])
+            .no_scan(true)
+            .run(&ctx.global)
+            .await
+            .context("second snapshot failed")?;
+
+        ctx.verify_builder()
+            .read_packs(true)
+            .run(&ctx.global)
+            .await
+            .context("verify failed")?;
+
+        let restore_path = ctx._tmp_dir.path().join("restore");
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await
+            .context("restore failed")?;
+
+        assert_eq!(std::fs::read(restore_path.join("zeros.bin"))?, zeros);
 
         Ok(())
     }

--- a/crates/mapache/tests/integration_tests/test_cmd_verify.rs
+++ b/crates/mapache/tests/integration_tests/test_cmd_verify.rs
@@ -245,4 +245,93 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_binary_index_on_disk() -> Result<()> {
+        let mut ctx = TestContext::new().await?;
+        let dataset = Dataset::new().with_structure(INTEGRATION_TEST_DATA);
+        let synthetic = SyntheticData::new(dataset);
+        let backup_data_tmp_path = ctx.setup_backup_data(&synthetic)?;
+
+        ctx.init_repo().await?;
+
+        ctx.snapshot(vec![
+            backup_data_tmp_path.join("file.txt"),
+            backup_data_tmp_path.join("0"),
+        ])
+        .await
+        .context("snapshot failed")?;
+
+        let index_dir = ctx.repo_path.join(INDEX_DIR);
+        assert!(index_dir.exists(), "index directory should exist");
+
+        let index_files: Vec<_> = std::fs::read_dir(&index_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_file())
+            .collect();
+
+        assert!(
+            !index_files.is_empty(),
+            "there should be at least one index file"
+        );
+
+        // v2 index files are binary, not JSON
+        for entry in &index_files {
+            let bytes = std::fs::read(entry.path())?;
+            assert!(
+                !bytes.is_empty(),
+                "index file should not be empty: {:?}",
+                entry.path()
+            );
+            assert_ne!(
+                bytes[0],
+                b'{',
+                "v2 index should be binary, not JSON: {:?}",
+                entry.path()
+            );
+        }
+
+        // Restore should work (index is readable)
+        let restore_path = ctx._tmp_dir.path().join("restore");
+        ctx.restore_builder(restore_path.clone())
+            .run(&ctx.global)
+            .await
+            .context("restore with binary index failed")?;
+
+        assert!(restore_path.join("file.txt").exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_verify_after_compression_none() -> Result<()> {
+        use mapache::commands::Compression;
+
+        let mut ctx = TestContext::new().await?;
+        let dataset = Dataset::new().with_structure(INTEGRATION_TEST_DATA);
+        let synthetic = SyntheticData::new(dataset);
+        let backup_data_tmp_path = ctx.setup_backup_data(&synthetic)?;
+
+        ctx.init_repo().await?;
+
+        let mut global = ctx.global.clone();
+        global.compression_level = Compression::None;
+
+        ctx.snapshot_builder(vec![
+            backup_data_tmp_path.join("file.txt"),
+            backup_data_tmp_path.join("0"),
+            backup_data_tmp_path.join("1"),
+        ])
+        .run(&global)
+        .await
+        .context("snapshot with --compression none failed")?;
+
+        ctx.verify_builder()
+            .read_packs(true)
+            .run(&global)
+            .await
+            .context("verify failed after --compression none snapshot")?;
+
+        Ok(())
+    }
 }

--- a/crates/mapache/tests/integration_tests/test_corrupt_repo.rs
+++ b/crates/mapache/tests/integration_tests/test_corrupt_repo.rs
@@ -153,10 +153,13 @@ mod tests {
             }
         }
 
-        // Second backup with new data should still succeed
+        // Second backup with new data should still succeed.
+        // Use no_parent(true) so the backup doesn't need to read old tree blobs
+        // from potentially corrupted packs — only new packs are written.
         fs::write(backup_data_tmp_path.join("new_file.txt"), b"brand new data")?;
 
         ctx.snapshot_builder(vec![backup_data_tmp_path.clone()])
+            .no_parent(true)
             .run(&ctx.global)
             .await?;
 


### PR DESCRIPTION
Detects files filled entirely with zero bytes during backup and stores them as metadata-only entries in the pack footer, consuming no data section space.
Includes detection, packing, indexing, restore, verification, v1→v2 migration, and bug fixes for get_pack_descriptors(), cold index lookup, and dead code removal.