### PR TITLE
Potential fix for code scanning alert no. 28: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -154,9 +154,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-android-arm64
       - name: Install Android NDK
         run: |
           curl -L https://dl.google.com/android/repository/android-ndk-r26d-linux.zip -o /tmp/ndk.zip
@@ -187,9 +184,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-windows-amd64
       - name: Install LLVM + cargo-xwin
         run: |
           sudo apt-get update -qq


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/28](https://github.com/jLantxa/mapache/security/code-scanning/28)

General fix: avoid restoring/saving shared caches in jobs that execute code checked out from a user-influenced ref. If caching is required, scope cache keys to immutable trusted context and only in trusted workflows/jobs.

Best fix here without changing build behavior: remove `Swatinem/rust-cache@v2` from the affected job(s) that checkout `${{ needs.setup.outputs.ref }}`. This preserves build outputs/functionality while eliminating the cache poisoning path. Specifically in `.github/workflows/build.yaml`, delete the rust-cache step in `build-windows-amd64` (the flagged path). Since the shown snippet also demonstrates the same risky pattern in `build-android-arm64`, remove that cache step too for consistency and to prevent similar findings.

No new imports/dependencies/methods are needed; this is YAML workflow step removal only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
