### PR TITLE
Potential fix for code scanning alert no. 21: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,10 @@ jobs:
       - id: ref
         run: |
           ref="${{ inputs.ref || github.ref_name }}"
+          if ! [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "Invalid ref '$ref'. Only full 40-character commit SHAs are allowed." >&2
+            exit 1
+          fi
           echo "value=$ref" >> "$GITHUB_OUTPUT"
           safe="${ref//\//-}"
           echo "safe=$safe" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Potential fix for [https://github.com/jLantxa/mapache/security/code-scanning/21](https://github.com/jLantxa/mapache/security/code-scanning/21)

General fix: do not execute arbitrary user-supplied refs in a privileged/default-branch-scoped `workflow_dispatch` workflow. Restrict checkout to trusted refs only (for example, full 40-hex commit SHA), and fail early for anything else.

Best minimal fix in this file: validate `inputs.ref` in the `setup` job before exporting it, allowing only strict commit SHA format, and use that validated value. This preserves existing functionality for explicit commit builds while blocking branch/tag refs that can be manipulated to run untrusted code paths in this privileged workflow.

Edit region: `.github/workflows/build.yaml`, in `jobs.setup.steps` at the existing `id: ref` run block (lines ~37–42 in your snippet). Replace the block so it:
1. Reads `inputs.ref` / fallback as today.
2. Validates against `^[0-9a-fA-F]{40}$`.
3. Exits non-zero on invalid input.
4. Outputs validated `value` and `safe`.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
