### PR TITLE
Potential fix for code scanning alert no. 29: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -187,9 +187,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-windows-amd64
       - name: Install LLVM + cargo-xwin
         run: |
           sudo apt-get update -qq
@@ -223,9 +220,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-darwin-arm64
       - name: Install macFUSE
         run: |
           brew tap homebrew/cask


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/29](https://github.com/jLantxa/mapache/security/code-scanning/29)

General fix: do not allow untrusted code execution to share/write privileged cache entries. In this workflow, the safest minimal change is to disable Rust cache usage in jobs that build a dispatch-selected ref. This preserves build functionality while removing the cache poisoning primitive.

Best fix for the shown snippet: in `.github/workflows/build.yaml`, remove the `Swatinem/rust-cache@v2` steps from the affected jobs that checkout `${{ needs.setup.outputs.ref }}` and then execute build/install commands. In the provided region, that means removing:
- `build-windows-amd64` cache step (`uses: Swatinem/rust-cache@v2`, `shared-key: release-windows-amd64`)
- `build-darwin-arm64` cache step (`uses: Swatinem/rust-cache@v2`, `shared-key: release-darwin-arm64`)

No new imports/dependencies are needed. This keeps existing build behavior, only sacrificing cache acceleration to eliminate poisoning risk in this untrusted-ref execution path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
