### PR TITLE
Potential fix for code scanning alert no. 26: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,9 +119,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: armv7-unknown-linux-musleabihf
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-linux-armv7
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq
@@ -154,9 +151,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-android-arm64
       - name: Install Android NDK
         run: |
           curl -L https://dl.google.com/android/repository/android-ndk-r26d-linux.zip -o /tmp/ndk.zip


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/26](https://github.com/jLantxa/mapache/security/code-scanning/26)

Best fix: prevent cache restore/save in jobs that execute potentially untrusted refs from `workflow_dispatch`. This preserves build behavior while removing the cache-poisoning primitive.

In `.github/workflows/build.yaml`, for each job that checks out `${{ needs.setup.outputs.ref }}`, remove the `Swatinem/rust-cache@v2` step (or gate it so it only runs for trusted refs). Since we only have this snippet and cannot safely assume trusted-ref metadata exists, the safest no-assumption fix is to remove the cache step in the shown jobs. This keeps functionality (build still runs) and eliminates poisoned cache persistence.

Apply to the shown regions:
- `build-linux-armv7`: remove lines 122–124 (`Swatinem/rust-cache@v2` with `shared-key: release-linux-armv7`)
- `build-android-arm64`: remove lines 157–159 (`Swatinem/rust-cache@v2` with `shared-key: release-android-arm64`)

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
