### PR TITLE
Potential fix for code scanning alert no. 27: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -154,9 +154,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-android-arm64
       - name: Install Android NDK
         run: |
           curl -L https://dl.google.com/android/repository/android-ndk-r26d-linux.zip -o /tmp/ndk.zip
@@ -187,9 +184,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-windows-amd64
       - name: Install LLVM + cargo-xwin
         run: |
           sudo apt-get update -qq


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/27](https://github.com/jLantxa/mapache/security/code-scanning/27)

The safest fix without changing core build functionality is to **disable cache usage in jobs that build a user-dispatched ref**. This removes the cache write/read primitive needed for poisoning while keeping checkout/build behavior intact.

Concretely in `.github/workflows/build.yaml`, remove the `Swatinem/rust-cache@v2` steps from the affected jobs shown in the snippet:

- `build-android-arm64`: remove lines 157–159 (`rust-cache` with `shared-key: release-android-arm64`)
- `build-windows-amd64`: remove lines 190–192 (`rust-cache` with `shared-key: release-windows-amd64`)

No new imports, methods, or dependencies are needed in a GitHub Actions YAML workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
