### PR TITLE
Potential fix for code scanning alert no. 22: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,9 +53,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-musl
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-linux-amd64
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/22](https://github.com/jLantxa/mapache/security/code-scanning/22)

The safest fix without changing core build behavior is to **remove cache usage from jobs that execute dispatch-supplied refs**. In this snippet, the concrete vulnerable primitive is `Swatinem/rust-cache@v2` in `build-linux-amd64` while code from `${{ needs.setup.outputs.ref }}` is executed.

Best targeted change:
- In `.github/workflows/build.yaml`, in job `build-linux-amd64`, remove the `Swatinem/rust-cache@v2` step (lines 56–58 in the snippet).
- Keep checkout/build steps intact so functionality (building selected ref) remains unchanged except no shared cache read/write.
- No new imports/dependencies are required.

This directly eliminates the cache poisoning vector identified by CodeQL for the shown region.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
