### PR TITLE
Potential fix for code scanning alert no. 23: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,9 +86,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-unknown-linux-musl
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-linux-arm64
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/23](https://github.com/jLantxa/mapache/security/code-scanning/23)

The safest fix without changing core build behavior is to **remove cache usage from jobs that checkout and execute user-selected refs**. In this snippet, that means removing the `Swatinem/rust-cache@v2` step from `build-linux-arm64`. This preserves the ability to build arbitrary refs from manual dispatch while eliminating the cache poisoning path identified by CodeQL.

Concretely, in `.github/workflows/build.yaml`, edit the `build-linux-arm64` job and delete the cache step at lines 89–91:

- `- uses: Swatinem/rust-cache@v2`
- `with:`
- `shared-key: release-linux-arm64`

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
