### PR TITLE
Potential fix for code scanning alert no. 31: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -223,9 +223,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-darwin-arm64
       - name: Install macFUSE
         run: |
           brew tap homebrew/cask
@@ -253,9 +250,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-apple-darwin
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-darwin-x86_64
       - name: Install macFUSE
         run: |
           brew tap homebrew/cask


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/31](https://github.com/jLantxa/mapache/security/code-scanning/31)

To fix this without changing build functionality, remove cache restore/save from jobs that checkout and execute code from `needs.setup.outputs.ref` in this `workflow_dispatch` flow. The simplest and safest fix is to delete the `Swatinem/rust-cache@v2` steps in the affected jobs so untrusted code cannot poison shared caches.

Best concrete change in `.github/workflows/build.yaml`:
- In `build-darwin-arm64`, remove:
  - `- uses: Swatinem/rust-cache@v2`
  - its `with:` block including `shared-key: release-darwin-arm64`
- In `build-darwin-amd64`, remove:
  - `- uses: Swatinem/rust-cache@v2`
  - its `with:` block including `shared-key: release-darwin-x86_64`

No imports, dependencies, or new definitions are needed. This preserves checkout/build/artifact behavior while eliminating the cache-poisoning sink.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
