### PR TITLE
Potential fix for code scanning alert no. 25: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,9 +86,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-unknown-linux-musl
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-linux-arm64
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq
@@ -119,9 +116,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: armv7-unknown-linux-musleabihf
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-linux-armv7
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/25](https://github.com/jLantxa/mapache/security/code-scanning/25)

To fix this without changing build functionality, remove cache usage from jobs that execute code from `${{ needs.setup.outputs.ref }}`. The best targeted fix in the shown snippet is to delete the `Swatinem/rust-cache@v2` steps in both affected jobs (`build-linux-arm64` and `build-linux-armv7`). This preserves checkout/toolchain/build behavior while eliminating the cache-poisoning sink.

In `.github/workflows/build.yaml`:
- In `build-linux-arm64`, remove:
  - `- uses: Swatinem/rust-cache@v2`
  - its `with:` block and `shared-key`.
- In `build-linux-armv7`, remove the same cache step and `with:` block.

No imports, methods, or extra definitions are needed in YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
