### PR TITLE
Potential fix for code scanning alert no. 24: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,9 +86,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-unknown-linux-musl
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-linux-arm64
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/24](https://github.com/jLantxa/mapache/security/code-scanning/24)

The safest fix without changing intended build behavior is to **remove cache usage from jobs that execute code checked out from `inputs.ref`**.  
In this snippet, the key risky point is `Swatinem/rust-cache@v2` in `build-linux-arm64`, which restores/saves cache before untrusted code execution.

Best concrete fix here:
- In `.github/workflows/build.yaml`, in job `build-linux-arm64`, remove the `Swatinem/rust-cache@v2` step (lines 89–91 in the snippet).
- Keep checkout/build flow unchanged so functionality remains (the build still runs for the selected ref), but no cache can be poisoned by that run.

No new imports, methods, or definitions are needed for YAML workflow changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
