### PR TITLE
Potential fix for code scanning alert no. 30: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -223,9 +223,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-darwin-arm64
       - name: Install macFUSE
         run: |
           brew tap homebrew/cask
@@ -253,9 +250,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-apple-darwin
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-darwin-x86_64
       - name: Install macFUSE
         run: |
           brew tap homebrew/cask


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/30](https://github.com/jLantxa/mapache/security/code-scanning/30)

To fix this without changing build functionality, disable cache usage in jobs that build code checked out from `needs.setup.outputs.ref`. The safest minimal change in the shown region is to remove the `Swatinem/rust-cache@v2` steps from both macOS jobs (`build-darwin-arm64` and `build-darwin-amd64`). This preserves checkout/build/artifact behavior while eliminating cache restore/save paths that can be poisoned.

In `.github/workflows/build.yaml`, edit:
- `build-darwin-arm64` steps: remove lines 226–228 (`Swatinem/rust-cache@v2` with `shared-key: release-darwin-arm64`).
- `build-darwin-amd64` steps: remove lines 256–258 (`Swatinem/rust-cache@v2` with `shared-key: release-darwin-x86_64`).

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
